### PR TITLE
🔧 chore: repo skeleton — pyproject / CI / NOTICE / LICENSE / README / install.sh (#1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+# Note: test collection is intentionally excluded from this workflow.
+# unsloth performs GPU-specific patching at import time; test collection
+# fails on CPU runners without a real CUDA device. Tests are run
+# separately in GPU environments.
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install "ruff>=0.9.0"
+
+      - name: ruff check
+        run: |
+          targets=""
+          for d in unturtle/ benchmarks/ tests/; do [ -d "$d" ] && targets="$targets $d"; done
+          ruff check $targets
+
+      - name: ruff format --check
+        run: |
+          targets=""
+          for d in unturtle/ benchmarks/ tests/; do [ -d "$d" ] && targets="$targets $d"; done
+          ruff format --check $targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
 
       - name: ruff check
         run: |
-          targets=""
-          for d in unturtle/ benchmarks/ tests/; do [ -d "$d" ] && targets="$targets $d"; done
+          targets="unturtle/"
+          for d in benchmarks/ tests/; do [ -d "$d" ] && targets="$targets $d"; done
           ruff check $targets
 
       - name: ruff format --check
         run: |
-          targets=""
-          for d in unturtle/ benchmarks/ tests/; do [ -d "$d" ] && targets="$targets $d"; done
+          targets="unturtle/"
+          for d in benchmarks/ tests/; do [ -d "$d" ] && targets="$targets $d"; done
           ruff format --check $targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 # Note: test collection is intentionally excluded from this workflow.
 # unsloth performs GPU-specific patching at import time; test collection

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,6 @@ dev/benchmark*.py
 dev/**/*.md
 .serena/
 **/superpowers/
+# but the tracked design docs are exempt:
+!docs/superpowers/
+!docs/superpowers/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,228 @@
+# Git worktrees
+.worktrees/
+
+# Reference repositories (cloned for local development, not committed)
+dev/repos/
+dev/papers/
+dev/local/
+
+# Local reference library (PDFs, notes — not committed)
+.references/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.class
+unsloth_compiled_cache/
+# ML artifacts (large files)
+feature/
+outputs/
+exports/
+/datasets/
+unsloth_training_checkpoints/
+*.gguf
+*.safetensors
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.venv_overlay/
+.venv_t5/
+environment.yaml
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+.pre-commit-cache/
+
+# PyPI configuration file and IDE/Editors
+.pypirc
+.vscode
+.idea/
+.claude/
+.codex/
+*.swp
+*.swo
+
+# oh-my-codex
+.omx/
+
+# Other
+resources/
+tmp/
+**/node_modules/
+auth.db
+
+# Local working docs
+# CLAUDE.md is tracked in unturtle (removed upstream unsloth exclusion)
+**/claude.md
+# **/AGENT.md
+**/agent.md
+log_rtx.txt
+log.txt
+*.log
+package-lock.json
+!docs/package-lock.json
+dev/benchmark*.py
+dev/**/*.md
+.serena/
+**/superpowers/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,32 @@
+Unturtle
+Copyright 2025-present nishide-dev & the Unturtle team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+This project is derived from Unsloth (https://github.com/unslothai/unsloth),
+Copyright 2023-present Daniel Han-Chen & the Unsloth team,
+licensed under the Apache License, Version 2.0.
+
+Fork point: commit a6c1f893fc87c0973f9c32e59ca3d7d54ffb9724 (2026-03-28)
+
+The following files are derived from the upstream Unsloth codebase
+and retain the original Apache 2.0 license header:
+
+  - unturtle/diffusion/trainer.py
+  - unturtle/utils/attention_dispatch.py
+  - unturtle/utils/packing.py
+  - unturtle/kernels/__init__.py
+
+All other files in this repository are original works by the Unturtle team.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Unturtle
+
+**dLLM method layer on top of [unsloth](https://github.com/unslothai/unsloth)**
+
+Unturtle adds diffusion language model (dLLM) capabilities — conversion recipes,
+training objectives, and inference acceleration — as a thin layer on top of the
+unsloth fast-training stack.
+
+## Layer architecture
+
+```
+transformers          model implementations + loss primitives
+TRL                   objective trainers (SFT, GRPO, …)
+unsloth               hardware acceleration patches (LoRA fast paths, kernels)
+unturtle              dLLM method layer (this repo)
+                        ├── models/backbones/     native diffusion backbones (LLaDA, Dream, ModernBERT-diffusion)
+                        ├── models/conversion/    AR→Diffusion methods (Tiny-A2D)
+                        ├── models/generation/    shared cache / block-decode / generation mixin
+                        ├── diffusion/            MDLM / BD3LM trainer, collator, GRPO
+                        ├── kernels/              Triton kernels, fast LoRA paths
+                        └── eval/                 smoke evaluators + lm-evaluation-harness adapter
+```
+
+## Quick start
+
+```bash
+uv venv .venv --python 3.12
+uv pip install torch --index-url https://download.pytorch.org/whl/cu124
+uv pip install -e ".[huggingface]"
+```
+
+## Legacy repository
+
+This repository is a clean rebuild forked from the legacy
+[unturtle monorepo](https://github.com/nishide-dev/unturtle) at commit
+`a6c1f893fc87c0973f9c32e59ca3d7d54ffb9724` (2026-03-28).
+The legacy repository includes Unturtle Studio and lighteval integration;
+those components are not carried forward here.
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ uv pip install -e ".[huggingface]"
 
 ## Legacy repository
 
-This repository is a clean rebuild forked from the legacy
-[unturtle monorepo](https://github.com/nishide-dev/unturtle) at commit
-`a6c1f893fc87c0973f9c32e59ca3d7d54ffb9724` (2026-03-28).
+This repository is a clean rebuild of the archived
+[unturtle-legacy](https://github.com/nishide-dev/unturtle-legacy) monorepo
+(originally a fork of unsloth; see `NOTICE` for the vendored-code provenance).
 The legacy repository includes Unturtle Studio and lighteval integration;
-those components are not carried forward here.
+those components are not carried forward here. Its issue/PR history remains
+browsable read-only.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ unturtle              dLLM method layer (this repo)
 ## Quick start
 
 ```bash
-uv venv .venv --python 3.12
-uv pip install torch --index-url https://download.pytorch.org/whl/cu124
-uv pip install -e ".[huggingface]"
+./install.sh          # uv venv + CUDA-matched torch + editable install (+ verification)
+./install.sh --eval   # additionally install the lm-eval-harness extra
 ```
+
+See the header of [`install.sh`](install.sh) for `TORCH_INDEX` / `PYTHON_VERSION`
+overrides. Plain `pip` is not supported — use `uv` (the script handles ordering:
+torch must be installed before the editable install so the CUDA-matched build
+is preserved).
 
 ## Legacy repository
 

--- a/docs/superpowers/plans/2026-06-11-unturtle-migration.md
+++ b/docs/superpowers/plans/2026-06-11-unturtle-migration.md
@@ -36,7 +36,11 @@ NEW=/grouper/nishide.21066-1000003/projects/unturtle-new       # 新リポジト
 - `unturtle_studio/` 全部、`unturtle/eval/experimental/` 全部
 - `unturtle/models/{llada,dream,modernbert}.py`（非推奨エイリアス）、`unturtle/models/a2d/`
 - `tests/models/test_import_compat.py`、`tests/eval/test_lighteval_*.py`（3件）、`tests/install/`（3件）、`tests/examples/test_validate_studio_mdlm_chat.py`、`examples/validate_studio_mdlm_chat.py`
-- `install.sh`、`.github/workflows/{deploy-docs,release,stale}.yml`（必要になったら個別に再導入）
+- legacy の `install.sh`（Python 3.13 前提の upstream ラッパー）、`.github/workflows/{deploy-docs,release,stale}.yml`（必要になったら個別に再導入）
+  - ※ 新リポジトリには **uv 前提の薄い `install.sh` を新規作成**して置く（Task 1 で追加済み）。
+    実行順序が重要: torch（CUDA ビルドを TORCH_INDEX で選択、既定 cu128）→ build/test ツール →
+    `uv pip install -e ".[huggingface]"`。素の pip は unsloth の依存グラフで壊れた `regex` を
+    解決する事故が確認されたため非サポートと明記。
 
 ---
 

--- a/docs/superpowers/plans/2026-06-11-unturtle-migration.md
+++ b/docs/superpowers/plans/2026-06-11-unturtle-migration.md
@@ -160,10 +160,23 @@ dev = ["ruff>=0.9.0", "ty>=0.0.0a1", "pytest>=8.0"]
 ```bash
 # .gitignore は legacy をベースに studio 関連行を削除してコピー
 rsync -a $LEGACY/.gitignore $NEW/.gitignore
-# studio/ 行を削除し、.references/ dev/local/ が ignore されていることを確認
+# studio 関連行（"studio/backend/..." 等）を削除する
 grep -n "studio" $NEW/.gitignore   # → 該当行を削除
-grep -n "references\|dev/local" $NEW/.gitignore
 ```
+
+`.gitignore` には以下が**すべて ignore 対象として含まれていること**を確認し、欠けていれば追加する（特に `.references/` は legacy では追跡対象だったが、新リポジトリでは「未整理のローカル調査メモ」としてローカル資産化する決定）:
+
+```gitignore
+.venv
+dev/repos/
+dev/papers/
+dev/local/
+.references/
+```
+
+確認コマンド: `grep -n "references\|dev/local\|dev/papers\|dev/repos\|^\.venv" $NEW/.gitignore`。
+`.references/` が無ければ追記する。これにより Task 0 でコピーした調査資産（`dev/local`・`dev/papers`・`.references`）は untracked にならず `git status` がクリーンになる。
+（`.references/` の有用部分を `docs/` へ整理して昇格させるのは移植完了後の別作業。本移植では追跡しない。）
 
 `unturtle/_version.py` は legacy をそのままコピー（`__version__ = "0.1.0"`）。
 `unturtle/__init__.py` は**最小**で作成（本格的な re-export は Task 7 で legacy 版を移植）:
@@ -176,7 +189,8 @@ from unturtle._version import __version__
 __all__ = ["__version__"]
 ```
 
-`NOTICE`（vendored 出典の記録。fork-point は legacy 側で `git -C $LEGACY merge-base HEAD upstream/main` を実行して埋める）:
+`NOTICE`（vendored 出典の記録。fork-point は確定済み: `git -C $LEGACY merge-base HEAD upstream/main` =
+`a6c1f893fc87c0973f9c32e59ca3d7d54ffb9724`）:
 
 ```text
 Unturtle
@@ -186,7 +200,7 @@ This product includes software developed by the Unsloth team
 (https://github.com/unslothai/unsloth), licensed under the Apache License 2.0.
 
 The following files are derived from unslothai/unsloth (fork point:
-commit <merge-base hash>, 2026-03-28):
+commit a6c1f893fc87c0973f9c32e59ca3d7d54ffb9724, 2026-03-28):
 - unturtle/trainer.py
 - unturtle/utils/attention_dispatch.py
 - unturtle/utils/packing.py

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,13 @@
 #
 # Requirements:
 #   - uv (https://docs.astral.sh/uv/)
-#   - NVIDIA GPU + driver. The torch CUDA build is selected via TORCH_INDEX;
-#     the default cu128 works with any CUDA 12.x driver (>= 525). If your
-#     driver supports CUDA 13, you may use the default PyPI wheels instead:
+#   - NVIDIA GPU + driver. The torch CUDA build is selected via TORCH_INDEX.
+#     The default cu128 runs on CUDA 12.x drivers via CUDA minor-version
+#     compatibility (empirically verified on driver 555 / CUDA 12.5). If the
+#     final verification step reports "CUDA not available", retry with an
+#     older build matching your driver, e.g.:
+#     TORCH_INDEX=https://download.pytorch.org/whl/cu124 ./install.sh
+#     If your driver supports CUDA 13, the default PyPI wheels also work:
 #     TORCH_INDEX=https://pypi.org/simple ./install.sh
 #
 # NOTE: plain `pip install -e ".[huggingface]"` is NOT supported — pip's
@@ -25,7 +29,7 @@ PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
 command -v uv >/dev/null || { echo "error: uv not found — install from https://docs.astral.sh/uv/"; exit 1; }
 
 echo "==> creating venv (.venv, python ${PYTHON_VERSION})"
-uv venv .venv --python "${PYTHON_VERSION}"
+uv venv .venv --python "${PYTHON_VERSION}" --allow-existing
 
 # torch must be installed BEFORE the editable install so that uv keeps the
 # CUDA-matched build instead of re-resolving torch from PyPI (which may ship

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Unturtle setup script (uv-based).
+#
+# Usage:
+#   ./install.sh           # core + huggingface extras
+#   ./install.sh --eval    # additionally install the lm-eval-harness extra
+#
+# Requirements:
+#   - uv (https://docs.astral.sh/uv/)
+#   - NVIDIA GPU + driver. The torch CUDA build is selected via TORCH_INDEX;
+#     the default cu128 works with any CUDA 12.x driver (>= 525). If your
+#     driver supports CUDA 13, you may use the default PyPI wheels instead:
+#     TORCH_INDEX=https://pypi.org/simple ./install.sh
+#
+# NOTE: plain `pip install -e ".[huggingface]"` is NOT supported — pip's
+# resolver has been observed to pick a broken ancient `regex` build from
+# unsloth's dependency graph. Use uv (this script).
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+TORCH_INDEX="${TORCH_INDEX:-https://download.pytorch.org/whl/cu128}"
+PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
+
+command -v uv >/dev/null || { echo "error: uv not found — install from https://docs.astral.sh/uv/"; exit 1; }
+
+echo "==> creating venv (.venv, python ${PYTHON_VERSION})"
+uv venv .venv --python "${PYTHON_VERSION}"
+
+# torch must be installed BEFORE the editable install so that uv keeps the
+# CUDA-matched build instead of re-resolving torch from PyPI (which may ship
+# a CUDA major version your driver does not support).
+echo "==> installing torch stack from ${TORCH_INDEX}"
+uv pip install torch torchvision torchaudio xformers --index-url "${TORCH_INDEX}"
+
+echo "==> installing build/test tooling"
+uv pip install "setuptools==80.9.0" "setuptools-scm==9.2.0" pytest ruff bitsandbytes
+
+echo "==> installing unturtle (editable) + huggingface extras"
+uv pip install -e ".[huggingface]"
+
+if [[ "${1:-}" == "--eval" ]]; then
+    echo "==> installing eval extra (lm-eval-harness)"
+    uv pip install -e ".[eval]"
+fi
+
+echo "==> verifying installation"
+.venv/bin/python - <<'PY'
+import torch
+print(f"torch {torch.__version__} | cuda available: {torch.cuda.is_available()}")
+assert torch.cuda.is_available(), "CUDA not available — check TORCH_INDEX vs your driver"
+import unsloth  # noqa: F401  (requires a GPU at import time)
+import unturtle
+print(f"unturtle {unturtle.__version__} — OK")
+PY
+
+echo "done. run tests with: uv run python -m pytest tests/ -m 'not slow' -v"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,114 @@
+[build-system]
+requires = ["setuptools==80.9.0", "setuptools-scm==9.2.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "unturtle"
+dynamic = ["version"]
+description = "dLLM method layer on top of unsloth — conversion, objectives, inference acceleration, and canonical evaluation for diffusion language models"
+readme = "README.md"
+requires-python = ">=3.9,<3.15"
+license = "Apache-2.0"
+keywords = ["ai", "llm", "diffusion", "dllm", "machine learning", "pytorch", "triton"]
+authors = [
+    {name = "nishide-dev"},
+]
+classifiers = [
+    "Programming Language :: Python",
+    "Environment :: GPU",
+    "Environment :: GPU :: NVIDIA CUDA",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "unsloth>=2026.6.2",
+    "typer>=0.12.0",
+    "pydantic>=2.0",
+    "pyyaml>=6.0",
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "unturtle._version.__version__"}
+
+[tool.setuptools]
+include-package-data = true
+
+[project.scripts]
+unturtle = "unturtle.cli:app"
+
+[tool.setuptools.packages.find]
+include = ["unturtle*"]
+
+[project.optional-dependencies]
+huggingface = [
+    "transformers>=4.51.3",
+    "datasets>=3.4.1",
+    "accelerate>=0.34.1",
+    "peft>=0.18.0",
+    "unsloth_zoo>=2026.6.2",
+    "huggingface_hub>=0.34.0",
+    "hf_transfer",
+    "trl",
+]
+eval = [
+    "lm-eval>=0.4.5",
+]
+dev = [
+    "ruff>=0.9.0",
+    "ty>=0.0.0a1",
+    "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: long-running or environment-sensitive tests excluded from fast suites",
+    "benchmark: performance-oriented tests that may be timing-sensitive",
+    "gpu: requires a CUDA-capable GPU; excluded from CPU fast suites",
+]
+
+[tool.ruff]
+target-version = "py311"
+force-exclude = true
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+]
+ignore = [
+    # --- intentional style choices ---
+    "E501",   # line too long — not enforced, formatter handles wrapping
+    "E731",   # lambda assignment — used intentionally in several places
+    "E741",   # ambiguous variable names — common in ML (l, O, I)
+    # --- wildcard imports are pervasive in vendored/unsloth code ---
+    "F403",   # star import used
+    "F405",   # may be from star import
+    # --- lazy imports inside functions are the pattern throughout this codebase ---
+    "F401",   # imported but unused (re-exports handled via __all__)
+    # --- these would require large-scale refactors not in scope ---
+    "UP006",  # use `list` instead of `List` — deferred
+    "UP007",  # use `X | Y` instead of `Union[X, Y]` — deferred
+    "UP035",  # typing module deprecated — deferred
+    "UP042",  # replace `class StrEnum(str, Enum)` with `StrEnum` — shim exists for <3.11
+    "UP045",  # use `X | None` instead of `Optional[X]` — deferred
+    # --- bugbear rules that are too noisy for current codebase state ---
+    "B006",   # mutable default argument — widespread, fix separately
+    "B008",   # function call in default argument (e.g. Depends()) — false positives
+    "B028",   # no explicit stacklevel in warnings.warn — deferred
+    "B904",   # raise from inside except — deferred
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "S101",   # assert is expected in tests
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.ty.environment]
+python-version = "3.11"

--- a/unturtle/__init__.py
+++ b/unturtle/__init__.py
@@ -1,0 +1,5 @@
+"""Unturtle — dLLM method layer on top of unsloth."""
+
+from unturtle._version import __version__
+
+__all__ = ["__version__"]

--- a/unturtle/_version.py
+++ b/unturtle/_version.py
@@ -1,0 +1,17 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unturtle version string (independent from unsloth)."""
+
+__version__ = "0.1.0"


### PR DESCRIPTION
Closes #1

## 概要
クリーン移植の Task 1: リポジトリ骨格。

- **pyproject.toml**: 単一パッケージ構成（`unturtle*` のみ）、`unsloth>=2026.6.2` / `unsloth_zoo>=2026.6.2` pin、entry point `unturtle = unturtle.cli:app`、studio/experimental extras なし、ruff の studio 由来 extend-exclude 削除
- **CI**: lint-only（ruff check / format --check）。unsloth が import 時に GPU を要求するため CPU ランナーでのテストは不可（legacy と同じ制約、コメントで明記）
- **NOTICE**: vendored 4ファイル（trainer / attention_dispatch / packing / kernels __init__）の出典と fork-point `a6c1f893`（2026-03-28）
- **LICENSE**: Apache 2.0 全文
- **install.sh**: uv 前提の薄いセットアップスクリプト。torch（TORCH_INDEX、既定 cu128）→ tooling → `-e .[huggingface]` の順序固定 + 最終検証。素の pip は壊れた regex を解決する事故が実測されたため非サポート明記。`--allow-existing` で冪等
- **README**: transformers / TRL / unsloth / unturtle の4層構図による位置付け、unturtle-legacy への誘導

## テスト
- `import unturtle` → 0.1.0
- GPU 環境（RTX 6000 Ada, driver 555 / CUDA 12.5）で torch 2.11.0+cu128 + unsloth 2026.6.2 の import 検証済み
- ruff check / format --check グリーン
- spec レビュー + 品質レビュー指摘（CI concurrency、README legacy リンク、LICENSE 欠落、install.sh 冪等性ほか）対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)