### PR TITLE
✨ feat(kernels,utils): port Triton kernels and packed/attention utils (#3)

### DIFF
--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from contextlib import contextmanager
+
+
+@contextmanager
+def timer(name):
+    start = time.time()
+    yield
+    end = time.time()
+    print(f"{name} took {end - start:.2f} seconds")
+
+
+@contextmanager
+def header_footer_context(title: str, char="-"):
+    print()
+    print(f"{char}" * 50 + f" {title} " + f"{char}" * 50)
+    yield
+    print(f"{char}" * (100 + len(title) + 2))
+    print()

--- a/tests/utils/os_utils.py
+++ b/tests/utils/os_utils.py
@@ -1,0 +1,127 @@
+import importlib
+import os
+import shutil
+import subprocess
+import sys
+
+
+def detect_package_manager():
+    """Detect the available package manager"""
+    package_managers = {
+        "apt": "/usr/bin/apt",
+        "yum": "/usr/bin/yum",
+        "dnf": "/usr/bin/dnf",
+        "pacman": "/usr/bin/pacman",
+        "zypper": "/usr/bin/zypper",
+    }
+
+    for pm, path in package_managers.items():
+        if os.path.exists(path):
+            return pm
+    return None
+
+
+def check_package_installed(package_name, package_manager=None):
+    """Check if a package is installed using the system package manager"""
+
+    if package_manager is None:
+        package_manager = detect_package_manager()
+
+    if package_manager is None:
+        print("Warning: Could not detect package manager")
+        return None
+
+    try:
+        if package_manager == "apt":
+            # Check with dpkg
+            result = subprocess.run(
+                ["dpkg", "-l", package_name], capture_output=True, text=True
+            )
+            return result.returncode == 0
+
+        elif package_manager in ["yum", "dnf"]:
+            # Check with rpm
+            result = subprocess.run(
+                ["rpm", "-q", package_name], capture_output=True, text=True
+            )
+            return result.returncode == 0
+
+        elif package_manager == "pacman":
+            result = subprocess.run(
+                ["pacman", "-Q", package_name], capture_output=True, text=True
+            )
+            return result.returncode == 0
+
+        elif package_manager == "zypper":
+            result = subprocess.run(
+                ["zypper", "se", "-i", package_name], capture_output=True, text=True
+            )
+            return package_name in result.stdout
+
+    except Exception as e:
+        print(f"Error checking package: {e}")
+        return None
+
+
+def require_package(package_name, executable_name=None):
+    """Require a package to be installed, exit if not found"""
+
+    # First check if executable is in PATH (most reliable)
+    if executable_name and shutil.which(executable_name):
+        print(f"✓ {executable_name} is available")
+        return
+
+    # Then check with package manager
+    pm = detect_package_manager()
+    is_installed = check_package_installed(package_name, pm)
+
+    if is_installed:
+        print(f"✓ Package {package_name} is installed")
+        return
+
+    # Package not found - show installation instructions
+    print(f"❌ Error: {package_name} is not installed")
+    print(f"\nPlease install {package_name} using your system package manager:")
+
+    install_commands = {
+        "apt": f"sudo apt update && sudo apt install {package_name}",
+        "yum": f"sudo yum install {package_name}",
+        "dnf": f"sudo dnf install {package_name}",
+        "pacman": f"sudo pacman -S {package_name}",
+        "zypper": f"sudo zypper install {package_name}",
+    }
+
+    if pm and pm in install_commands:
+        print(f"  {install_commands[pm]}")
+    else:
+        for pm_name, cmd in install_commands.items():
+            print(f"  {pm_name}: {cmd}")
+
+    print("\nAlternatively, install with conda:")
+    print(f"  conda install -c conda-forge {package_name}")
+
+    print("\nPlease install the required package and run the script again.")
+    sys.exit(1)
+
+
+# Usage
+# require_package("ffmpeg", "ffmpeg")
+
+
+def require_python_package(package_name, import_name=None, pip_name=None):
+    """Require a Python package to be installed, exit if not found"""
+    if import_name is None:
+        import_name = package_name
+    if pip_name is None:
+        pip_name = package_name
+
+    if importlib.util.find_spec(import_name) is None:
+        print(f"❌ Error: Python package '{package_name}' is not installed")
+        print(f"\nPlease install {package_name} using pip:")
+        print(f"  pip install {pip_name}")
+        print("  # or with conda:")
+        print(f"  conda install {pip_name}")
+        print("\nAfter installation, run this script again.")
+        sys.exit(1)
+    else:
+        print(f"✓ Python package '{package_name}' is installed")

--- a/tests/utils/test_attention_masks.py
+++ b/tests/utils/test_attention_masks.py
@@ -1,0 +1,286 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Unit tests for packed-attention mask helpers with sliding-window logic."""
+
+import math
+
+import torch
+
+from unturtle.utils import attention_dispatch
+from unturtle.utils import packing as packing_utils
+
+
+def _make_seq_info(lengths):
+    lengths = torch.tensor(lengths, dtype=torch.int32)
+    cu = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32),
+            torch.cumsum(lengths, dim=0, dtype=torch.int32),
+        ]
+    )
+    max_len = int(lengths.max().item())
+    return lengths, cu, max_len
+
+
+def test_sdpa_packed_attention_mask_sliding_window():
+    seq_info = _make_seq_info([5, 3])
+    mask = packing_utils.build_sdpa_packed_attention_mask(
+        seq_info,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        sliding_window=3,
+    )
+
+    assert mask.shape == (1, 1, 8, 8)
+
+    block_first = mask[0, 0, :5, :5]
+    upper = torch.triu(torch.ones_like(block_first), diagonal=1).bool()
+    assert torch.all(block_first[upper] == float("-inf"))
+    assert block_first[3, 0].item() == float("-inf")
+    assert block_first[4, 1].item() == float("-inf")
+    assert block_first[4, 2].item() > -math.inf
+    assert mask[0, 0, 0, 6].item() == float("-inf")
+
+
+def test_xformers_block_mask_sliding_window(monkeypatch):
+    class _FakeMask:
+        def __init__(self, lengths, window=None):
+            self.lengths = lengths
+            self.window = window
+
+        @classmethod
+        def from_seqlens(cls, lengths):
+            return cls(tuple(lengths))
+
+        def make_local_attention(self, window_size):
+            return _FakeMask(self.lengths, window=window_size)
+
+    monkeypatch.setattr(packing_utils, "_XFormersBlockMask", _FakeMask, raising=False)
+
+    seq_info = _make_seq_info([4, 4])
+    mask = packing_utils.build_xformers_block_causal_mask(
+        seq_info,
+        sliding_window=2,
+    )
+
+    assert isinstance(mask, _FakeMask)
+    assert mask.window == 2
+
+
+def test_run_attention_sdpa_passes_sliding_window(monkeypatch):
+    seq_info = _make_seq_info([3, 2])
+    sliding_window = 2
+
+    original_builder = attention_dispatch.build_sdpa_packed_attention_mask
+    captured = {}
+
+    def _capture_builder(seq_info_arg, *, dtype, device, sliding_window=None):
+        captured["window"] = sliding_window
+        return original_builder(
+            seq_info_arg,
+            dtype=dtype,
+            device=device,
+            sliding_window=sliding_window,
+        )
+
+    monkeypatch.setattr(
+        attention_dispatch,
+        "build_sdpa_packed_attention_mask",
+        _capture_builder,
+    )
+
+    def _fake_sdpa(Q, K, V, **kwargs):
+        captured["mask"] = kwargs.get("attn_mask")
+        return torch.zeros_like(Q)
+
+    monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
+
+    config = attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.SDPA,
+        n_kv_heads=1,
+        n_groups=1,
+    )
+
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=5,
+        kv_seq_len=5,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+        sliding_window=sliding_window,
+    )
+
+    Q = torch.zeros(1, 1, 5, 1)
+    K = torch.zeros_like(Q)
+    V = torch.zeros_like(Q)
+
+    attention_dispatch.run_attention(
+        config=config,
+        context=context,
+        Q=Q,
+        K=K,
+        V=V,
+    )
+
+    assert captured["window"] == sliding_window
+    mask = captured["mask"]
+    assert mask is not None and mask.shape == (1, 1, 5, 5)
+    assert mask[0, 0, 4, 1].item() == float("-inf")
+
+
+def test_run_attention_xformers_passes_sliding_window(monkeypatch):
+    seq_info = _make_seq_info([4])
+    sliding_window = 3
+
+    class _FakeBias:
+        pass
+
+    captured = {}
+
+    def _fake_builder(seq_info_arg, *, sliding_window=None, base_mask=None):
+        captured["window"] = sliding_window
+        captured["base"] = base_mask
+        return _FakeBias()
+
+    def _fake_attention(Q, K, V, attn_bias=None, **_):
+        captured["bias"] = attn_bias
+        return torch.zeros_like(Q)
+
+    monkeypatch.setattr(
+        attention_dispatch, "build_xformers_block_causal_mask", _fake_builder
+    )
+    monkeypatch.setattr(
+        attention_dispatch, "xformers_attention", _fake_attention, raising=False
+    )
+    monkeypatch.setattr(
+        attention_dispatch, "XFORMERS_BLOCK_DIAG_CLS", _FakeBias, raising=False
+    )
+
+    config = attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.XFORMERS,
+        n_kv_heads=1,
+        n_groups=1,
+    )
+
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+        sliding_window=sliding_window,
+    )
+
+    Q = torch.zeros(1, 1, 4, 1)
+    K = torch.zeros_like(Q)
+    V = torch.zeros_like(Q)
+
+    attention_dispatch.run_attention(
+        config=config,
+        context=context,
+        Q=Q,
+        K=K,
+        V=V,
+    )
+
+    assert captured["window"] == sliding_window
+    assert isinstance(captured["bias"], _FakeBias)
+
+
+def test_select_attention_backend_uses_sdpa_on_cpu_even_when_fast_paths_installed(
+    monkeypatch,
+):
+    monkeypatch.setattr(attention_dispatch, "HAS_FLASH_ATTENTION", True)
+    monkeypatch.setattr(attention_dispatch, "HAS_XFORMERS", True)
+
+    backend = attention_dispatch.select_attention_backend(
+        use_varlen=False,
+        device_type="cpu",
+    )
+
+    assert backend == attention_dispatch.SDPA
+
+
+def test_run_attention_flash_varlen_receives_window_and_softcap(monkeypatch):
+    seq_info = _make_seq_info([4])
+    sliding_window = 3
+    softcap = 0.5
+    window_tuple = (sliding_window, sliding_window)
+
+    captured = {}
+
+    def _fake_flash_varlen(Q, K, V, cu_q, cu_k, max_q, max_k, **kwargs):
+        captured["kwargs"] = kwargs
+        return torch.zeros_like(Q)
+
+    monkeypatch.setattr(
+        attention_dispatch,
+        "flash_attn_varlen_func",
+        _fake_flash_varlen,
+    )
+    monkeypatch.setattr(attention_dispatch, "HAS_FLASH_ATTENTION", True)
+
+    config = attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.FLASH_VARLEN,
+        n_kv_heads=1,
+        n_groups=1,
+        flash_varlen_kwargs={
+            "dropout_p": 0.0,
+            "softmax_scale": 1.0,
+            "causal": True,
+            "softcap": softcap,
+            "window_size": window_tuple,
+        },
+    )
+
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=2,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+        sliding_window=sliding_window,
+    )
+
+    Q = torch.zeros(1, 1, 4, 2)
+    K = torch.zeros_like(Q)
+    V = torch.zeros_like(Q)
+
+    attention_dispatch.run_attention(
+        config=config,
+        context=context,
+        Q=Q,
+        K=K,
+        V=V,
+    )
+
+    assert captured["kwargs"]["softcap"] == softcap
+    assert captured["kwargs"]["window_size"] == window_tuple
+
+
+"""Unit tests for packed-attention mask helpers with sliding-window logic."""

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -1,0 +1,404 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from datasets import Dataset
+from trl import SFTConfig, SFTTrainer
+from trl.trainer.sft_trainer import DataCollatorForLanguageModeling
+from unsloth import FastLanguageModel
+from unsloth.utils import attention_dispatch as attention_dispatch_utils
+
+from unturtle.utils.packing import (
+    configure_padding_free,
+    configure_sample_packing,
+    enable_padding_free_metadata,
+    enable_sample_packing,
+    mask_packed_sequence_boundaries,
+)
+
+
+def _build_packed_training_setup(tmp_path, device):
+    dtype = None
+    if device.type == "cuda":
+        dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+    try:
+        model, tokenizer = FastLanguageModel.from_pretrained(
+            model_name="hf-internal-testing/tiny-random-LlamaForCausalLM",
+            max_seq_length=64,
+            load_in_4bit=False,
+            dtype=dtype,
+        )
+    except OSError as exc:  # pragma: no cover - offline CI
+        pytest.skip(f"Requires access to tiny llama checkpoint: {exc}")
+
+    model.to(device)
+
+    dataset = Dataset.from_dict(
+        {
+            "text": [
+                "Hello world!",
+                "Short sample.",
+                "This is a slightly longer packed example to test batching.",
+                "Another response to include in the batch.",
+            ]
+        }
+    )
+
+    training_args = SFTConfig(
+        per_device_train_batch_size=1,
+        per_device_eval_batch_size=1,
+        gradient_accumulation_steps=1,
+        dataset_text_field="text",
+        max_length=64,
+        logging_steps=1,
+        max_steps=1,
+        fp16=device.type == "cuda" and not torch.cuda.is_bf16_supported(),
+        bf16=device.type == "cuda" and torch.cuda.is_bf16_supported(),
+        dataset_num_proc=1,
+        output_dir=str(tmp_path),
+        packing=True,
+    )
+
+    trainer = SFTTrainer(
+        model=model,
+        processing_class=tokenizer,
+        train_dataset=dataset,
+        args=training_args,
+    )
+
+    enable_sample_packing(model, trainer)
+
+    dataloader = trainer.get_train_dataloader()
+    batch = next(iter(dataloader))
+
+    model_device = next(model.parameters()).device
+
+    for key, value in list(batch.items()):
+        if torch.is_tensor(value):
+            batch[key] = value.to(model_device)
+
+    from unsloth.models import llama as llama_mod
+
+    return model, batch, trainer, llama_mod
+
+
+def _trim_batch_to_total_tokens(data, total_tokens):
+    def _trim_tensor(t: torch.Tensor):
+        if t.ndim >= 2 and t.size(1) > total_tokens:
+            return t[:, :total_tokens].contiguous()
+        return t
+
+    trimmed = {}
+    for key, value in data.items():
+        if torch.is_tensor(value):
+            trimmed[key] = _trim_tensor(value)
+        else:
+            trimmed[key] = value
+    return trimmed
+
+
+def test_mask_packed_sequence_boundaries_marks_single_row():
+    shift_labels = torch.arange(6, dtype=torch.long).view(1, 6)
+    changed = mask_packed_sequence_boundaries(
+        shift_labels,
+        torch.tensor([2, 1, 3], dtype=torch.int32),
+    )
+    assert changed is True
+    flat = shift_labels.view(-1)
+    assert flat[1].item() == -100
+    assert flat[2].item() == -100
+    assert flat[5].item() == -100
+    assert flat[0].item() != -100
+
+
+def test_mask_packed_sequence_boundaries_across_multiple_rows():
+    shift_labels = torch.arange(10, dtype=torch.long).view(2, 5)
+    lengths = torch.tensor([3, 2, 4, 1], dtype=torch.int32)
+    changed = mask_packed_sequence_boundaries(shift_labels, lengths)
+    assert changed is True
+    flat = shift_labels.view(-1)
+    for idx in (2, 4, 8, 9):
+        assert flat[idx].item() == -100
+    assert torch.any(flat != -100)
+
+
+def test_configure_sample_packing():
+    config = SimpleNamespace()
+    configure_sample_packing(config)
+
+    assert config.packing is True
+    assert config.padding_free is True
+    assert config.remove_unused_columns is False
+
+
+def test_configure_padding_free():
+    config = SimpleNamespace(remove_unused_columns=True)
+    configure_padding_free(config)
+
+    assert config.padding_free is True
+    assert config.remove_unused_columns is False
+
+
+class _DummyChild(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.max_seq_length = 8
+
+
+class _DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.max_seq_length = 16
+        self.child = _DummyChild()
+        self.config = SimpleNamespace(_attn_implementation="sdpa")
+        self.generation_config = SimpleNamespace(attn_implementation="sdpa")
+
+
+class _DummyTrainer:
+    def __init__(self):
+        self.args = SimpleNamespace(remove_unused_columns=True)
+        collator_args = {
+            "pad_token_id": 0,
+            "completion_only_loss": False,
+            "return_tensors": "pt",
+        }
+        optional_flags = [
+            {"padding_free": True, "return_position_ids": False},
+            {"padding_free": True},
+            {},
+        ]
+        for extra in optional_flags:
+            try:
+                self.data_collator = DataCollatorForLanguageModeling(
+                    **collator_args, **extra
+                )
+                break
+            except TypeError:
+                continue
+        # Ensure attributes exist even if the constructor did not accept them
+        if not hasattr(self.data_collator, "padding_free"):
+            self.data_collator.padding_free = True
+        if not hasattr(self.data_collator, "return_position_ids"):
+            self.data_collator.return_position_ids = False
+
+
+class _PaddingFreeCollator:
+    def __init__(self):
+        self.padding_free = True
+        self.return_position_ids = False
+        self.calls = 0
+
+    def torch_call(self, examples):
+        self.calls += 1
+        return {
+            "input_ids": torch.tensor([[0]], dtype=torch.long),
+            "examples_seen": self.calls,
+        }
+
+
+def test_enable_sample_packing():
+    model = _DummyModel()
+    trainer = _DummyTrainer()
+
+    enable_sample_packing(model, trainer)
+
+    # model hierarchy should now allow packed overlength inputs
+    assert model._unsloth_allow_packed_overlength is True
+    assert model.child._unsloth_allow_packed_overlength is True
+
+    collator = trainer.data_collator
+    assert collator.return_position_ids is True
+    assert collator._unsloth_packing_wrapped is True
+
+    examples = [
+        {
+            "input_ids": [0, 1, 2],
+            "labels": [0, 1, 2],
+            "seq_lengths": [2, 1],
+        },
+        {
+            "input_ids": [3, 4, 5],
+            "labels": [3, 4, 5],
+            "seq_lengths": [3],
+        },
+    ]
+    batch = collator.torch_call(examples)
+
+    # packed lengths are aggregated into a single tensor
+    assert "packed_seq_lengths" in batch
+    assert torch.equal(
+        batch["packed_seq_lengths"],
+        torch.tensor([2, 1, 3], dtype=torch.int32),
+    )
+
+    assert batch["input_ids"].shape == (1, 6)
+    expected_positions = torch.tensor([0, 1, 0, 0, 1, 2], dtype=torch.long)
+    assert torch.equal(batch["position_ids"].view(-1)[:6], expected_positions)
+
+
+def test_enable_sample_packing_trl_collator(tmp_path):
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    model, _, trainer, _ = _build_packed_training_setup(tmp_path, device)
+
+    enable_sample_packing(model, trainer)
+
+    examples = [
+        {
+            "input_ids": [0, 1, 2],
+            "labels": [0, 1, 2],
+            "seq_lengths": [2, 1],
+        },
+        {
+            "input_ids": [3, 4, 5],
+            "labels": [3, 4, 5],
+            "seq_lengths": [3],
+        },
+    ]
+
+    batch = trainer.data_collator.torch_call(examples)
+
+    assert batch["input_ids"].shape == (1, 6)
+    assert torch.equal(
+        batch["packed_seq_lengths"],
+        torch.tensor([2, 1, 3], dtype=torch.int32),
+    )
+
+    expected_positions = torch.tensor([0, 1, 0, 0, 1, 2], dtype=torch.long)
+    assert torch.equal(batch["position_ids"].view(-1)[:6], expected_positions)
+
+    if hasattr(trainer, "accelerator"):
+        trainer.accelerator.free_memory()
+
+
+def test_enable_padding_free_metadata():
+    model = _DummyModel()
+    trainer = SimpleNamespace(
+        args=SimpleNamespace(remove_unused_columns=True),
+        data_collator=_PaddingFreeCollator(),
+    )
+
+    enable_padding_free_metadata(model, trainer)
+
+    assert model._unsloth_allow_packed_overlength is True
+    assert model.child._unsloth_allow_packed_overlength is True
+
+    collator = trainer.data_collator
+    assert collator.return_position_ids is True
+    assert collator._unsloth_padding_free_lengths_wrapped is True
+
+    examples = [
+        {"input_ids": [0, 1, 2]},
+        {"input_ids": [3, 4]},
+    ]
+    batch = collator.torch_call(examples)
+    assert torch.equal(
+        batch["packed_seq_lengths"],
+        torch.tensor([3, 2], dtype=torch.int32),
+    )
+    assert trainer.args.remove_unused_columns is False
+
+
+def test_packing_sdpa(tmp_path):
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    model, batch, trainer, llama_mod = _build_packed_training_setup(tmp_path, device)
+
+    assert "packed_seq_lengths" in batch
+    assert "attention_mask" not in batch
+    assert batch["packed_seq_lengths"].dtype == torch.int32
+
+    total_tokens = batch["input_ids"].size(-1)
+    assert int(batch["packed_seq_lengths"].sum().item()) == total_tokens
+
+    packed_tokens = int(batch["packed_seq_lengths"].sum().item())
+    assert "position_ids" in batch
+    flat_positions = batch["position_ids"].reshape(-1)[:packed_tokens]
+    expected_positions = torch.cat(
+        [
+            torch.arange(length, dtype=torch.long)
+            for length in batch["packed_seq_lengths"].tolist()
+        ]
+    )
+    assert torch.equal(flat_positions.cpu(), expected_positions)
+    inputs = _trim_batch_to_total_tokens(batch, packed_tokens)
+
+    seq_info = llama_mod.get_packed_info_from_kwargs(
+        {"packed_seq_lengths": batch["packed_seq_lengths"]},
+        inputs["input_ids"].device,
+    )
+    assert seq_info is not None
+
+    original_mask = attention_dispatch_utils.build_sdpa_packed_attention_mask
+    mask_calls = []
+    captured_loss_labels = {}
+
+    def _capture_mask(seq_info, dtype, device, *, sliding_window=None):
+        mask_calls.append(tuple(seq_info[0].tolist()))
+        return original_mask(
+            seq_info,
+            dtype=dtype,
+            device=device,
+            sliding_window=sliding_window,
+        )
+
+    def _capture_loss(*, logits, labels, **loss_kwargs):
+        captured_loss_labels["labels"] = labels.detach().to("cpu")
+        return torch.zeros((), device=logits.device, dtype=logits.dtype)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(attention_dispatch_utils, "HAS_FLASH_ATTENTION", False)
+        )
+        stack.enter_context(
+            patch.object(attention_dispatch_utils, "HAS_XFORMERS", False)
+        )
+        stack.enter_context(
+            patch.object(
+                attention_dispatch_utils,
+                "build_sdpa_packed_attention_mask",
+                side_effect=_capture_mask,
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                llama_mod,
+                "fast_cross_entropy_loss",
+                side_effect=_capture_loss,
+            )
+        )
+        with torch.no_grad():
+            outputs = model(**inputs)
+
+    assert mask_calls, "SDPA packed mask was not constructed"
+    assert outputs.loss is not None
+    assert "labels" in captured_loss_labels
+    flat_loss_labels = captured_loss_labels["labels"].reshape(-1)
+    boundaries = (
+        torch.cumsum(
+            batch["packed_seq_lengths"].to(device="cpu", dtype=torch.long), dim=0
+        )
+        - 1
+    )
+    for idx in boundaries.tolist():
+        assert flat_loss_labels[idx].item() == -100
+    assert torch.any(flat_loss_labels != -100)
+
+    if hasattr(trainer, "accelerator"):
+        trainer.accelerator.free_memory()

--- a/unturtle/kernels/__init__.py
+++ b/unturtle/kernels/__init__.py
@@ -1,0 +1,81 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle.kernels — Triton-optimised kernels for dLLM training.
+
+Canonical home for unturtle-specific kernels vendored or extended for unturtle.
+
+Public API::
+
+    from unturtle.kernels import (
+        Fast_CrossEntropyLoss,
+        LoRA_QKV,
+        LoRA_QKV_Bias,
+        apply_lora_o,
+        apply_lora_qkv,
+        apply_lora_qkv_with_bias,
+        apply_lora_mlp_swiglu,
+        fast_cross_entropy_loss,
+        fast_masked_diffusion_loss,
+        fast_rope_embedding,
+        fused_masked_diffusion_loss,
+        masked_diffusion_loss_from_timesteps,
+    )
+"""
+
+from unsloth.kernels.cross_entropy_loss import (
+    Fast_CrossEntropyLoss,
+    fast_cross_entropy_loss,
+)
+from unsloth.kernels.rope_embedding import fast_rope_embedding
+
+from .fused_masked_diffusion_loss import fused_masked_diffusion_loss
+from .masked_diffusion_loss import (
+    fast_masked_diffusion_loss,
+    masked_diffusion_loss_from_timesteps,
+)
+
+__all__ = [
+    "Fast_CrossEntropyLoss",
+    "fast_cross_entropy_loss",
+    "fast_masked_diffusion_loss",
+    "masked_diffusion_loss_from_timesteps",
+    "fused_masked_diffusion_loss",
+    "fast_rope_embedding",
+]
+
+try:
+    from .fast_lora import (
+        LoRA_QKV,
+        LoRA_QKV_Bias,
+        apply_lora_mlp_swiglu,
+        apply_lora_o,
+        apply_lora_qkv,
+        apply_lora_qkv_with_bias,
+    )
+except (ImportError, OSError, AttributeError):
+    # fast_lora has optional bitsandbytes-backed dependencies; keep the rest of
+    # unturtle.kernels importable when they are unavailable or partially linked.
+    pass
+else:
+    __all__.extend(
+        [
+            "LoRA_QKV",
+            "LoRA_QKV_Bias",
+            "apply_lora_qkv",
+            "apply_lora_qkv_with_bias",
+            "apply_lora_o",
+            "apply_lora_mlp_swiglu",
+        ]
+    )

--- a/unturtle/kernels/fast_lora.py
+++ b/unturtle/kernels/fast_lora.py
@@ -1,0 +1,246 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton-fused LoRA kernel extensions for dLLM models.
+
+Provides ``apply_lora_qkv_with_bias``: the bias-aware variant of unsloth's
+``apply_lora_qkv`` kernel needed for Dream's ``q/k/v_proj`` layers which have
+``bias=True``.
+
+Mathematics::
+
+    Q = X @ Wq.T + bq + (X @ Aq.T) @ Bq.T * Sq
+    K = X @ Wk.T + bk + (X @ Ak.T) @ Bk.T * Sk
+    V = X @ Wv.T + bv + (X @ Av.T) @ Bv.T * Sv
+
+The weight-update part is identical to ``LoRA_QKV``; this class adds the bias
+addition in forward and the bias gradient (``dQ.sum(0)`` etc.) in backward.
+"""
+
+from __future__ import annotations
+
+import torch
+from unsloth.kernels.fast_lora import (
+    LoRA_QKV,
+    _maybe_fake_quantize_activations,
+    apply_lora_mlp_swiglu,
+    apply_lora_o,
+    apply_lora_qkv,
+    fast_dequantize,
+    get_lora_parameters_bias,
+    matmul_lora,
+    torch_amp_custom_bwd,
+    torch_amp_custom_fwd,
+)
+
+__all__ = [
+    "LoRA_QKV",
+    "LoRA_QKV_Bias",
+    "apply_lora_qkv",
+    "apply_lora_qkv_with_bias",
+    "apply_lora_o",
+    "apply_lora_mlp_swiglu",
+]
+
+
+class LoRA_QKV_Bias(torch.autograd.Function):
+    """Fused QKV LoRA with bias support.
+
+    Identical to :class:`unsloth.kernels.fast_lora.LoRA_QKV` except each
+    projection's bias is added after the matmul (forward) and the bias
+    gradients are accumulated in backward.
+
+    Args order matches ``LoRA_QKV`` with three extra bias args appended:
+    ``Qbias, Kbias, Vbias``.
+    """
+
+    @staticmethod
+    @torch_amp_custom_fwd
+    def forward(
+        ctx,
+        X: torch.Tensor,
+        QW,
+        QW_quant,
+        QA,
+        QB,
+        QS,
+        QBias,
+        KW,
+        KW_quant,
+        KA,
+        KB,
+        KS,
+        KBias,
+        VW,
+        VW_quant,
+        VA,
+        VB,
+        VS,
+        VBias,
+        inplace: bool = True,
+    ):
+        orig_shape = X.shape
+        X_for_matmul = X.view(-1, X.shape[-1]) if X.dim() == 3 else X
+
+        Q = matmul_lora(X_for_matmul, QW, QW_quant, QA, QB, QS)
+        K = matmul_lora(X_for_matmul, KW, KW_quant, KA, KB, KS)
+        V = matmul_lora(X_for_matmul, VW, VW_quant, VA, VB, VS)
+
+        if len(orig_shape) == 3:
+            Q = Q.view(orig_shape[0], orig_shape[1], -1)
+            K = K.view(orig_shape[0], orig_shape[1], -1)
+            V = V.view(orig_shape[0], orig_shape[1], -1)
+
+        # Add biases (broadcast over batch and sequence dimensions)
+        if QBias is not None:
+            Q = Q + QBias
+        if KBias is not None:
+            K = K + KBias
+        if VBias is not None:
+            V = V + VBias
+
+        ctx.custom_saved_tensors = (
+            QW,
+            QW_quant,
+            QS,
+            KW,
+            KW_quant,
+            KS,
+            VW,
+            VW_quant,
+            VS,
+        )
+        ctx.save_for_backward(X, QA, QB, KA, KB, VA, VB)
+        ctx.inplace = inplace
+        ctx.has_bias = (QBias is not None, KBias is not None, VBias is not None)
+        return Q, K, V
+
+    @staticmethod
+    @torch_amp_custom_bwd
+    def backward(ctx, dQ, dK, dV):
+        QW, QW_quant, QS, KW, KW_quant, KS, VW, VW_quant, VS = ctx.custom_saved_tensors
+        X, QA, QB, KA, KB, VA, VB = ctx.saved_tensors
+        has_Qb, has_Kb, has_Vb = ctx.has_bias
+
+        batch, seq_len, hd = X.shape
+        dQ = dQ.reshape(-1, dQ.shape[-1])
+        dK = dK.reshape(-1, dK.shape[-1])
+        dV = dV.reshape(-1, dV.shape[-1])
+        X = X.reshape(-1, X.shape[-1])
+        dtype = X.dtype
+
+        QA, QB = QA.to(dtype).t(), QB.to(dtype).t()
+        KA, KB = KA.to(dtype).t(), KB.to(dtype).t()
+        VA, VB = VA.to(dtype).t(), VB.to(dtype).t()
+
+        d_QA = torch.empty_like(QA)
+        d_QB = torch.empty_like(QB)
+        d_KA = torch.empty_like(KA)
+        d_KB = torch.empty_like(KB)
+        d_VA = torch.empty_like(VA)
+        d_VB = torch.empty_like(VB)
+
+        d_QA.addmm_(X.t(), dQ @ QB.t(), alpha=QS, beta=0)
+        d_QB.addmm_(QA.t() @ X.t(), dQ, alpha=QS, beta=0)
+
+        d_KA.addmm_(X.t(), dK @ KB.t(), alpha=KS, beta=0)
+        d_KB.addmm_(KA.t() @ X.t(), dK, alpha=KS, beta=0)
+
+        d_VA.addmm_(X.t(), dV @ VB.t(), alpha=VS, beta=0)
+        d_VB.addmm_(VA.t() @ X.t(), dV, alpha=VS, beta=0)
+
+        # dX
+        QW = fast_dequantize(QW.t(), QW_quant)
+        dX = torch.matmul(dQ, QW.t(), out=X if ctx.inplace else None)
+        del QW
+        dX.addmm_(dQ @ QB.t(), QA.t(), alpha=QS)
+
+        KW = fast_dequantize(KW.t(), KW_quant)
+        dX.addmm_(dK, KW.t())
+        del KW
+        dX.addmm_(dK @ KB.t(), KA.t(), alpha=KS)
+
+        VW = fast_dequantize(VW.t(), VW_quant)
+        dX.addmm_(dV, VW.t())
+        del VW
+        dX.addmm_(dV @ VB.t(), VA.t(), alpha=VS)
+
+        # Bias gradients: sum over batch*seq dims
+        d_QBias = dQ.sum(0) if has_Qb else None
+        d_KBias = dK.sum(0) if has_Kb else None
+        d_VBias = dV.sum(0) if has_Vb else None
+
+        # X, QW, QW_quant, QA, QB, QS, QBias,
+        # KW, KW_quant, KA, KB, KS, KBias,
+        # VW, VW_quant, VA, VB, VS, VBias, inplace
+        return (
+            dX.view(batch, seq_len, hd),
+            None,
+            None,
+            d_QA.t(),
+            d_QB.t(),
+            None,
+            d_QBias,
+            None,
+            None,
+            d_KA.t(),
+            d_KB.t(),
+            None,
+            d_KBias,
+            None,
+            None,
+            d_VA.t(),
+            d_VB.t(),
+            None,
+            d_VBias,
+            None,
+        )
+
+
+def apply_lora_qkv_with_bias(self, X, inplace: bool = True):
+    """Bias-aware drop-in for ``apply_lora_qkv``.
+
+    Use this as ``self_attn.apply_qkv`` for models where ``q/k/v_proj``
+    have ``bias=True`` (e.g. Dream).
+
+    Reads parameters via ``get_lora_parameters_bias`` which returns a
+    6-tuple ``(W, W_quant, A, B, S, bias)``.
+    """
+    X = _maybe_fake_quantize_activations(X, self.q_proj)
+    QW, QW_quant, QA, QB, QS, QBias = get_lora_parameters_bias(self.q_proj)
+    KW, KW_quant, KA, KB, KS, KBias = get_lora_parameters_bias(self.k_proj)
+    VW, VW_quant, VA, VB, VS, VBias = get_lora_parameters_bias(self.v_proj)
+    Q, K, V = LoRA_QKV_Bias.apply(
+        X,
+        QW,
+        QW_quant,
+        QA,
+        QB,
+        QS,
+        QBias,
+        KW,
+        KW_quant,
+        KA,
+        KB,
+        KS,
+        KBias,
+        VW,
+        VW_quant,
+        VA,
+        VB,
+        VS,
+        VBias,
+        inplace,
+    )
+    return Q, K, V

--- a/unturtle/kernels/fused_masked_diffusion_loss.py
+++ b/unturtle/kernels/fused_masked_diffusion_loss.py
@@ -1,0 +1,169 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Fused masked diffusion loss — eliminates the ``labels.clone()`` overhead.
+
+``fast_masked_diffusion_loss`` (Phase 1) builds a masked label tensor via::
+
+    masked_labels = labels.clone()        # B×L alloc + copy
+    masked_labels[~diffusion_mask] = -100 # B×L scatter write
+
+``fused_masked_diffusion_loss`` replaces those two steps with a single
+``torch.where`` call that executes as one GPU pass::
+
+    fused_labels = torch.where(diffusion_mask_flat, labels_flat, NEG100)
+
+This saves one ``(B, L)`` allocation and one indexed-write kernel launch.
+The improvement is most significant for large vocab (128K+) models, where
+the label tensor is proportionally expensive to clone.
+
+Gradient computation is unchanged — ``Fast_CrossEntropyLoss`` handles it
+internally based on the fused label tensor.
+
+Loss normalization modes (``loss_norm_type``):
+  - ``"token"``    – divide by total maskable tokens across the batch (default).
+                     Matches the MDLM reference (dllm MDLMTrainer) and keeps
+                     loss scale stable as batch size changes.
+  - ``"sequence"`` – divide by per-sequence maskable count, then mean over B.
+                     Equivalent to averaging per-example NLL.
+  - ``"batch"``    – divide by batch size B only (simple mean over sequences).
+
+Reference:
+  zhziszz/dllm  dllm/core/trainers/mdlm.py  L200–210
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from unsloth.kernels.cross_entropy_loss import Fast_CrossEntropyLoss
+
+# Singleton -100 tensors reused across calls to avoid repeated scalar allocs.
+# Created lazily per device.
+_NEG100_CACHE: dict[torch.device, torch.Tensor] = {}
+
+
+def _get_neg100(device: torch.device) -> torch.Tensor:
+    """Return a scalar int64 tensor with value -100 on *device* (cached)."""
+    if device not in _NEG100_CACHE:
+        _NEG100_CACHE[device] = torch.tensor(-100, dtype=torch.long, device=device)
+    return _NEG100_CACHE[device]
+
+
+def fused_masked_diffusion_loss(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    diffusion_mask: torch.Tensor,
+    loss_weights=None,
+    logit_softcapping: float = 0,
+    logit_scaling: float = 0,
+    loss_norm_type: str = "token",
+) -> torch.Tensor:
+    """Triton CE loss with fused diffusion-mask application (no label clone).
+
+    Drop-in replacement for ``fast_masked_diffusion_loss``.
+    On GPU, replaces ``labels.clone() + scatter`` with a single
+    ``torch.where`` call.  On CPU, uses the same ``F.cross_entropy`` path.
+
+    Args:
+        logits:           ``(B, L, V)`` — raw model output logits.
+        labels:           ``(B, L)``    — clean token ids ``x_0``.
+        diffusion_mask:   ``(B, L)`` bool — ``True`` at masked positions
+                          (loss is computed here).
+        loss_weights:     ``(B,)`` or ``(B, L)`` float — per-token weights.
+                          Pass ``None`` for uniform weighting.
+        logit_softcapping: Gemma-2 style softcap (0 = disabled).
+        logit_scaling:    Cohere style logit scale (0 = disabled).
+        loss_norm_type:   How to normalise the accumulated loss.
+                          ``"token"``    – divide by total maskable tokens (default).
+                          ``"sequence"`` – per-sequence maskable count, then mean over B.
+                          ``"batch"``    – divide by B only.
+
+    Returns:
+        Scalar loss tensor.
+    """
+    B, L, V = logits.shape
+    assert labels.shape == (B, L), f"labels shape mismatch: {labels.shape}"
+    assert diffusion_mask.shape == (B, L), (
+        f"diffusion_mask shape mismatch: {diffusion_mask.shape}"
+    )
+
+    flat_labels = labels.view(-1)  # [B*L]
+    flat_mask = diffusion_mask.view(-1)  # [B*L] bool
+
+    if logits.device.type == "cuda":
+        # Fused: single torch.where instead of clone + scatter.
+        fused_labels = torch.where(
+            flat_mask, flat_labels, _get_neg100(flat_labels.device)
+        )
+        per_token_loss = Fast_CrossEntropyLoss.apply(
+            logits.view(B * L, V),
+            fused_labels,
+            logit_softcapping,
+            logit_scaling,
+        )  # [B*L], float32
+    else:
+        # CPU fallback — identical semantics to fast_masked_diffusion_loss.
+        fused_labels = torch.where(
+            flat_mask,
+            flat_labels,
+            torch.tensor(-100, dtype=torch.long),
+        )
+        per_token_loss = F.cross_entropy(
+            logits.view(B * L, V),
+            fused_labels,
+            ignore_index=-100,
+            reduction="none",
+        ).float()  # [B*L]
+
+    # maskable_mask: positions eligible for masking (labels != -100), shape [B, L]
+    maskable_mask = labels != -100  # [B, L]
+
+    # Apply per-token weights before normalization (if provided).
+    if loss_weights is not None:
+        per_token_loss = per_token_loss.view(B, L)
+        w = loss_weights
+        if w.shape == (B,):
+            w = w.unsqueeze(1)  # [B, 1]
+        assert w.shape == (B, L) or w.shape == (B, 1), (
+            f"loss_weights must be (B,), (B,1) or (B,L), got {w.shape}"
+        )
+        per_token_loss = per_token_loss * w.to(per_token_loss.dtype)  # [B, L]
+
+    # --- Normalization ---
+    if loss_norm_type == "token":
+        # Normalize by total maskable tokens in the batch.
+        # Matches MDLM reference (dllm/core/trainers/mdlm.py L202) and d1 SFT.
+        n_maskable = maskable_mask.sum().clamp_min(1)
+        if loss_weights is None:
+            return per_token_loss.sum() / n_maskable
+        return per_token_loss.sum() / n_maskable
+
+    if loss_norm_type == "sequence":
+        # Per-sequence normalisation, then mean over B.
+        # Equivalent to averaging per-example NLL.
+        per_token_loss = per_token_loss.view(B, L)
+        n_per_seq = maskable_mask.sum(dim=-1, keepdim=True).clamp_min(1)  # [B, 1]
+        return (per_token_loss / n_per_seq.to(per_token_loss.dtype)).sum() / B
+
+    if loss_norm_type == "batch":
+        # Simple mean over sequences.
+        per_token_loss = per_token_loss.view(B, L)
+        return per_token_loss.sum() / B
+
+    raise ValueError(
+        f"Unknown loss_norm_type '{loss_norm_type}'. "
+        "Choose from: 'token', 'sequence', 'batch'."
+    )

--- a/unturtle/kernels/masked_diffusion_loss.py
+++ b/unturtle/kernels/masked_diffusion_loss.py
@@ -1,0 +1,129 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Masked Diffusion Language Model (dLLM) loss functions.
+
+Implements the masked diffusion cross-entropy loss used by LLaDA / MDLM / d1-style
+training.  The core CE computation reuses the existing Triton-optimised
+``Fast_CrossEntropyLoss`` kernel; the dLLM-specific additions are:
+
+1. Only masked positions contribute to the loss (unmasked → label = -100).
+2. Optional per-batch-element timestep weighting  ``w(t)``  (used by d1 SFT and
+   MDLM's scheduler-based weighting).
+
+References:
+    LLaDA  – https://arxiv.org/abs/2406.04329
+    MDLM   – https://arxiv.org/abs/2406.07524
+    d1     – https://arxiv.org/abs/2504.12216
+"""
+
+import torch
+
+from unturtle.kernels.fused_masked_diffusion_loss import fused_masked_diffusion_loss
+
+
+def fast_masked_diffusion_loss(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    diffusion_mask: torch.Tensor,
+    loss_weights: torch.Tensor | None = None,
+    logit_softcapping: float = 0,
+    logit_scaling: float = 0,
+    loss_norm_type: str = "token",
+) -> torch.Tensor:
+    """Triton-accelerated cross-entropy loss for masked diffusion language models.
+
+    Only the positions indicated by ``diffusion_mask`` contribute to the loss.
+    An optional per-token weight tensor ``loss_weights`` allows timestep-based
+    weighting (e.g. ``w(t) = -α'(t) / (1 - α(t))`` from MDLM, or ``1/t`` from d1).
+
+    This function reuses the existing ``Fast_CrossEntropyLoss`` Triton kernel by
+    setting ``label = -100`` at unmasked positions, which the kernel already treats
+    as "ignore".  Timestep weights are applied at the Python level so that no new
+    Triton kernel is required for Phase 1.
+
+    Args:
+        logits:           ``(B, L, V)`` – raw model output logits.
+        labels:           ``(B, L)``    – clean token ids ``x_0``.
+        diffusion_mask:   ``(B, L)`` bool – ``True`` at positions that were masked
+                          during the forward diffusion process (loss is computed here).
+        loss_weights:     ``(B, L)`` float or ``(B,)`` float (broadcast over L) –
+                          per-token weights.  Pass ``None`` for uniform weighting
+                          (MDLM / LLaDA style).  Pass ``1/t`` expanded to ``(B, L)``
+                          for d1-style timestep weighting.
+        logit_softcapping: Gemma-2 style softcap value (0 = disabled).
+        logit_scaling:    Cohere style logit scale (0 = disabled).
+        loss_norm_type:   How to normalise the accumulated loss.
+                          ``"token"``    – divide by total maskable tokens (default).
+                          ``"sequence"`` – per-sequence maskable count, then mean over B.
+                          ``"batch"``    – divide by B only.
+
+    Returns:
+        Scalar loss.
+    """
+    B, L, V = logits.shape
+    assert labels.shape == (B, L), f"labels shape mismatch: {labels.shape}"
+    assert diffusion_mask.shape == (B, L), (
+        f"diffusion_mask shape mismatch: {diffusion_mask.shape}"
+    )
+
+    # Delegate to fused_masked_diffusion_loss which eliminates the labels.clone()
+    # overhead via a single torch.where call (no separate scatter write).
+    return fused_masked_diffusion_loss(
+        logits=logits,
+        labels=labels,
+        diffusion_mask=diffusion_mask,
+        loss_weights=loss_weights,
+        logit_softcapping=logit_softcapping,
+        logit_scaling=logit_scaling,
+        loss_norm_type=loss_norm_type,
+    )
+
+
+def masked_diffusion_loss_from_timesteps(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    diffusion_mask: torch.Tensor,
+    timesteps: torch.Tensor,
+    logit_softcapping: float = 0,
+    logit_scaling: float = 0,
+) -> torch.Tensor:
+    """Convenience wrapper: d1-style ``loss / t`` timestep weighting.
+
+    Computes ``fast_masked_diffusion_loss`` with per-sequence weights ``1 / t``
+    where ``t`` is the diffusion timestep used during the forward process.
+
+    Args:
+        logits:         ``(B, L, V)``
+        labels:         ``(B, L)``
+        diffusion_mask: ``(B, L)`` bool
+        timesteps:      ``(B,)`` float in ``(eps, 1]`` – the diffusion timestep
+                        for each sequence in the batch.
+
+    Returns:
+        Scalar loss.
+    """
+    assert timesteps.shape == (logits.shape[0],), (
+        f"timesteps must have shape (B,)={logits.shape[0]}, got {timesteps.shape}"
+    )
+    loss_weights = 1.0 / timesteps.clamp_min(1e-6)  # [B]
+    return fast_masked_diffusion_loss(
+        logits=logits,
+        labels=labels,
+        diffusion_mask=diffusion_mask,
+        loss_weights=loss_weights,
+        logit_softcapping=logit_softcapping,
+        logit_scaling=logit_scaling,
+    )

--- a/unturtle/utils/__init__.py
+++ b/unturtle/utils/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unturtle-owned utility helpers vendored from unsloth as part of Phase Z."""

--- a/unturtle/utils/attention_dispatch.py
+++ b/unturtle/utils/attention_dispatch.py
@@ -1,0 +1,323 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Vendored from unsloth/utils/attention_dispatch.py for issue #67.
+
+"""Shared helpers for attention backend selection and execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+import torch
+from torch import Tensor
+from torch.nn.functional import scaled_dot_product_attention
+from unsloth.models._utils import HAS_FLASH_ATTENTION, xformers, xformers_attention
+
+from .packing import (
+    build_sdpa_packed_attention_mask,
+    build_xformers_block_causal_mask,
+)
+
+if HAS_FLASH_ATTENTION:
+    from flash_attn import flash_attn_func, flash_attn_varlen_func
+else:
+    flash_attn_func = None
+    flash_attn_varlen_func = None
+HAS_XFORMERS = xformers is not None
+
+if HAS_XFORMERS and torch.cuda.is_available():
+    _cc = torch.cuda.get_device_capability()
+    if _cc[0] >= 12:
+        HAS_XFORMERS = False
+SDPA_HAS_GQA = "enable_gqa" in (scaled_dot_product_attention.__doc__ or "")
+
+FLASH_VARLEN = "flash_varlen"
+FLASH_DENSE = "flash_dense"
+XFORMERS = "xformers"
+SDPA = "sdpa"
+
+
+XFORMERS_BLOCK_DIAG_CLS = (
+    xformers.attn_bias.BlockDiagonalCausalMask if HAS_XFORMERS else None
+)
+
+
+@dataclass
+class AttentionConfig:
+    backend: str
+    n_kv_heads: int
+    n_groups: int
+    flash_dense_kwargs: Optional[dict[str, Any]] = None
+    flash_varlen_kwargs: Optional[dict[str, Any]] = None
+    sdpa_kwargs: Optional[dict[str, Any]] = None
+    xformers_kwargs: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class AttentionContext:
+    bsz: int
+    q_len: int
+    kv_seq_len: int
+    n_heads: int
+    head_dim: int
+    requires_grad: bool
+    seq_info: Optional[Tuple[Tensor, Tensor, int]]
+    attention_mask: Optional[Tensor]
+    causal_mask: Optional[Any]
+    sliding_window: Optional[int] = None
+
+
+def select_attention_backend(
+    use_varlen: bool = False,
+    *,
+    device_type: str,
+) -> str:
+    if device_type == "cuda" and HAS_FLASH_ATTENTION:
+        if use_varlen:
+            return FLASH_VARLEN
+        return FLASH_DENSE
+    if device_type == "cuda" and HAS_XFORMERS:
+        return XFORMERS
+    return SDPA
+
+
+def run_attention(
+    *,
+    config: AttentionConfig,
+    context: AttentionContext,
+    Q: Tensor,
+    K: Tensor,
+    V: Tensor,
+) -> Tensor:
+    backend = config.backend
+    if backend == FLASH_VARLEN and context.seq_info is None:
+        backend = FLASH_DENSE if HAS_FLASH_ATTENTION else SDPA
+
+    if context.attention_mask is not None and backend in (
+        FLASH_DENSE,
+        FLASH_VARLEN,
+        XFORMERS,
+    ):
+        backend = SDPA
+
+    flash_dense_kwargs = config.flash_dense_kwargs or {}
+    flash_varlen_kwargs = config.flash_varlen_kwargs or {}
+    sdpa_kwargs = config.sdpa_kwargs or {}
+    xformers_kwargs = config.xformers_kwargs or {}
+
+    bsz = context.bsz
+    n_heads = context.n_heads
+    q_len = context.q_len
+    head_dim = context.head_dim
+    kv_seq_len = context.kv_seq_len
+    requires_grad = context.requires_grad
+    sliding_window = context.sliding_window
+
+    if backend == FLASH_VARLEN:
+        Q_f = Q.transpose(1, 2).reshape(bsz * q_len, n_heads, head_dim)
+        K_f = K.transpose(1, 2).reshape(bsz * q_len, config.n_kv_heads, head_dim)
+        V_f = V.transpose(1, 2).reshape(bsz * q_len, config.n_kv_heads, head_dim)
+        _, cu_seqlens, max_seqlen = context.seq_info
+        return flash_attn_varlen_func(
+            Q_f,
+            K_f,
+            V_f,
+            cu_seqlens,
+            cu_seqlens,
+            max_seqlen,
+            max_seqlen,
+            **flash_varlen_kwargs,
+        ).view(bsz, q_len, n_heads, head_dim)
+    if backend == FLASH_DENSE:
+        Q_t = Q.transpose(1, 2)
+        K_t = K.transpose(1, 2)
+        V_t = V.transpose(1, 2)
+        return flash_attn_func(Q_t, K_t, V_t, **flash_dense_kwargs).reshape(
+            bsz, q_len, n_heads, head_dim
+        )
+    if backend == XFORMERS:
+        attn_bias = build_xformers_block_causal_mask(
+            context.seq_info,
+            sliding_window=sliding_window,
+            base_mask=context.causal_mask,
+        )
+
+        Q_t = Q.transpose(1, 2)
+        K_t = K.transpose(1, 2)
+        V_t = V.transpose(1, 2)
+
+        K_mod = K_t
+        V_mod = V_t
+        Q_mod = Q_t
+
+        if config.n_groups != 1:
+            K_mod = K_t.view(bsz, kv_seq_len, config.n_kv_heads, 1, head_dim)
+            V_mod = V_t.view(bsz, kv_seq_len, config.n_kv_heads, 1, head_dim)
+            K_mod = K_mod.expand(
+                bsz, kv_seq_len, config.n_kv_heads, config.n_groups, head_dim
+            )
+            V_mod = V_mod.expand(
+                bsz, kv_seq_len, config.n_kv_heads, config.n_groups, head_dim
+            )
+
+            if requires_grad:
+                K_mod = K_mod.reshape(bsz, kv_seq_len, n_heads, head_dim)
+                V_mod = V_mod.reshape(bsz, kv_seq_len, n_heads, head_dim)
+            else:
+                Q_mod = Q_t.view(
+                    bsz, q_len, config.n_kv_heads, config.n_groups, head_dim
+                )
+
+        has_block = XFORMERS_BLOCK_DIAG_CLS is not None and isinstance(
+            attn_bias, XFORMERS_BLOCK_DIAG_CLS
+        )
+
+        if config.n_groups != 1 and has_block:
+            if not requires_grad:
+                Q_mod = Q_mod.view(
+                    1, bsz * q_len, config.n_kv_heads, config.n_groups, head_dim
+                )
+                K_mod = K_mod.view(
+                    1, bsz * kv_seq_len, config.n_kv_heads, config.n_groups, head_dim
+                )
+                V_mod = V_mod.view(
+                    1, bsz * kv_seq_len, config.n_kv_heads, config.n_groups, head_dim
+                )
+            else:
+                Q_mod = Q_mod.view(1, bsz * q_len, n_heads, head_dim)
+                K_mod = K_mod.view(1, bsz * kv_seq_len, n_heads, head_dim)
+                V_mod = V_mod.view(1, bsz * kv_seq_len, n_heads, head_dim)
+
+        out = xformers_attention(
+            Q_mod,
+            K_mod,
+            V_mod,
+            attn_bias=attn_bias,
+            **xformers_kwargs,
+        )
+
+        if config.n_groups != 1 and not requires_grad:
+            out = out.view(bsz, q_len, config.n_kv_heads, config.n_groups, head_dim)
+            out = out.reshape(bsz, q_len, n_heads, head_dim)
+        else:
+            out = out.view(bsz, q_len, n_heads, head_dim)
+        return out
+
+    local_mask = context.attention_mask
+    is_causal_local = False
+    if context.seq_info is not None and local_mask is None:
+        local_mask = build_sdpa_packed_attention_mask(
+            context.seq_info,
+            dtype=Q.dtype,
+            device=Q.device,
+            sliding_window=sliding_window,
+        )
+    else:
+        q_len_local = Q.shape[-2]
+        k_len_local = K.shape[-2]
+        if local_mask is not None and isinstance(local_mask, torch.Tensor):
+            local_mask = local_mask.to(device=Q.device)
+
+            if local_mask.dim() == 2:
+                if local_mask.dtype == torch.bool:
+                    key_keep = local_mask
+                else:
+                    key_keep = local_mask != 0
+
+                past_len = k_len_local - q_len_local
+                q_pos = torch.arange(past_len, past_len + q_len_local, device=Q.device)
+                k_pos = torch.arange(k_len_local, device=Q.device)
+
+                causal_keep = k_pos[None, :] <= q_pos[:, None]
+                if sliding_window is not None:
+                    causal_keep &= k_pos[None, :] >= (
+                        q_pos[:, None] - (sliding_window - 1)
+                    )
+
+                local_mask = causal_keep[None, None, :, :] & key_keep[:, None, None, :]
+
+            elif local_mask.dim() == 3:
+                local_mask = local_mask[:, None, :, :]
+
+            elif local_mask.dim() == 4:
+                if local_mask.dtype != torch.bool:
+                    local_mask = local_mask.eq(0)
+            else:
+                raise ValueError(
+                    f"Unsupported SDPA attention_mask rank: {local_mask.dim()}"
+                )
+
+            if local_mask.dtype == torch.bool:
+                no_allowed = ~local_mask.any(dim=-1, keepdim=True)
+                local_mask = local_mask | no_allowed
+
+        is_causal_local = local_mask is None and q_len_local == k_len_local
+
+    kwargs = dict(sdpa_kwargs)
+    kwargs.setdefault("attn_mask", local_mask)
+    kwargs.setdefault("is_causal", is_causal_local)
+
+    use_sdpa_gqa = SDPA_HAS_GQA and config.n_groups != 1
+    if (
+        use_sdpa_gqa
+        and (not requires_grad)
+        and isinstance(local_mask, torch.Tensor)
+        and local_mask.dim() >= 3
+        and local_mask.shape[0] > 1
+    ):
+        use_sdpa_gqa = False
+
+    if use_sdpa_gqa:
+        kwargs.setdefault("enable_gqa", True)
+        out = scaled_dot_product_attention(Q, K, V, **kwargs)
+        return out.transpose(1, 2)
+
+    K_mod = K
+    V_mod = V
+    if config.n_groups != 1:
+        K_mod = K[:, :, None, :, :].expand(
+            bsz, config.n_kv_heads, config.n_groups, kv_seq_len, head_dim
+        )
+        V_mod = V[:, :, None, :, :].expand(
+            bsz, config.n_kv_heads, config.n_groups, kv_seq_len, head_dim
+        )
+        K_mod = K_mod.reshape(bsz, n_heads, kv_seq_len, head_dim)
+        V_mod = V_mod.reshape(bsz, n_heads, kv_seq_len, head_dim)
+
+    out = scaled_dot_product_attention(
+        Q.contiguous(),
+        K_mod.contiguous(),
+        V_mod.contiguous(),
+        **kwargs,
+    )
+    return out.transpose(1, 2).contiguous()
+
+
+__all__ = [
+    "AttentionConfig",
+    "AttentionContext",
+    "FLASH_DENSE",
+    "FLASH_VARLEN",
+    "HAS_FLASH_ATTENTION",
+    "HAS_XFORMERS",
+    "SDPA",
+    "XFORMERS",
+    "build_sdpa_packed_attention_mask",
+    "build_xformers_block_causal_mask",
+    "run_attention",
+    "select_attention_backend",
+]

--- a/unturtle/utils/packing.py
+++ b/unturtle/utils/packing.py
@@ -1,0 +1,410 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Vendored from unsloth/utils/packing.py for issue #67.
+
+"""Utilities for enabling packed (padding-free) batches across Unturtle."""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Any, Iterable, Optional, Sequence, Tuple
+
+import torch
+
+try:
+    from xformers.ops.fmha.attn_bias import (
+        BlockDiagonalCausalMask as _XFormersBlockMask,
+    )
+except Exception:
+    try:
+        from xformers.attn_bias import BlockDiagonalCausalMask as _XFormersBlockMask
+    except Exception:
+        _XFormersBlockMask = None
+
+_XFORMERS_MASK_CACHE_MAXSIZE = 32
+_XFORMERS_MASK_CACHE: OrderedDict[Tuple[Tuple[int, ...], int], Any] = OrderedDict()
+
+# Cache per device for get_packed_info_from_kwargs to avoid repeated D2H sync across layers
+_PACKED_INFO_CACHE: dict = {}
+
+# Cache per device for build_sdpa_packed_attention_mask to avoid repeated D2H sync across layers
+_SDPA_MASK_CACHE: dict = {}
+
+# Cache per device for build_xformers_block_causal_mask to avoid repeated D2H sync across layers
+_XFORMERS_BLOCK_MASK_CACHE: dict = {}
+
+
+def _window_cache_key(sliding_window: Optional[int]) -> int:
+    if sliding_window is None or sliding_window <= 0:
+        return 0
+    return int(sliding_window)
+
+
+def _get_cached_block_mask(
+    lengths: Tuple[int, ...],
+    sliding_window: Optional[int],
+):
+    if _XFormersBlockMask is None:
+        return None
+
+    window_key = _window_cache_key(sliding_window)
+    cache_key = (lengths, window_key)
+    cached = _XFORMERS_MASK_CACHE.get(cache_key)
+    if cached is not None:
+        _XFORMERS_MASK_CACHE.move_to_end(cache_key)
+        return cached
+
+    mask = _XFormersBlockMask.from_seqlens(list(lengths))
+    if window_key and mask is not None and hasattr(mask, "make_local_attention"):
+        mask = mask.make_local_attention(window_size=window_key)
+
+    _XFORMERS_MASK_CACHE[cache_key] = mask
+    if len(_XFORMERS_MASK_CACHE) > _XFORMERS_MASK_CACHE_MAXSIZE:
+        _XFORMERS_MASK_CACHE.popitem(last=False)
+    return mask
+
+
+class _TrlPackingWarningFilter(logging.Filter):
+    to_filter = (
+        "attention implementation is not",
+        "kernels-community",
+    )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        return not any(substring in message for substring in self.to_filter)
+
+
+_TRL_FILTER_INSTALLED = False
+
+
+def _ensure_trl_warning_filter():
+    global _TRL_FILTER_INSTALLED
+    if _TRL_FILTER_INSTALLED:
+        return
+    logging.getLogger("trl.trainer.sft_trainer").addFilter(_TrlPackingWarningFilter())
+    _TRL_FILTER_INSTALLED = True
+
+
+def mark_allow_overlength(module):
+    """Mark a module hierarchy so padding-free batches can exceed max_seq_length."""
+    if module is None:
+        return
+    if hasattr(module, "max_seq_length"):
+        module._unsloth_allow_packed_overlength = True
+    children = getattr(module, "children", None)
+    if children is None:
+        return
+    for child in children():
+        mark_allow_overlength(child)
+
+
+def configure_sample_packing(config):
+    """Mutate an ``SFTConfig`` so TRL prepares packed batches."""
+    _ensure_trl_warning_filter()
+    config.packing = True
+    config.padding_free = True
+    config.remove_unused_columns = False
+
+
+def configure_padding_free(config):
+    """Mutate an ``SFTConfig`` so TRL enables padding-free batching without packing."""
+    _ensure_trl_warning_filter()
+    config.padding_free = True
+    config.remove_unused_columns = False
+
+
+def enable_sample_packing(
+    model,
+    trainer,
+    *,
+    sequence_lengths_key: str = "seq_lengths",
+) -> None:
+    """Enable runtime support for packed batches on an existing trainer."""
+    if model is None or trainer is None:
+        raise ValueError("model and trainer must not be None")
+
+    mark_allow_overlength(model)
+
+    if hasattr(trainer, "args") and hasattr(trainer.args, "remove_unused_columns"):
+        trainer.args.remove_unused_columns = False
+
+    collator = getattr(trainer, "data_collator", None)
+    if collator is None or not hasattr(collator, "torch_call"):
+        return
+    if getattr(collator, "_unsloth_packing_wrapped", False):
+        return
+
+    if hasattr(collator, "padding_free"):
+        collator.padding_free = True
+    if hasattr(collator, "return_position_ids"):
+        collator.return_position_ids = True
+
+    original_torch_call = collator.torch_call
+
+    def torch_call_with_lengths(examples: Sequence[dict]):
+        batch = original_torch_call(examples)
+        if examples and isinstance(examples[0], dict):
+            seq_lengths: list[int] = []
+            for example in examples:
+                lengths = example.get(sequence_lengths_key)
+                if isinstance(lengths, Iterable):
+                    seq_lengths.extend(int(length) for length in lengths)
+            if not seq_lengths:
+                for example in examples:
+                    ids = example.get("input_ids")
+                    if isinstance(ids, Iterable):
+                        seq_lengths.append(len(ids))
+            if seq_lengths:
+                batch["packed_seq_lengths"] = torch.tensor(
+                    seq_lengths, dtype=torch.int32
+                )
+                if "attention_mask" in batch:
+                    batch.pop("attention_mask")
+        return batch
+
+    collator.torch_call = torch_call_with_lengths
+    collator._unsloth_packing_wrapped = True
+
+
+def enable_padding_free_metadata(model, trainer):
+    """Inject seq-length metadata when padding-free batching is enabled without packing."""
+    collator = getattr(trainer, "data_collator", None)
+    if (
+        collator is None
+        or getattr(collator, "_unsloth_padding_free_lengths_wrapped", False)
+        or not getattr(collator, "padding_free", False)
+    ):
+        return
+
+    mark_allow_overlength(model)
+    if hasattr(collator, "return_position_ids"):
+        collator.return_position_ids = True
+    if hasattr(trainer, "args") and hasattr(trainer.args, "remove_unused_columns"):
+        trainer.args.remove_unused_columns = False
+
+    original_torch_call = collator.torch_call
+
+    def torch_call_with_padding_free_metadata(examples: Sequence[dict]):
+        seq_lengths: list[int] = []
+        if examples and isinstance(examples[0], dict):
+            for example in examples:
+                lengths = example.get("seq_lengths")
+                if lengths is None:
+                    ids = example.get("input_ids")
+                    if ids is None:
+                        continue
+                    lengths = [len(ids)]
+                    example["seq_lengths"] = lengths
+                seq_lengths.extend(lengths)
+
+        batch = original_torch_call(examples)
+        if seq_lengths:
+            batch["packed_seq_lengths"] = torch.tensor(
+                seq_lengths,
+                dtype=torch.int32,
+            )
+        return batch
+
+    collator.torch_call = torch_call_with_padding_free_metadata
+    collator._unsloth_padding_free_lengths_wrapped = True
+
+
+def get_packed_info_from_kwargs(
+    kwargs: dict,
+    device: torch.device,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor, int]]:
+    """Return packed sequence metadata expected by the attention kernels."""
+
+    seq_lengths = kwargs.get("packed_seq_lengths")
+    if seq_lengths is None:
+        return None
+
+    entry = _PACKED_INFO_CACHE.get(device)
+    if entry is not None and entry["seq_lengths"] is seq_lengths:
+        return entry["result"]
+
+    lengths = seq_lengths.to(device=device, dtype=torch.int32, non_blocking=True)
+    cu_seqlens = torch.zeros(lengths.numel() + 1, dtype=torch.int32, device=device)
+    torch.cumsum(lengths, dim=0, dtype=torch.int32, out=cu_seqlens[1:])
+
+    max_seqlen = int(lengths.max().item())
+    result = (lengths, cu_seqlens, max_seqlen)
+    _PACKED_INFO_CACHE[device] = {"seq_lengths": seq_lengths, "result": result}
+    return result
+
+
+def build_xformers_block_causal_mask(
+    seq_info: Optional[Tuple[torch.Tensor, torch.Tensor, int]],
+    *,
+    sliding_window: Optional[int] = None,
+    base_mask: Optional[Any] = None,
+):
+    if _XFormersBlockMask is None:
+        return None
+    if seq_info is not None:
+        seq_lengths, _, _ = seq_info
+        device = seq_lengths.device
+        params = (sliding_window,)
+        entry = _XFORMERS_BLOCK_MASK_CACHE.get(device)
+        if (
+            entry is not None
+            and entry["seq_lengths"] is seq_lengths
+            and entry["params"] == params
+        ):
+            return entry["mask"]
+
+        lengths_tensor = seq_lengths.to("cpu", torch.int32)
+        if lengths_tensor.numel() == 0:
+            return None
+        lengths = tuple(int(x) for x in lengths_tensor.tolist())
+        mask = _get_cached_block_mask(lengths, sliding_window)
+
+        _XFORMERS_BLOCK_MASK_CACHE[device] = {
+            "seq_lengths": seq_lengths,
+            "params": params,
+            "mask": mask,
+        }
+    else:
+        mask = base_mask
+
+        if (
+            sliding_window is not None
+            and sliding_window > 0
+            and mask is not None
+            and hasattr(mask, "make_local_attention")
+        ):
+            mask = mask.make_local_attention(window_size=sliding_window)
+    return mask
+
+
+def build_sdpa_packed_attention_mask(
+    seq_info: Tuple[torch.Tensor, torch.Tensor, int],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+    sliding_window: Optional[int] = None,
+) -> torch.Tensor:
+    seq_lengths, _, _ = seq_info
+
+    params = (dtype, sliding_window)
+    entry = _SDPA_MASK_CACHE.get(device)
+    if (
+        entry is not None
+        and entry["seq_lengths"] is seq_lengths
+        and entry["params"] == params
+    ):
+        return entry["mask"]
+
+    total_tokens = int(seq_lengths.sum().item())
+    mask = torch.full(
+        (total_tokens, total_tokens),
+        float("-inf"),
+        dtype=dtype,
+        device=device,
+    )
+    offset = 0
+    for length in seq_lengths.tolist():
+        length = int(length)
+        if length <= 0:
+            continue
+        block = torch.zeros((length, length), dtype=dtype, device=device)
+        upper = torch.triu(
+            torch.ones((length, length), device=device), diagonal=1
+        ).bool()
+        block = block.masked_fill(upper, float("-inf"))
+        if (
+            sliding_window is not None
+            and sliding_window > 0
+            and length > sliding_window
+        ):
+            idx = torch.arange(length, device=device)
+            dist = idx.unsqueeze(1) - idx.unsqueeze(0)
+            window_mask = dist >= sliding_window
+            block = block.masked_fill(window_mask, float("-inf"))
+        mask[offset : offset + length, offset : offset + length] = block
+        offset += length
+
+    result = mask.unsqueeze(0).unsqueeze(0)
+    _SDPA_MASK_CACHE[device] = {
+        "seq_lengths": seq_lengths,
+        "params": params,
+        "mask": result,
+    }
+    return result
+
+
+def _normalize_packed_lengths(
+    seq_lengths: Any,
+    *,
+    device: torch.device,
+) -> Optional[torch.Tensor]:
+    if seq_lengths is None:
+        return None
+    if isinstance(seq_lengths, torch.Tensor):
+        lengths = seq_lengths.to(device=device, dtype=torch.int64)
+    else:
+        lengths = torch.tensor(seq_lengths, device=device, dtype=torch.int64)
+    if lengths.ndim != 1:
+        lengths = lengths.reshape(-1)
+    if lengths.numel() == 0:
+        return None
+    return lengths
+
+
+def mask_packed_sequence_boundaries(
+    shift_labels: torch.Tensor,
+    seq_lengths: Any,
+    *,
+    ignore_index: int = -100,
+) -> bool:
+    """Mark final token of every packed sample so CE ignores boundary predictions."""
+    lengths = _normalize_packed_lengths(seq_lengths, device=shift_labels.device)
+    if lengths is None:
+        return False
+
+    flat = shift_labels.reshape(-1)
+    total_tokens = flat.shape[0]
+    boundary_positions = torch.cumsum(lengths, dim=0) - 1
+    valid = boundary_positions < total_tokens
+    if not torch.all(valid):
+        boundary_positions = boundary_positions[valid]
+    if boundary_positions.numel() == 0:
+        return False
+    flat[boundary_positions] = ignore_index
+    return True
+
+
+def clear_packed_caches():
+    """Release cached masks/metadata to free device memory."""
+    _PACKED_INFO_CACHE.clear()
+    _SDPA_MASK_CACHE.clear()
+    _XFORMERS_BLOCK_MASK_CACHE.clear()
+
+
+__all__ = [
+    "configure_sample_packing",
+    "configure_padding_free",
+    "enable_sample_packing",
+    "enable_padding_free_metadata",
+    "mark_allow_overlength",
+    "get_packed_info_from_kwargs",
+    "build_xformers_block_causal_mask",
+    "build_sdpa_packed_attention_mask",
+    "mask_packed_sequence_boundaries",
+    "clear_packed_caches",
+]


### PR DESCRIPTION
Closes #3

## 概要
クリーン移植 Task 2。他モジュールの依存先（葉）である kernels / utils を移植。

- `unturtle/kernels/`（fast_lora / masked_diffusion_loss / fused_masked_diffusion_loss）と `unturtle/utils/`（attention_dispatch / packing）を legacy からバイト一致で移植（diff -r で検証済み）
- tests/utils 14件、新スタック（unsloth 2026.6.2 / transformers 5.5.0 / torch 2.11+cu128）で **slow 含め全 PASS、本体修正ゼロ**
- unsloth_zoo 2026.6.2 に同等物なし（grep で確認）→ vendored 維持、NOTICE 変更なし
- legacy の tests/utils に紛れていた未参照 markdown 3件（aime/ocr/perplexity_eval.md）は持ち込まない

## テスト
- `pytest tests/utils/ -v` → 14 passed（slow 含む）
- ruff check / format --check グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)