### PR TITLE
✨ feat(generation): port shared cache / block-decode / sampler registry (#5)

### DIFF
--- a/tests/models/test_cache.py
+++ b/tests/models/test_cache.py
@@ -1,0 +1,153 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from unturtle.models.generation.cache import BlockKVCache
+
+
+class TestBlockKVCache:
+    """Test BlockKVCache abstraction."""
+
+    def test_init(self):
+        """Test cache initialization."""
+        cache = BlockKVCache(block_size=32, num_layers=12)
+        assert cache.block_size == 32
+        assert cache.num_layers == 12
+        assert len(cache.key_cache) == 12
+        assert len(cache.value_cache) == 12
+        assert cache.seen_tokens == 0
+        assert cache.current_block == 0
+
+    def test_update_first_layer(self):
+        """Test updating cache for first layer."""
+        cache = BlockKVCache(block_size=32, num_layers=2)
+        batch_size, num_heads, seq_len, head_dim = 2, 8, 16, 64
+
+        key = torch.randn(batch_size, num_heads, seq_len, head_dim)
+        value = torch.randn(batch_size, num_heads, seq_len, head_dim)
+
+        updated_key, updated_value = cache.update(key, value, layer_idx=0)
+
+        assert updated_key.shape == (batch_size, num_heads, seq_len, head_dim)
+        assert updated_value.shape == (batch_size, num_heads, seq_len, head_dim)
+        assert cache.seen_tokens == seq_len
+        assert cache.get_seq_length(0) == seq_len
+
+    def test_update_concatenates_past(self):
+        """Test that update concatenates with past cache."""
+        cache = BlockKVCache(block_size=32, num_layers=2)
+        batch_size, num_heads, head_dim = 2, 8, 64
+
+        # First update
+        key1 = torch.randn(batch_size, num_heads, 16, head_dim)
+        value1 = torch.randn(batch_size, num_heads, 16, head_dim)
+        cache.update(key1, value1, layer_idx=0)
+
+        # Second update
+        key2 = torch.randn(batch_size, num_heads, 16, head_dim)
+        value2 = torch.randn(batch_size, num_heads, 16, head_dim)
+        updated_key, updated_value = cache.update(key2, value2, layer_idx=0)
+
+        assert updated_key.shape == (batch_size, num_heads, 32, head_dim)
+        assert updated_value.shape == (batch_size, num_heads, 32, head_dim)
+        assert cache.seen_tokens == 32
+        assert cache.get_seq_length(0) == 32
+
+    def test_update_multiple_layers(self):
+        """Test updating multiple layers independently."""
+        cache = BlockKVCache(block_size=32, num_layers=3)
+        batch_size, num_heads, seq_len, head_dim = 2, 8, 16, 64
+
+        for layer_idx in range(3):
+            key = torch.randn(batch_size, num_heads, seq_len, head_dim)
+            value = torch.randn(batch_size, num_heads, seq_len, head_dim)
+            cache.update(key, value, layer_idx=layer_idx)
+
+        # Only first layer should update seen_tokens
+        assert cache.seen_tokens == seq_len
+
+        # All layers should have cached states
+        for layer_idx in range(3):
+            assert cache.get_seq_length(layer_idx) == seq_len
+
+    def test_reset(self):
+        """Test cache reset."""
+        cache = BlockKVCache(block_size=32, num_layers=2)
+        batch_size, num_heads, seq_len, head_dim = 2, 8, 16, 64
+
+        key = torch.randn(batch_size, num_heads, seq_len, head_dim)
+        value = torch.randn(batch_size, num_heads, seq_len, head_dim)
+        cache.update(key, value, layer_idx=0)
+
+        assert cache.seen_tokens > 0
+        cache.reset()
+
+        assert cache.seen_tokens == 0
+        assert cache.current_block == 0
+        assert cache.get_seq_length(0) == 0
+
+    def test_reset_block(self):
+        """Test resetting cache to a specific block."""
+        cache = BlockKVCache(block_size=16, num_layers=2)
+        batch_size, num_heads, head_dim = 2, 8, 64
+
+        # Fill cache with 48 tokens (3 blocks)
+        for _ in range(3):
+            key = torch.randn(batch_size, num_heads, 16, head_dim)
+            value = torch.randn(batch_size, num_heads, 16, head_dim)
+            cache.update(key, value, layer_idx=0)
+
+        assert cache.get_seq_length(0) == 48
+
+        # Reset to block 1 (keep first 16 tokens)
+        cache.reset_block(1)
+        assert cache.get_seq_length(0) == 16
+        assert cache.seen_tokens == 16
+        assert cache.current_block == 1
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_to_device(self):
+        """Test moving cache to CUDA."""
+        cache = BlockKVCache(block_size=32, num_layers=2)
+        batch_size, num_heads, seq_len, head_dim = 2, 8, 16, 64
+
+        key = torch.randn(batch_size, num_heads, seq_len, head_dim)
+        value = torch.randn(batch_size, num_heads, seq_len, head_dim)
+        cache.update(key, value, layer_idx=0)
+
+        cache.to(torch.device("cuda"))
+        assert cache.device.type == "cuda"
+        assert cache.key_cache[0].device.type == "cuda"
+        assert cache.value_cache[0].device.type == "cuda"
+
+    def test_lazy_layer_extension(self):
+        """Test that cache extends lazily when accessing new layers."""
+        cache = BlockKVCache(block_size=32)  # num_layers=None
+        assert len(cache.key_cache) == 0
+
+        batch_size, num_heads, seq_len, head_dim = 2, 8, 16, 64
+        key = torch.randn(batch_size, num_heads, seq_len, head_dim)
+        value = torch.randn(batch_size, num_heads, seq_len, head_dim)
+
+        # Update layer 5 (should extend to 6 layers)
+        cache.update(key, value, layer_idx=5)
+        assert len(cache.key_cache) == 6
+        assert cache.get_seq_length(5) == seq_len
+
+    def test_get_max_length(self):
+        """Test that max_length returns None (unlimited)."""
+        cache = BlockKVCache(block_size=32, num_layers=2)
+        assert cache.get_max_length() is None

--- a/tests/models/test_sampler.py
+++ b/tests/models/test_sampler.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from unturtle.models.generation.sampler import (
+    DISCRETE_ALGORITHMS,
+    algorithm_to_flags,
+    resolve_algorithm,
+)
+
+
+class _CacheCapable:
+    """Stub model that supports block-decode (implements _model_forward_with_cache)."""
+
+    def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
+
+class _NoCache:
+    """Stub model without block-decode capability."""
+
+
+def test_known_algorithms_present() -> None:
+    assert set(DISCRETE_ALGORITHMS) == {"mdlm", "block_decode", "bd3lm"}
+
+
+def test_algorithm_to_flags_mdlm() -> None:
+    assert algorithm_to_flags("mdlm") == {
+        "use_cache": False,
+        "use_block_diffusion": False,
+    }
+
+
+def test_algorithm_to_flags_block_decode() -> None:
+    flags = algorithm_to_flags("block_decode")
+    assert flags["use_cache"] is True
+    assert flags["use_block_diffusion"] is False
+
+
+def test_algorithm_to_flags_bd3lm() -> None:
+    flags = algorithm_to_flags("bd3lm")
+    assert flags["use_block_diffusion"] is True
+    assert flags["use_cache"] is False
+
+
+def test_algorithm_to_flags_unknown_raises() -> None:
+    with pytest.raises(ValueError) as exc:
+        algorithm_to_flags("continuous_ddpm")
+    assert "continuous_ddpm" in str(exc.value)
+    assert "mdlm" in str(exc.value)
+
+
+def test_resolve_auto_picks_block_decode_when_capable() -> None:
+    assert (
+        resolve_algorithm("auto", _CacheCapable(), bd3lm_requested=False)
+        == "block_decode"
+    )
+
+
+def test_resolve_auto_picks_bd3lm_when_requested() -> None:
+    assert resolve_algorithm("auto", _CacheCapable(), bd3lm_requested=True) == "bd3lm"
+
+
+def test_resolve_auto_falls_back_to_mdlm_without_cache_capability() -> None:
+    assert resolve_algorithm("auto", _NoCache(), bd3lm_requested=False) == "mdlm"
+
+
+def test_resolve_explicit_passthrough() -> None:
+    assert resolve_algorithm("mdlm", _CacheCapable(), bd3lm_requested=False) == "mdlm"
+
+
+def test_resolve_unknown_raises() -> None:
+    with pytest.raises(ValueError):
+        resolve_algorithm("nope", _CacheCapable(), bd3lm_requested=False)

--- a/unturtle/models/__init__.py
+++ b/unturtle/models/__init__.py
@@ -1,0 +1,53 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle.models — Diffusion Language Model architectures.
+
+Public API (generation infrastructure — available now)::
+
+    from unturtle.models.generation.cache import BlockKVCache
+    from unturtle.models.generation.diffusion_generation_utils import (
+        MaskedDiffusionGenerationConfig,
+        MaskedDiffusionGenerationMixin,
+        MaskedDiffusionModelOutput,
+        prepare_for_sampling,
+    )
+
+Backbones and conversion methods will be exported here once Task 4 / Task 5 land:
+
+    from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
+    from unturtle.models.backbones.dream import DreamConfig, DreamModel
+    from unturtle.models.conversion.a2d import (
+        TinyA2DLlamaConfig, TinyA2DLlamaLMHeadModel,
+        TinyA2DQwen2Config, TinyA2DQwen2LMHeadModel,
+        TinyA2DQwen3Config, TinyA2DQwen3LMHeadModel,
+    )
+"""
+
+from .generation.cache import BlockKVCache
+from .generation.diffusion_generation_utils import (
+    MaskedDiffusionGenerationConfig,
+    MaskedDiffusionGenerationMixin,
+    MaskedDiffusionModelOutput,
+    prepare_for_sampling,
+)
+
+__all__ = [
+    "BlockKVCache",
+    "MaskedDiffusionGenerationConfig",
+    "MaskedDiffusionGenerationMixin",
+    "MaskedDiffusionModelOutput",
+    "prepare_for_sampling",
+    # Backbones (Task 4) and conversion (Task 5) exports will be added here.
+]

--- a/unturtle/models/generation/__init__.py
+++ b/unturtle/models/generation/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle.models.generation — shared inference infrastructure.
+
+Neither a backbone nor a conversion method: cache, block-decode, and the masked-diffusion
+generation mixin used by all dLLM model families.
+"""

--- a/unturtle/models/generation/block_decode_mixin.py
+++ b/unturtle/models/generation/block_decode_mixin.py
@@ -1,0 +1,430 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Block-decode generation mixin for dLLM models.
+# Algorithm structure ported from Fast-dLLM: dev/repos/fast-dllm/dream/model/generation_utils_block.py
+
+"""Block-decode generation mixin for dLLM models.
+
+Provides shared block-decode algorithm that can be used by LLaDA, Dream, and other dLLM models.
+Subclasses implement model-specific forward wrappers while inheriting common block-decode logic.
+"""
+
+import math
+import time
+from typing import Any, Dict, Optional, Tuple, Union, cast
+
+import torch
+from torch.nn import functional as F
+
+from .diffusion_generation_utils import sample_tokens, select_threshold_transfer_mask
+
+
+class BlockDecodeMixin:
+    """Mixin providing block-decode generation for dLLM models.
+
+    This mixin implements Fast-dLLM's block-decode algorithm:
+    1. Divide generation into blocks of block_length tokens
+    2. For each block:
+       a. Initial forward: full sequence → build KV cache
+       b. Cache handling: trim to previous blocks OR mark current block for replacement
+       c. Denoising loop: iteratively refine current block with cached context
+       d. Token sampling: unmask tokens based on timestep schedule
+
+    Subclasses must implement:
+    - _model_forward_with_cache(): Model-specific forward call with cache handling
+    """
+
+    def _block_decode_loop(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        generation_config,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, Any]]]:
+        """Common block-decode loop logic (Fast-dLLM style).
+
+        Args:
+            input_ids: Input token IDs [batch, prompt_len]
+            attention_mask: Attention mask [batch, prompt_len] or None
+            generation_config: MaskedDiffusionGenerationConfig with:
+                - max_length: Total sequence length (prompt + generation)
+                - block_length: Tokens per block (default: gen_length)
+                - steps: Total denoising steps
+                - mask_token_id: Token ID for [MASK]
+                - use_replace_cache: If True, use replace_position mode (default: False)
+                - alg: Algorithm ('origin' only in Phase M.1)
+                - temperature, top_p, top_k: Sampling parameters
+
+        Returns:
+            Generated sequence [batch, max_length]
+
+        Raises:
+            ValueError: If gen_length % block_length != 0
+            NotImplementedError: If alg != 'origin' (Phase M.1 limitation)
+        """
+        # Extract config (Fast-dLLM Dream style: use max_length, compute gen_length)
+        max_length = generation_config.max_length
+        block_length = getattr(generation_config, "block_length", None)
+        steps = generation_config.steps
+        mask_token_id = generation_config.mask_token_id
+        use_replace_cache = getattr(generation_config, "use_replace_cache", False)
+        alg = generation_config.alg
+        temperature = getattr(generation_config, "temperature", 1.0)
+        top_p = getattr(generation_config, "top_p", None)
+        top_k = getattr(generation_config, "top_k", None)
+        eps = getattr(generation_config, "eps", 0.001)
+
+        output_timing = getattr(generation_config, "output_timing", False)
+        timing: Optional[Dict[str, Any]] = None
+
+        def _time_start() -> Optional[float]:
+            if not output_timing:
+                return None
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
+            return time.perf_counter()
+
+        def _time_end(start: Optional[float], key: str) -> None:
+            if start is None or timing is None:
+                return
+            if device.type == "cuda":
+                torch.cuda.synchronize(device)
+            timing[key] += time.perf_counter() - start
+
+        # Setup (Fast-dLLM line 413: gen_length = max_length - input_ids.shape[1])
+        device = input_ids.device
+        _, prompt_len = input_ids.shape
+        gen_length = max_length - prompt_len
+
+        # Pad input_ids with [MASK] tokens (Fast-dLLM line 412)
+        x = F.pad(input_ids, (0, gen_length), value=mask_token_id)
+
+        # Extend attention_mask if provided
+        if attention_mask is not None and attention_mask.ndim == 2:
+            attention_mask = F.pad(attention_mask, (0, gen_length), value=1)
+
+        # Default block_length: single block (original behavior)
+        if block_length is None:
+            block_length = gen_length
+
+        # Validate divisibility
+        if gen_length % block_length != 0:
+            raise ValueError(
+                f"gen_length ({gen_length}) must be divisible by block_length ({block_length}). "
+                f"Use block_length that evenly divides max_new_tokens."
+            )
+
+        num_blocks = gen_length // block_length
+        if steps < num_blocks:
+            raise ValueError(f"steps ({steps}) must be >= num_blocks ({num_blocks}).")
+        if steps % num_blocks != 0:
+            raise ValueError(
+                f"steps ({steps}) must be divisible by num_blocks ({num_blocks}) for block decode."
+            )
+        steps_per_block = steps // num_blocks
+
+        if output_timing:
+            timing = {
+                "total_block_decode_s": 0.0,
+                "initial_cache_build_s": 0.0,
+                "cache_prep_s": 0.0,
+                "denoise_forward_s": 0.0,
+                "logits_slice_s": 0.0,
+                "sampling_s": 0.0,
+                "threshold_transfer_s": 0.0,
+                "num_blocks": num_blocks,
+                "steps_per_block": steps_per_block,
+                "num_block_iterations": 0,
+                "total_masked_tokens": 0,
+                "parallel_decode": bool(generation_config.parallel_decode),
+                "use_replace_cache": bool(use_replace_cache),
+                "alg": alg,
+            }
+
+        # Timestep schedule (uniform per block)
+        timesteps = torch.linspace(1.0, eps, steps_per_block + 1, device=device)
+
+        total_start = _time_start()
+
+        # Block-decode loop
+        for block_idx in range(num_blocks):
+            current_block_start = prompt_len + block_idx * block_length
+            current_block_end = current_block_start + block_length
+
+            # Step 1: Initial forward (full sequence) to build cache
+            initial_cache_start = _time_start()
+            outputs = self._model_forward_with_cache(
+                input_ids=x,
+                attention_mask=attention_mask,
+                past_key_values=None,
+                use_cache=True,
+                replace_position=None,
+            )
+            _time_end(initial_cache_start, "initial_cache_build_s")
+            past_key_values = outputs.past_key_values
+
+            # Step 2: Prepare cache for denoising
+            cache_prep_start = _time_start()
+            if use_replace_cache:
+                # Dual cache mode: keep full cache, will use replace_position later
+                cache_for_denoise = past_key_values
+            else:
+                # Trim mode: keep only previous blocks
+                from .cache_utils import trim_kv_cache
+
+                cache_for_denoise = trim_kv_cache(past_key_values, current_block_start)
+            _time_end(cache_prep_start, "cache_prep_s")
+
+            # Step 3: Denoising loop for current block
+            # Fast-dLLM threshold mode runs until the block is fully denoised.
+            # We keep a hard safety cap of block_length iterations because the
+            # threshold selector guarantees at least one newly unmasked token
+            # per row per iteration.
+            step_idx = 0
+            max_block_iterations = (
+                block_length if generation_config.parallel_decode else steps_per_block
+            )
+            while step_idx < max_block_iterations:
+                # Check if block is fully denoised
+                mask_index_block = (
+                    x[:, current_block_start:current_block_end] == mask_token_id
+                )
+                n_masked = mask_index_block.sum().item()
+
+                if n_masked == 0:
+                    break  # Block complete, move to next
+
+                if timing is not None:
+                    timing["num_block_iterations"] += 1
+                    timing["total_masked_tokens"] += n_masked
+
+                # Prepare input for forward pass
+                if use_replace_cache:
+                    # Dual mode: forward the current block while replacing the
+                    # corresponding absolute positions in the full cache.
+                    query_start = self._get_block_decode_query_start(
+                        current_block_start=current_block_start,
+                        current_block_end=current_block_end,
+                        use_replace_cache=use_replace_cache,
+                    )
+                    x_forward = x[:, query_start:current_block_end]
+                    if attention_mask is not None and attention_mask.ndim >= 3:
+                        attn_forward = attention_mask[
+                            :, :, query_start:current_block_end, :
+                        ]
+                    else:
+                        attn_forward = attention_mask
+
+                    # Mark current block positions for replacement
+                    replace_position = torch.zeros_like(x, dtype=torch.bool)
+                    replace_position[:, current_block_start:current_block_end] = True
+                else:
+                    # Trim mode: forward from current_block_start onwards
+                    x_forward = x[:, current_block_start:]
+                    if attention_mask is not None and attention_mask.ndim >= 3:
+                        attn_forward = attention_mask[:, :, current_block_start:, :]
+                    else:
+                        attn_forward = (
+                            attention_mask[:, current_block_start:]
+                            if attention_mask is not None
+                            else None
+                        )
+                    replace_position = None
+
+                # Forward pass with cache
+                denoise_forward_start = _time_start()
+                outputs = self._model_forward_with_cache(
+                    input_ids=x_forward,
+                    attention_mask=attn_forward,
+                    past_key_values=cache_for_denoise,
+                    use_cache=True,
+                    replace_position=replace_position,
+                )
+                _time_end(denoise_forward_start, "denoise_forward_s")
+
+                logits_slice_start = _time_start()
+                logits = cast(Any, self)._postprocess_block_decode_logits(
+                    outputs.logits
+                )
+
+                # Extract logits for current block
+                if use_replace_cache:
+                    # Dual-cache forwards may return only the current block logits,
+                    # or a block-local window with one-token left context.
+                    if logits.shape[1] <= current_block_end:
+                        block_logits = logits[:, -block_length:, :]
+                    else:
+                        block_logits = logits[
+                            :, current_block_start:current_block_end, :
+                        ]
+                else:
+                    # Incremental forward: first block_length tokens are current block
+                    block_logits = logits[:, :block_length, :]
+
+                # Get masked positions' logits
+                mask_logits = block_logits[mask_index_block]  # [N_masked, vocab_size]
+                if (
+                    generation_config.parallel_decode
+                    and 0 <= mask_token_id < mask_logits.shape[-1]
+                ):
+                    mask_logits = mask_logits.clone()
+                    mask_logits[:, mask_token_id] = torch.finfo(mask_logits.dtype).min
+                _time_end(logits_slice_start, "logits_slice_s")
+
+                # Sample tokens with confidence
+                sampling_start = _time_start()
+                if generation_config.parallel_decode:
+                    if alg == "maskgit_plus":
+                        sampled_confidence, sampled = sample_tokens(
+                            mask_logits,
+                            temperature=temperature,
+                            top_p=top_p,
+                            top_k=top_k,
+                            confidence_type="max_prob",
+                        )
+                    elif alg == "topk_margin":
+                        sampled_confidence, sampled = sample_tokens(
+                            mask_logits,
+                            temperature=temperature,
+                            top_p=top_p,
+                            top_k=top_k,
+                            confidence_type="margin",
+                        )
+                    elif alg == "entropy":
+                        sampled_confidence, sampled = sample_tokens(
+                            mask_logits,
+                            temperature=temperature,
+                            top_p=top_p,
+                            top_k=top_k,
+                            confidence_type="neg_entropy",
+                        )
+                    else:
+                        raise RuntimeError(
+                            f"Unknown alg: {alg!r}. Choose from 'origin', 'maskgit_plus', 'topk_margin', 'entropy'."
+                        )
+                else:
+                    sampled_confidence, sampled = sample_tokens(
+                        mask_logits,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        confidence_type="max_prob",
+                    )
+                _time_end(sampling_start, "sampling_s")
+
+                transfer_start = _time_start()
+                if generation_config.parallel_decode:
+                    current_block = x[:, current_block_start:current_block_end]
+                    masked_confidence = torch.zeros(
+                        current_block.shape,
+                        dtype=logits.dtype,
+                        device=current_block.device,
+                    )
+                    masked_confidence[mask_index_block] = sampled_confidence
+
+                    transfer_index = select_threshold_transfer_mask(
+                        masked_confidence=masked_confidence,
+                        mask_index_block=mask_index_block,
+                        threshold=generation_config.confidence_threshold,
+                    )
+
+                    selected_mask = mask_index_block & transfer_index
+                    if selected_mask.any():
+                        current_block[selected_mask] = sampled[
+                            selected_mask[mask_index_block]
+                        ]
+                else:
+                    # Phase M.1: Sequential decoding (origin algorithm)
+                    # Timestep transition
+                    t = timesteps[step_idx]
+                    s = timesteps[step_idx + 1]
+
+                    # p_transfer: probability of unmasking at this step
+                    p_transfer = 1.0 - s / t if step_idx < steps_per_block - 1 else 1.0
+
+                    # Apply transfer probability (unmask some tokens)
+                    transfer_mask = (
+                        torch.rand(sampled.shape, device=device) < p_transfer
+                    )
+
+                    # Build updated block
+                    x0_block = x[:, current_block_start:current_block_end].clone()
+                    x0_flat = x0_block[mask_index_block]  # Masked positions only
+                    x0_flat[transfer_mask] = sampled[
+                        transfer_mask
+                    ]  # Unmask transferred tokens
+                    x0_block[mask_index_block] = x0_flat
+
+                    # Update sequence
+                    x[:, current_block_start:current_block_end] = x0_block
+
+                _time_end(transfer_start, "threshold_transfer_s")
+                step_idx += 1
+
+                # Note: Cache is NOT updated during denoising loop
+                # (Fast-dLLM: cache stays constant within block)
+
+        _time_end(total_start, "total_block_decode_s")
+        if timing is not None:
+            return x, timing
+        return x
+
+    def _get_block_decode_query_start(
+        self,
+        current_block_start: int,
+        current_block_end: int,
+        use_replace_cache: bool,
+    ) -> int:
+        """Model-specific query start for block-decode forwards."""
+        return current_block_start
+
+    def _postprocess_block_decode_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """Model-specific logit postprocessing before block slicing."""
+        return logits
+
+    def _model_forward_with_cache(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Any],
+        use_cache: bool,
+        replace_position: Optional[torch.Tensor] = None,
+    ):
+        """Model-specific forward with cache.
+
+        Subclasses must implement this to handle:
+        - Model-specific forward signature
+        - Cache format conversion (if needed)
+        - replace_position handling (if supported)
+
+        Args:
+            input_ids: Token IDs [batch, seq_len]
+            attention_mask: Attention mask [batch, seq_len] or None
+            past_key_values: KV cache (model-specific format)
+            use_cache: Whether to return cache
+            replace_position: Bool tensor [batch, seq_len] for dual-cache mode (optional)
+
+        Returns:
+            Model output with .past_key_values and .logits attributes
+
+        Raises:
+            NotImplementedError: If subclass doesn't implement this method
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement _model_forward_with_cache(). "
+            f"This method should call self.model() or self() with appropriate cache handling."
+        )
+
+
+__all__ = ["BlockDecodeMixin"]

--- a/unturtle/models/generation/cache.py
+++ b/unturtle/models/generation/cache.py
@@ -1,0 +1,216 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Block-wise KV-cache abstraction for dLLM inference.
+# Duck-type compatible with transformers Cache API (update/get_seq_length/get_max_length)
+# but does NOT inherit from transformers.Cache (intentional — incompatible lifecycle).
+
+"""Block-wise KV-cache for diffusion language model inference.
+
+This module provides :class:`BlockKVCache` which stores key-value activations
+in block-wise chunks to enable efficient reuse during iterative denoising.
+
+Usage::
+
+    from unturtle.models.generation.cache import BlockKVCache
+
+    cache = BlockKVCache(block_size=32, num_layers=24)
+
+    # During generation
+    for block_idx in range(num_blocks):
+        outputs = model(
+            input_ids=block_tokens,
+            past_key_values=cache,
+            use_cache=True,
+        )
+        cache = outputs.past_key_values
+"""
+
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+
+
+class BlockKVCache:
+    """Block-wise KV-cache for diffusion LM inference.
+
+    Stores key-value activations in blocks to support future cache reuse optimization.
+
+    .. warning::
+       Phase L (baseline): Cache is reset after each denoising step. No performance
+       improvement expected until Phase M implements confidence-aware parallel decoding
+       with true block-wise reuse.
+
+    Attributes:
+        block_size (int): Number of tokens per cache block.
+        num_layers (int): Number of transformer layers.
+        key_cache (List[torch.Tensor]): Cached key states per layer.
+        value_cache (List[torch.Tensor]): Cached value states per layer.
+        seen_tokens (int): Total number of tokens processed.
+        current_block (int): Index of the currently active block.
+
+    Args:
+        block_size (int): Tokens per block (e.g., 32).
+        num_layers (int, optional): Number of layers. If None, layers are added lazily.
+        dtype (torch.dtype, optional): Data type for cache tensors. Defaults to float32.
+        device (torch.device, optional): Device for cache tensors. Defaults to CPU.
+
+    Example::
+
+        cache = BlockKVCache(block_size=32, num_layers=24)
+
+        # In model forward
+        outputs = model(
+            input_ids[:, block_start:block_end],
+            past_key_values=cache,
+            use_cache=True,
+        )
+        cache = outputs.past_key_values  # Updated cache
+    """
+
+    def __init__(
+        self,
+        block_size: int = 32,
+        num_layers: Optional[int] = None,
+        dtype: torch.dtype = torch.float32,
+        device: Optional[torch.device] = None,
+    ):
+        self.block_size = block_size
+        self.num_layers = num_layers
+        self.dtype = dtype
+        self.device = device if device is not None else torch.device("cpu")
+
+        # Initialize cache storage
+        self.key_cache: List[Optional[torch.Tensor]] = [None] * (num_layers or 0)
+        self.value_cache: List[Optional[torch.Tensor]] = [None] * (num_layers or 0)
+
+        self.seen_tokens = 0
+        self.current_block = 0
+
+    def __repr__(self):
+        return (
+            f"BlockKVCache(block_size={self.block_size}, "
+            f"num_layers={len(self.key_cache)}, "
+            f"seen_tokens={self.seen_tokens}, "
+            f"current_block={self.current_block})"
+        )
+
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+        cache_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Update cache with new key/value states for a layer.
+
+        Args:
+            key_states: New key tensor of shape [batch, num_heads, seq_len, head_dim].
+            value_states: New value tensor of shape [batch, num_heads, seq_len, head_dim].
+            layer_idx: Index of the transformer layer (0-indexed).
+            cache_kwargs: Optional cache-specific arguments (e.g., 'block_idx').
+
+        Returns:
+            Tuple of (updated_keys, updated_values) including past cached states.
+        """
+        # Lazily extend cache if needed
+        if layer_idx >= len(self.key_cache):
+            self._extend_to_layer(layer_idx)
+
+        # For first layer, update token count
+        if layer_idx == 0:
+            self.seen_tokens += key_states.shape[2]
+
+        # Concatenate with past cache if exists
+        cached_key = self.key_cache[layer_idx]
+        cached_value = self.value_cache[layer_idx]
+        if cached_key is not None and cached_value is not None:
+            key_states = torch.cat([cached_key, key_states], dim=2)
+            value_states = torch.cat([cached_value, value_states], dim=2)
+
+        # Store updated cache
+        self.key_cache[layer_idx] = key_states
+        self.value_cache[layer_idx] = value_states
+
+        return key_states, value_states
+
+    def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
+        """Return the sequence length of cached states.
+
+        Args:
+            layer_idx: Layer index to query. Defaults to 0.
+
+        Returns:
+            Sequence length of the cached key/value states.
+        """
+        if layer_idx is None:
+            layer_idx = 0
+        if layer_idx >= len(self.key_cache):
+            return 0
+        cached = self.key_cache[layer_idx]
+        if cached is None:
+            return 0
+        return cached.shape[2]
+
+    def get_max_length(self) -> Optional[int]:
+        """Return the maximum cache capacity (None = unlimited)."""
+        return None
+
+    def reset(self):
+        """Clear all cached states."""
+        self.key_cache = [None] * len(self.key_cache)
+        self.value_cache = [None] * len(self.value_cache)
+        self.seen_tokens = 0
+        self.current_block = 0
+
+    def reset_block(self, block_idx: int):
+        """Reset cache to a specific block (for block-decode restart).
+
+        Args:
+            block_idx: Target block index. Cache will retain states up to
+                       block_idx * block_size tokens.
+        """
+        target_len = block_idx * self.block_size
+        for layer_idx in range(len(self.key_cache)):
+            cached_key = self.key_cache[layer_idx]
+            cached_value = self.value_cache[layer_idx]
+            if cached_key is not None and cached_value is not None:
+                self.key_cache[layer_idx] = cached_key[:, :, :target_len, :]
+                self.value_cache[layer_idx] = cached_value[:, :, :target_len, :]
+        self.seen_tokens = target_len
+        self.current_block = block_idx
+
+    def _extend_to_layer(self, layer_idx: int):
+        """Extend cache lists to accommodate layer_idx."""
+        while len(self.key_cache) <= layer_idx:
+            self.key_cache.append(None)
+            self.value_cache.append(None)
+
+    def to(self, device: torch.device) -> "BlockKVCache":
+        """Move all cached tensors to a device.
+
+        Args:
+            device: Target device (e.g., torch.device("cuda")).
+
+        Returns:
+            Self (for method chaining).
+        """
+        self.device = device
+        for layer_idx in range(len(self.key_cache)):
+            cached_key = self.key_cache[layer_idx]
+            cached_value = self.value_cache[layer_idx]
+            if cached_key is not None and cached_value is not None:
+                self.key_cache[layer_idx] = cached_key.to(device)
+                self.value_cache[layer_idx] = cached_value.to(device)
+        return self

--- a/unturtle/models/generation/cache_utils.py
+++ b/unturtle/models/generation/cache_utils.py
@@ -1,0 +1,267 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Block-decode KV cache utilities for dLLM models.
+# Ported from Fast-dLLM (NVIDIA): dev/repos/fast-dllm/llada/model/modeling_llada.py
+
+"""Block-decode KV cache utilities for dLLM models.
+
+This module provides utilities for managing KV cache in block-decode generation:
+- Cache trimming: Keep only first N tokens (prefix cache mode)
+- Cache replacement: Selectively update positions (dual cache mode, Fast-dLLM style)
+- Format conversion: Tuple ↔ DynamicCache (transformers compatibility)
+"""
+
+from typing import Any, Optional, Tuple
+
+import torch
+from transformers.cache_utils import Cache, DynamicCache
+
+
+def trim_kv_cache(
+    past_key_values: Any,
+    target_length: int,
+) -> Tuple[Tuple[torch.Tensor, ...], ...]:
+    """Trim KV cache to retain only the first target_length tokens.
+
+    This follows Fast-dLLM's prefix cache approach: after full-sequence forward,
+    trim cache to previous blocks only, then forward current block with trimmed cache.
+
+    Args:
+        past_key_values: Either DynamicCache or tuple of (key, value) tuples per layer.
+            Shape per tensor: [batch, num_heads, seq_len, head_dim]
+        target_length: Number of tokens to retain in cache.
+
+    Returns:
+        Trimmed past_key_values as tuple format with seq_len = target_length.
+
+    Raises:
+        ValueError: If target_length is invalid.
+        TypeError: If cache format is unexpected.
+
+    Example:
+        >>> cache = model(x, use_cache=True).past_key_values  # Full sequence
+        >>> trimmed = trim_kv_cache(cache, prompt_len + block_idx * block_len)
+        >>> # Now forward from current block with trimmed cache
+    """
+    if target_length < 0:
+        raise ValueError(f"target_length must be non-negative, got {target_length}")
+
+    if target_length == 0:
+        raise ValueError("target_length=0 would result in empty cache")
+
+    # Convert DynamicCache to tuple format if needed
+    if not isinstance(past_key_values, tuple):
+        if not hasattr(past_key_values, "layers"):
+            raise TypeError(
+                f"Expected cache object to have '.layers' attribute, but got {type(past_key_values).__name__}. "
+                f"Supported cache types: DynamicCache (transformers) or raw tuple format."
+            )
+
+        new_past_key_values = []
+        try:
+            for layer in past_key_values.layers:
+                key_trimmed = layer.keys[:, :, :target_length, :]
+                value_trimmed = layer.values[:, :, :target_length, :]
+                new_past_key_values.append((key_trimmed, value_trimmed))
+        except AttributeError as e:
+            raise RuntimeError(
+                f"Failed to access cache layer attributes. Cache type: {type(past_key_values).__name__}. "
+                f"Expected 'keys' and 'values' attributes on each layer. Original error: {e}"
+            ) from e
+
+        return tuple(new_past_key_values)
+    else:
+        # Already tuple format
+        if len(past_key_values) == 0:
+            raise ValueError("Received empty tuple cache")
+
+        new_past_key_values = []
+        for layer_idx in range(len(past_key_values)):
+            layer_cache = past_key_values[layer_idx]
+
+            if not isinstance(layer_cache, tuple) or len(layer_cache) != 2:
+                raise TypeError(
+                    f"Layer {layer_idx}: expected tuple of (key, value), "
+                    f"got {type(layer_cache).__name__} with length {len(layer_cache) if hasattr(layer_cache, '__len__') else 'N/A'}"
+                )
+
+            key, value = layer_cache
+            if key.ndim == 4 and value.ndim == 4:
+                key_trimmed = key[:, :, :target_length, :]
+                value_trimmed = value[:, :, :target_length, :]
+            elif key.ndim == 3 and value.ndim == 3:
+                key_trimmed = key[:, :target_length, :]
+                value_trimmed = value[:, :target_length, :]
+            else:
+                raise TypeError(
+                    f"Layer {layer_idx}: expected 3D or 4D key/value tensors, got "
+                    f"key.ndim={key.ndim}, value.ndim={value.ndim}"
+                )
+            new_past_key_values.append((key_trimmed, value_trimmed))
+
+        return tuple(new_past_key_values)
+
+
+def replace_kv_cache(
+    past_key_values: Tuple[Tuple[torch.Tensor, torch.Tensor], ...],
+    new_key: torch.Tensor,
+    new_value: torch.Tensor,
+    replace_position: torch.Tensor,
+    layer_idx: int,
+) -> Tuple[Tuple[torch.Tensor, torch.Tensor], ...]:
+    """Replace KV cache at specified positions (Fast-dLLM style).
+
+    This implements Fast-dLLM's dual-cache mode: instead of trimming and concatenating,
+    selectively replace cache positions in-place. This is more efficient for block-decode
+    where we refine tokens iteratively within a block.
+
+    Algorithm (Fast-dLLM llada/model/modeling_llada.py lines 732-748):
+    1. For each batch element, find indices where replace_position[b] == 1
+    2. Replace past_key[b, :, indices] with new_key[b, :, :len(indices)]
+    3. Return modified cache (in-place update)
+
+    Args:
+        past_key_values: Tuple of (key, value) pairs per layer.
+            Shape per tensor: [batch, num_heads, seq_len, head_dim]
+        new_key: New key tensor [batch, num_heads, selected_len, head_dim]
+        new_value: New value tensor [batch, num_heads, selected_len, head_dim]
+        replace_position: Bool tensor [batch, seq_len] where 1 = replace, 0 = keep
+        layer_idx: Layer index to update (0-indexed)
+
+    Returns:
+        Updated cache in same tuple format.
+
+    Raises:
+        IndexError: If layer_idx is out of range.
+        ValueError: If shapes don't match.
+
+    Example:
+        >>> # Initial forward: build full cache
+        >>> cache = model(x, use_cache=True).past_key_values
+        >>> # Mark current block for replacement
+        >>> replace_pos = torch.zeros(B, L, dtype=torch.bool)
+        >>> replace_pos[:, block_start:block_end] = True
+        >>> # Forward current block, get new K/V
+        >>> new_k, new_v = ...
+        >>> # Replace cache at marked positions
+        >>> for layer_idx in range(num_layers):
+        >>>     cache = replace_kv_cache(cache, new_k, new_v, replace_pos, layer_idx)
+    """
+    if layer_idx < 0 or layer_idx >= len(past_key_values):
+        raise IndexError(
+            f"layer_idx={layer_idx} out of range for cache with {len(past_key_values)} layers"
+        )
+
+    # Validate replace_position
+    if replace_position.ndim != 2:
+        raise ValueError(
+            f"replace_position must be 2D [batch, seq_len], got shape {replace_position.shape}"
+        )
+
+    batch_size = replace_position.shape[0]
+
+    # Extract current layer cache
+    past_key, past_value = past_key_values[layer_idx]
+
+    # Validate shapes
+    if past_key.shape[0] != batch_size:
+        raise ValueError(
+            f"Batch size mismatch: replace_position has {batch_size}, "
+            f"but past_key has {past_key.shape[0]}"
+        )
+
+    # Clone cache to avoid modifying input (side-effect free)
+    past_key = past_key.clone()
+    past_value = past_value.clone()
+
+    # Perform replacement per batch (Fast-dLLM algorithm)
+    for b in range(batch_size):
+        # Get indices where replace_position[b] == 1
+        batch_replace_indices = replace_position[b].nonzero(as_tuple=True)[0]
+
+        if len(batch_replace_indices) > 0:
+            # Validate new tensor has enough elements
+            num_replace = len(batch_replace_indices)
+            if new_key.shape[2] < num_replace:
+                raise ValueError(
+                    f"Batch {b}: replace_position marks {num_replace} positions, "
+                    f"but new_key only has {new_key.shape[2]} tokens"
+                )
+
+            # Replace positions in past_key and past_value for this batch
+            # past_key[b, :, indices] = new_key[b, :, :len(indices)]
+            past_key[b, :, batch_replace_indices] = new_key[b, :, :num_replace]
+            past_value[b, :, batch_replace_indices] = new_value[b, :, :num_replace]
+
+    # Rebuild cache tuple with updated layer
+    new_past_key_values = list(past_key_values)
+    new_past_key_values[layer_idx] = (past_key, past_value)
+
+    return tuple(new_past_key_values)
+
+
+def tuple_to_cache(
+    past_key_values: Tuple[Tuple[torch.Tensor, ...], ...],
+    device: torch.device,
+) -> DynamicCache:
+    """Convert raw tuple cache to DynamicCache for transformers compatibility.
+
+    Args:
+        past_key_values: Tuple of (key, value) tuples per layer
+        device: Target device for cache
+
+    Returns:
+        DynamicCache object
+
+    Raises:
+        TypeError: If input is not tuple format
+        ValueError: If cache is empty
+    """
+    if not isinstance(past_key_values, tuple):
+        raise TypeError(
+            f"Expected tuple format, got {type(past_key_values).__name__}. "
+            f"Use this function to convert tuple → DynamicCache for transformers models."
+        )
+
+    if len(past_key_values) == 0:
+        raise ValueError("Cannot convert empty tuple to DynamicCache")
+
+    cache = DynamicCache()
+
+    for layer_idx, layer_cache in enumerate(past_key_values):
+        if not isinstance(layer_cache, tuple) or len(layer_cache) != 2:
+            raise TypeError(
+                f"Layer {layer_idx}: expected (key, value) tuple, "
+                f"got {type(layer_cache).__name__}"
+            )
+
+        key, value = layer_cache
+
+        # Ensure tensors are on target device
+        if key.device != device:
+            key = key.to(device)
+        if value.device != device:
+            value = value.to(device)
+
+        cache.update(key, value, layer_idx)
+
+    return cache
+
+
+__all__ = [
+    "trim_kv_cache",
+    "replace_kv_cache",
+    "tuple_to_cache",
+]

--- a/unturtle/models/generation/diffusion_generation_utils.py
+++ b/unturtle/models/generation/diffusion_generation_utils.py
@@ -1,0 +1,1396 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Shared MDLM-style generation utilities for masked diffusion LMs.
+# Extracted from unturtle/models/dream/generation_utils.py (Dream-specific
+# logit right-shift is intentionally excluded — it is a Dream training artefact
+# and does NOT apply to A2D or LLaDA models).
+
+"""Shared MDLM-style generation utilities for masked diffusion LMs.
+
+This module provides :class:`MaskedDiffusionGenerationMixin` which implements
+the iterative masked-token denoising loop used by LLaDA, MDLM, and A2D models.
+
+Key difference from :class:`~unturtle.models.backbones.dream.DreamGenerationMixin`:
+- **No logit right-shift** — Dream shifts logits by one position because its
+  training objective is shifted; A2D / LLaDA predict token ``i`` at position
+  ``i`` directly so no shift is needed.
+
+Usage::
+
+    from unturtle.models.generation.diffusion_generation_utils import (
+        MaskedDiffusionGenerationConfig,
+        MaskedDiffusionGenerationMixin,
+        MaskedDiffusionModelOutput,
+    )
+"""
+
+import copy
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from transformers.cache_utils import DynamicCache
+
+import torch
+import torch.distributions as dists
+from torch.nn import functional as F
+from transformers import __version__
+from transformers.generation.configuration_utils import GenerationConfig
+from transformers.utils import ModelOutput, is_torchdynamo_compiling, logging
+
+logger = logging.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Cache management utilities (Phase M: Block-decode)
+# ---------------------------------------------------------------------------
+
+
+def _trim_kv_cache(
+    past_key_values: Any,
+    target_length: int,
+) -> Tuple[Tuple[torch.Tensor, ...], ...]:
+    """Trim KV cache to retain only the first target_length tokens.
+
+    This follows Fast-dLLM's approach for cache trimming in non-dual mode.
+
+    Args:
+        past_key_values: Either DynamicCache or tuple of (key, value) tuples per layer.
+            Shape per tensor: [batch, num_heads, seq_len, head_dim]
+        target_length: Number of tokens to retain in cache.
+
+    Returns:
+        Trimmed past_key_values as tuple format with seq_len = target_length.
+
+    Raises:
+        ValueError: If target_length is invalid.
+        TypeError: If cache format is unexpected.
+    """
+    if target_length < 0:
+        raise ValueError(f"target_length must be non-negative, got {target_length}")
+
+    if target_length == 0:
+        raise ValueError("target_length=0 would result in empty cache")
+
+    # Convert DynamicCache to tuple format if needed
+    if not isinstance(past_key_values, tuple):
+        if not hasattr(past_key_values, "layers"):
+            raise TypeError(
+                f"Expected cache object to have '.layers' attribute, but got {type(past_key_values).__name__}. "
+                f"Supported cache types: DynamicCache (transformers) or raw tuple format."
+            )
+
+        new_past_key_values = []
+        try:
+            for layer in past_key_values.layers:
+                key_trimmed = layer.keys[:, :, :target_length, :]
+                value_trimmed = layer.values[:, :, :target_length, :]
+                new_past_key_values.append((key_trimmed, value_trimmed))
+        except AttributeError as e:
+            raise RuntimeError(
+                f"Failed to access cache layer attributes. Cache type: {type(past_key_values).__name__}. "
+                f"Expected 'keys' and 'values' attributes on each layer. Original error: {e}"
+            ) from e
+
+        return tuple(new_past_key_values)
+    else:
+        # Already tuple format
+        if len(past_key_values) == 0:
+            raise ValueError("Received empty tuple cache")
+
+        new_past_key_values = []
+        for layer_idx in range(len(past_key_values)):
+            layer_cache = past_key_values[layer_idx]
+
+            if not isinstance(layer_cache, tuple) or len(layer_cache) != 2:
+                raise TypeError(
+                    f"Layer {layer_idx}: expected tuple of (key, value), "
+                    f"got {type(layer_cache).__name__} with length {len(layer_cache) if hasattr(layer_cache, '__len__') else 'N/A'}"
+                )
+
+            key, value = layer_cache
+            key_trimmed = key[:, :, :target_length, :]
+            value_trimmed = value[:, :, :target_length, :]
+            new_past_key_values.append((key_trimmed, value_trimmed))
+
+        return tuple(new_past_key_values)
+
+
+def _tuple_to_cache(
+    past_key_values: Tuple[Tuple[torch.Tensor, ...], ...],
+    device: torch.device,
+) -> "DynamicCache":
+    """Convert raw tuple cache to DynamicCache for transformers compatibility.
+
+    This is necessary because transformers' attention layers call `.update()` on
+    the cache object, which tuples don't support.
+
+    Args:
+        past_key_values: Tuple of (key, value) tuples per layer.
+            Shape per tensor: [batch, num_heads, seq_len, head_dim]
+        device: Device to place the cache tensors on.
+
+    Returns:
+        DynamicCache object compatible with transformers attention layers.
+
+    Raises:
+        TypeError: If cache structure is invalid.
+        ValueError: If cache is empty or malformed.
+    """
+    from transformers.cache_utils import DynamicCache
+
+    if not isinstance(past_key_values, tuple):
+        raise TypeError(
+            f"Expected past_key_values to be tuple, got {type(past_key_values).__name__}"
+        )
+
+    if len(past_key_values) == 0:
+        raise ValueError("Cannot convert empty tuple to DynamicCache")
+
+    cache = DynamicCache()
+    for layer_idx, layer_cache in enumerate(past_key_values):
+        if not isinstance(layer_cache, tuple):
+            raise TypeError(
+                f"Layer {layer_idx}: expected tuple of (key, value), got {type(layer_cache).__name__}"
+            )
+
+        if len(layer_cache) != 2:
+            raise ValueError(
+                f"Layer {layer_idx}: expected tuple of length 2 (key, value), got length {len(layer_cache)}"
+            )
+
+        key, value = layer_cache
+
+        if not isinstance(key, torch.Tensor) or not isinstance(value, torch.Tensor):
+            raise TypeError(
+                f"Layer {layer_idx}: expected key and value to be torch.Tensor, "
+                f"got key={type(key).__name__}, value={type(value).__name__}"
+            )
+
+        if key.shape != value.shape:
+            raise ValueError(
+                f"Layer {layer_idx}: key and value shape mismatch: "
+                f"key.shape={key.shape}, value.shape={value.shape}"
+            )
+
+        try:
+            cache.update(key, value, layer_idx)
+        except Exception as e:
+            raise RuntimeError(
+                f"Layer {layer_idx}: DynamicCache.update() failed. "
+                f"Key shape: {key.shape}, value shape: {value.shape}, device: {key.device}. "
+                f"Original error: {e}"
+            ) from e
+
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# Helper functions (shared with Dream; kept in sync manually)
+# ---------------------------------------------------------------------------
+
+
+def top_p_logits(logits: torch.Tensor, top_p: float) -> torch.Tensor:
+    """Nucleus (top-p) filtering of logits."""
+    sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+    cumulative_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1), dim=-1)
+    sorted_indices_to_remove = cumulative_probs > top_p
+    # Shift right: keep the first token above the threshold
+    sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
+    sorted_indices_to_remove[..., 0] = 0
+    mask = torch.zeros_like(logits, dtype=torch.bool, device=logits.device)
+    mask = mask.scatter_(-1, sorted_indices, sorted_indices_to_remove)
+    return logits.masked_fill(mask, torch.finfo(logits.dtype).min)
+
+
+def top_k_logits(logits: torch.Tensor, top_k: int) -> torch.Tensor:
+    """Top-k filtering of logits."""
+    top_k = min(top_k, logits.size(-1))
+    indices_to_remove = logits < torch.topk(logits, top_k)[0][..., -1, None]
+    return logits.masked_fill(indices_to_remove, torch.finfo(logits.dtype).min)
+
+
+def sample_tokens(
+    logits: torch.Tensor,
+    temperature: float = 0.0,
+    top_p: Optional[float] = None,
+    top_k: Optional[int] = None,
+    margin_confidence: bool = False,
+    neg_entropy: bool = False,
+    confidence_type: Optional[str] = None,
+) -> Tuple[torch.Tensor, torch.LongTensor]:
+    """Sample tokens from logits and return (confidence, token_ids).
+
+    Supported confidence modes:
+    - default / ``max_prob``: sampled token probability (or argmax probability)
+    - ``margin``: top1 - top2 probability margin
+    - ``neg_entropy``: sum(p * log p), matching Fast-dLLM / unturtle entropy mode
+
+    ``confidence_type`` is the canonical API for block-decode codepaths.
+    ``margin_confidence`` / ``neg_entropy`` are preserved for existing callers.
+    """
+    if confidence_type is not None:
+        if confidence_type == "max_prob":
+            margin_confidence = False
+            neg_entropy = False
+        elif confidence_type == "margin":
+            margin_confidence = True
+            neg_entropy = False
+        elif confidence_type == "neg_entropy":
+            margin_confidence = False
+            neg_entropy = True
+        else:
+            raise ValueError(
+                f"Unknown confidence_type={confidence_type!r}. "
+                "Choose from 'max_prob', 'margin', 'neg_entropy'."
+            )
+
+    if temperature > 0:
+        logits = logits / temperature
+    if top_p is not None and top_p < 1:
+        logits = top_p_logits(logits, top_p)
+    if top_k is not None:
+        logits = top_k_logits(logits, top_k)
+    probs = torch.softmax(logits, dim=-1)
+
+    if temperature > 0:
+        try:
+            x0 = dists.Categorical(probs=probs).sample()
+            confidence = torch.gather(probs, -1, x0.unsqueeze(-1)).squeeze(-1)
+        except (RuntimeError, ValueError) as e:
+            error_msg = str(e).lower()
+            if "probability" in error_msg or "nan" in error_msg or "inf" in error_msg:
+                warnings.warn(
+                    f"Categorical sampling failed due to invalid probabilities (possibly NaN/Inf). "
+                    f"Falling back to argmax. Original error: {e}",
+                    UserWarning,
+                )
+                confidence, x0 = probs.max(dim=-1)
+            else:
+                raise RuntimeError(
+                    f"Unexpected error during token sampling with temperature={temperature}. "
+                    f"Probs shape: {probs.shape}. Original error: {e}"
+                ) from e
+    else:
+        confidence, x0 = probs.max(dim=-1)
+
+    if margin_confidence:
+        sorted_probs, _ = torch.sort(probs, dim=-1, descending=True)
+        confidence = sorted_probs[:, 0] - sorted_probs[:, 1]
+
+    if neg_entropy:
+        epsilon = 1e-10
+        log_probs = torch.log(probs + epsilon)
+        confidence = torch.sum(probs * log_probs, dim=-1)
+
+    return confidence, x0
+
+
+def select_threshold_transfer_mask(
+    masked_confidence: torch.Tensor,
+    mask_index_block: torch.Tensor,
+    threshold: float,
+) -> torch.Tensor:
+    """Select block-local tokens to unmask under paper-style threshold semantics.
+
+    For each batch row:
+    - consider only currently masked positions in the current block
+    - unmask all tokens with confidence >= threshold
+    - if none meet threshold, still unmask the single max-confidence token
+
+    `masked_confidence` is block-shaped and only meaningful at masked positions.
+    Values at unmasked positions are ignored.
+    """
+    if masked_confidence.ndim != 2 or mask_index_block.ndim != 2:
+        raise ValueError(
+            "masked_confidence and mask_index_block must be 2-D tensors of shape [batch, block_length]"
+        )
+    if masked_confidence.shape != mask_index_block.shape:
+        raise ValueError(
+            f"Shape mismatch: masked_confidence.shape={masked_confidence.shape}, "
+            f"mask_index_block.shape={mask_index_block.shape}"
+        )
+
+    valid_confidence = masked_confidence.masked_fill(~mask_index_block, float("-inf"))
+    transfer_mask = mask_index_block & (valid_confidence >= threshold)
+
+    has_masked = mask_index_block.any(dim=1)
+    has_selected = transfer_mask.any(dim=1)
+    needs_fallback = has_masked & ~has_selected
+    if needs_fallback.any():
+        fallback_indices = valid_confidence.argmax(dim=1)
+        transfer_mask[needs_fallback, fallback_indices[needs_fallback]] = True
+
+    return transfer_mask
+
+
+# ---------------------------------------------------------------------------
+# BD3LM generation helpers (shared with MaskedDiffusionBlockGenerationMixin)
+# ---------------------------------------------------------------------------
+
+
+def prepare_for_sampling(
+    x: torch.Tensor,
+    block_size: int,
+    pad_token_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build block-causal attention mask and logical position IDs.
+
+    Positions are grouped into blocks of ``block_size`` by their physical index.
+    Position *k* can attend to any position in blocks 0 .. block(k).  Padding
+    tokens are excluded from attention: they neither query nor serve as keys.
+
+    Args:
+        x: Token ID tensor of shape ``[B, T]``.
+        block_size: Number of tokens per block.
+        pad_token_id: Token ID used for padding (will be masked out).
+
+    Returns:
+        attn_mask: ``[B, 1, T, T]`` bool tensor — ``True`` means the query can
+            attend to the key at that position.
+        position_ids: ``[B, T]`` long tensor — 0-based logical positions; padding
+            positions are set to 0.
+    """
+    B, T = x.shape
+    device = x.device
+
+    # Per-sample valid mask
+    valid = x != pad_token_id  # [B, T]
+
+    # Logical positions for RoPE (cumsum over valid tokens, 0-based)
+    pos_raw = torch.cumsum(valid.to(torch.long), dim=-1)  # [B, T] 1-based
+    logical_pos = pos_raw - 1  # [B, T] 0-based
+
+    position_ids = torch.where(
+        valid,
+        logical_pos,
+        torch.zeros_like(logical_pos),
+    ).to(device=device, dtype=torch.long)  # [B, T]
+
+    # Block IDs in physical coordinates (shared across batch)
+    pos = torch.arange(T, device=device)
+    block_ids = torch.div(pos, block_size, rounding_mode="floor")  # [T]
+    block_ids = block_ids.view(1, T).expand(B, -1)  # [B, T]
+
+    # Padding positions get a sentinel block ID of -1
+    block_ids = torch.where(
+        valid,
+        block_ids,
+        torch.full_like(block_ids, -1),
+    )
+
+    # Build [B, 1, T, T] mask: key-block <= query-block AND both valid
+    bid_q = block_ids.view(B, 1, T, 1)  # query
+    bid_k = block_ids.view(B, 1, 1, T)  # key
+
+    valid_q = bid_q >= 0
+    valid_k = bid_k >= 0
+
+    attn_mask = (bid_k <= bid_q) & valid_q & valid_k  # [B, 1, T, T]
+
+    return attn_mask, position_ids
+
+
+def _add_gumbel_noise(logits: torch.Tensor, temperature: float) -> torch.Tensor:
+    """Apply Gumbel-max noise to logits for temperature sampling.
+
+    Uses float64 for numerical stability, as recommended by arXiv:2409.02908.
+    """
+    if temperature == 0.0:
+        return logits
+    logits = logits.to(torch.float64)
+    noise = torch.rand_like(logits, dtype=torch.float64)
+    gumbel_noise = (-torch.log(noise)) ** temperature
+    return logits.exp() / gumbel_noise
+
+
+def _get_num_transfer_tokens(
+    mask_index: torch.Tensor,
+    steps: int,
+) -> torch.Tensor:
+    """Compute the linear unmasking schedule for one block.
+
+    Distributes the unmasking of ``mask_num`` tokens across ``steps`` steps
+    with a uniform (linear) schedule.  Any remainder is added to the first step.
+
+    Args:
+        mask_index: ``[B, L]`` bool tensor marking masked positions.
+        steps: Number of inner diffusion steps.
+
+    Returns:
+        ``[B, steps]`` int64 tensor of token counts to unmask per step.
+    """
+    B = mask_index.shape[0]
+    device = mask_index.device
+    mask_num = mask_index.sum(dim=1)  # [B]
+
+    num_transfer = torch.zeros(B, steps, dtype=torch.long, device=device)
+    for b in range(B):
+        n = mask_num[b].item()
+        if n == 0:
+            continue
+        base = int(n) // steps
+        remainder = int(n) % steps
+        num_transfer[b] = base
+        if remainder > 0:
+            num_transfer[b, :remainder] += 1
+    return num_transfer
+
+
+def _diffusion_step_block(
+    logits: torch.Tensor,  # [B, L, V]
+    x_block: torch.Tensor,  # [B, L]
+    mask_block: torch.Tensor,  # [B, L] bool
+    num_transfer_step: torch.Tensor,  # [B]
+    temperature: float,
+) -> torch.Tensor:
+    """One inner diffusion step over a block slice.
+
+    Samples candidate tokens from logits, computes confidence (softmax
+    probability of the predicted token), and commits the top-k most confident
+    masked positions.
+
+    Args:
+        logits: Logit tensor ``[B, L, V]``.
+        x_block: Current token IDs for the block ``[B, L]``.
+        mask_block: Boolean mask ``[B, L]`` — ``True`` means the position is
+            still masked and can be committed.
+        num_transfer_step: Number of tokens to commit per sample ``[B]``.
+        temperature: Gumbel noise temperature.
+
+    Returns:
+        Updated ``x_block`` tensor with committed tokens filled in.
+    """
+    if not mask_block.any():
+        return x_block
+
+    B, L, _ = logits.shape
+    device = logits.device
+
+    # Sample tokens via Gumbel-max
+    logits_noisy = _add_gumbel_noise(logits, temperature=temperature)
+    x0 = torch.argmax(logits_noisy, dim=-1)  # [B, L]
+
+    # Confidence: softmax probability of the sampled token at each masked position
+    p = F.softmax(logits.float(), dim=-1)
+    x0_p = torch.gather(p, dim=-1, index=x0.unsqueeze(-1)).squeeze(-1)  # [B, L]
+
+    # Only masked positions are candidates
+    x0 = torch.where(mask_block, x0, x_block)
+    confidence = torch.where(mask_block, x0_p, torch.full_like(x0_p, -float("inf")))
+
+    # Select top-k positions per sample to commit
+    transfer = torch.zeros(B, L, dtype=torch.bool, device=device)
+    for j in range(B):
+        k = int(num_transfer_step[j].item())
+        if k <= 0:
+            continue
+        valid_count = (confidence[j] > -float("inf")).sum().item()
+        if valid_count == 0:
+            continue
+        k = min(k, int(valid_count))
+        _, sel = torch.topk(confidence[j], k)
+        transfer[j, sel] = True
+
+    x_block_new = x_block.clone()
+    x_block_new[transfer] = x0[transfer]
+    return x_block_new
+
+
+# ---------------------------------------------------------------------------
+# Output dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MaskedDiffusionModelOutput(ModelOutput):
+    """Output of :meth:`MaskedDiffusionGenerationMixin.diffusion_generate`."""
+
+    sequences: torch.LongTensor = None
+    history: Optional[Tuple[torch.LongTensor, ...]] = None
+    timing: Optional[Dict[str, Any]] = None
+
+
+# ---------------------------------------------------------------------------
+# Generation config
+# ---------------------------------------------------------------------------
+
+
+class MaskedDiffusionGenerationConfig(GenerationConfig):
+    """Generation configuration for MDLM-style masked diffusion models.
+
+    Parameters
+    ----------
+    steps : int
+        Number of denoising steps (default: 128).
+    mask_token_id : int or None
+        ID of the ``[MASK]`` token.  Required; must be set before generation.
+    temperature : float
+        Sampling temperature.  0.0 means argmax (default: 0.0).
+    top_p : float or None
+        Nucleus sampling probability (default: None → disabled).
+    top_k : int or None
+        Top-k sampling (default: None → disabled).
+    alg : str
+        Unmasking algorithm.  One of ``"origin"``, ``"maskgit_plus"``,
+        ``"topk_margin"``, ``"entropy"`` (default: ``"origin"``).
+    alg_temp : float or None
+        Temperature for the confidence-based token selection step in
+        non-``"origin"`` algorithms (default: None → deterministic topk).
+    eps : float
+        Minimum timestep (default: 1e-3).
+    use_cache : bool
+        Enable block-wise KV-cache for faster inference (default: False).
+    block_length : int or None
+        Number of tokens to decode in each block. Must divide ``max_new_tokens``
+        evenly. If None, defaults to single-block (``max_new_tokens``).
+        Only used when ``use_cache=True`` (default: None).
+    use_replace_cache : bool
+        Use dual-cache mode (forward only current block). If False, use trim mode
+        (forward from current block start to end). Only used when ``use_cache=True``
+        (default: True). See Fast-dLLM paper for details.
+    parallel_decode : bool
+        Enable confidence-aware parallel decoding (Phase M.2). Unmask multiple
+        confident tokens per step instead of one. Only used when ``use_cache=True``
+        (default: False).
+    confidence_threshold : float
+        Minimum confidence for parallel unmasking (0-1). Tokens with confidence
+        below this threshold are NOT unmasked in the current step. Higher values
+        are more conservative (fewer parallel unmasks). Only used when
+        ``parallel_decode=True`` (default: 0.9).
+    confidence_type : str
+        Type of confidence measure for parallel decoding. One of:
+        - "max_prob": Maximum probability (default)
+        - "margin": Top1 - Top2 probability margin
+        - "neg_entropy": Negative entropy
+        Only used when ``parallel_decode=True`` (default: "max_prob").
+    output_history : bool
+        If True and ``return_dict=True``, include per-step token sequences in
+        the output (default: False).
+    return_dict : bool
+        Return a :class:`MaskedDiffusionModelOutput` instead of a plain tensor
+        (default: False).
+    right_shift_logits : bool, optional
+        If ``True``, shift logits one position right before committing tokens
+        (Dream-style compatibility for right-shifted label training).
+        Defaults to ``False``.
+    """
+
+    def __init__(self, **kwargs):
+        self.temperature: float = kwargs.pop("temperature", 0.0)
+        self.top_p: Optional[float] = kwargs.pop("top_p", None)
+        self.top_k: Optional[int] = kwargs.pop("top_k", None)
+        self.max_length: int = kwargs.pop("max_length", 20)
+        self.max_new_tokens: Optional[int] = kwargs.pop("max_new_tokens", None)
+        # diffusion-specific
+        self.eps: float = kwargs.pop("eps", 1e-3)
+        self.steps: int = kwargs.pop("steps", 128)
+        self.alg: str = kwargs.pop("alg", "origin")
+        self.alg_temp: Optional[float] = kwargs.pop("alg_temp", None)
+        # cache control (Phase M.1)
+        self.use_cache: bool = kwargs.pop("use_cache", False)
+        self.block_length: Optional[int] = kwargs.pop("block_length", None)
+        self.use_replace_cache: bool = kwargs.pop("use_replace_cache", True)
+        # parallel decode (Phase M.2)
+        self.parallel_decode: bool = kwargs.pop("parallel_decode", False)
+        self.confidence_threshold: float = kwargs.pop("confidence_threshold", 0.9)
+        self.confidence_type: str = kwargs.pop("confidence_type", "max_prob")
+        # BD3LM block-diffusion generation
+        self.use_block_diffusion: bool = kwargs.pop("use_block_diffusion", False)
+        self.bd3lm_block_size: int = kwargs.pop("bd3lm_block_size", 32)
+        self.cfg_scale: float = kwargs.pop("cfg_scale", 0.0)
+        self.right_shift_logits: bool = kwargs.pop("right_shift_logits", False)
+        # output control
+        self.num_return_sequences: int = kwargs.pop("num_return_sequences", 1)
+        self.return_dict: bool = kwargs.pop("return_dict", False)
+        self.output_history: bool = kwargs.pop("output_history", False)
+        self.output_timing: bool = kwargs.pop("output_timing", False)
+        # step progress callback: called after each denoising step with (step, total)
+        # where step is 1-indexed and total is the total number of steps.
+        self.step_callback: Optional[Callable[[int, int], None]] = kwargs.pop(
+            "step_callback", None
+        )
+        # stream callback: called after each step with (step, total, x)
+        # where x is a detached clone snapshot of the current token IDs (LongTensor).
+        self.stream_callback: Optional[Callable[[int, int, torch.LongTensor], None]] = (
+            kwargs.pop("stream_callback", None)
+        )
+        # special tokens
+        self.mask_token_id: Optional[int] = kwargs.pop("mask_token_id", None)
+        self.pad_token_id: Optional[int] = kwargs.pop("pad_token_id", None)
+        self.bos_token_id: Optional[int] = kwargs.pop("bos_token_id", None)
+        self.eos_token_id: Optional[int] = kwargs.pop("eos_token_id", None)
+        # HF internals
+        self.generation_kwargs = kwargs.pop("generation_kwargs", {})
+        self._from_model_config = kwargs.pop("_from_model_config", False)
+        self._commit_hash = kwargs.pop("_commit_hash", None)
+        self.transformers_version = kwargs.pop("transformers_version", __version__)
+
+        if not self._from_model_config:
+            for key, value in kwargs.items():
+                try:
+                    setattr(self, key, value)
+                except AttributeError as err:
+                    logger.error(f"Can't set {key} with value {value} for {self}")
+                    raise err
+
+        self.validate(is_init=True)
+
+    def validate(self, is_init: bool = False, **kwargs):
+        """Validate generation config parameters."""
+        if self.parallel_decode and not self.use_cache:
+            raise ValueError(
+                "`parallel_decode=True` requires `use_cache=True`. "
+                "Confidence-aware parallel decoding relies on the KV-cache infrastructure. "
+                "Please set `use_cache=True` or disable `parallel_decode`."
+            )
+
+        if self.parallel_decode and self.alg == "origin":
+            raise ValueError(
+                "`parallel_decode=True` does not support `alg='origin'`. "
+                "Use one of 'maskgit_plus', 'topk_margin', or 'entropy'."
+            )
+
+        if not 0.0 <= self.confidence_threshold <= 1.0:
+            raise ValueError(
+                f"confidence_threshold must be in [0, 1], got {self.confidence_threshold}"
+            )
+
+        if self.confidence_type not in {"max_prob", "margin", "neg_entropy"}:
+            raise ValueError(
+                f"Unknown confidence_type={self.confidence_type!r}. "
+                "Choose from 'max_prob', 'margin', 'neg_entropy'."
+            )
+
+        if self.use_block_diffusion and self.use_cache:
+            raise ValueError(
+                "`use_block_diffusion=True` and `use_cache=True` are mutually exclusive. "
+                "BD3LM generation uses its own block-causal attention mask and cannot use "
+                "the Fast-dLLM KV-cache path simultaneously. "
+                "Use `use_block_diffusion=True` for BD3LM (A2D models) or "
+                "`use_cache=True` for Fast-dLLM block-decode (LLaDA/Dream/A2D)."
+            )
+
+        if self.use_block_diffusion and getattr(self, "return_dict", False):
+            raise ValueError(
+                "`use_block_diffusion=True` does not support `return_dict=True`. "
+                "BD3LM generation returns a plain tensor. Use `return_dict=False`."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Mixin
+# ---------------------------------------------------------------------------
+
+
+class MaskedDiffusionGenerationMixin:
+    """Generation mixin for MDLM-style masked diffusion LMs.
+
+    Provides :meth:`diffusion_generate` which implements the iterative masked-
+    token denoising loop.  The mixin is designed to be mixed into model classes
+    as the *first* base class so that its :meth:`diffusion_generate` takes
+    precedence over HuggingFace's autoregressive ``generate``.
+
+    Subclasses must implement a HF-compatible ``forward(input_ids, ...)`` that
+    returns an object with a ``.logits`` attribute of shape ``[B, L, V]``.
+
+    Unlike :class:`~unturtle.models.backbones.dream.DreamGenerationMixin`, **no** logit
+    right-shift is applied here.  A2D and LLaDA models predict token ``i``
+    at output position ``i`` directly.
+    """
+
+    # ------------------------------------------------------------------
+    # Internal helpers (mirror of DreamGenerationMixin)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _expand_inputs_for_generation(
+        expand_size: int = 1,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.LongTensor] = None,
+    ):
+        if expand_size == 1:
+            return input_ids, attention_mask
+        if input_ids is not None:
+            input_ids = input_ids.repeat_interleave(expand_size, dim=0)
+        if attention_mask is not None:
+            attention_mask = attention_mask.repeat_interleave(expand_size, dim=0)
+        return input_ids, attention_mask
+
+    def _validate_generated_length(
+        self, generation_config, input_ids_length, has_default_max_length
+    ):
+        if is_torchdynamo_compiling():
+            return
+        if (
+            has_default_max_length
+            and generation_config.max_new_tokens is None
+            and generation_config.max_length == 20
+        ):
+            warnings.warn(
+                f"Using the model-agnostic default `max_length` (={generation_config.max_length}) to control the "
+                "generation length. We recommend setting `max_new_tokens` to control the maximum length of the "
+                "generation.",
+                UserWarning,
+            )
+        if input_ids_length >= generation_config.max_length:
+            raise ValueError(
+                f"Input length of input_ids is {input_ids_length}, but `max_length` is set to"
+                f" {generation_config.max_length}. This can lead to unexpected behavior. You should consider"
+                " increasing `max_length` or, better yet, setting `max_new_tokens`."
+            )
+
+    def _prepare_generated_length(
+        self, generation_config, has_default_max_length, input_ids_length
+    ):
+        if generation_config.max_new_tokens is not None:
+            if not has_default_max_length and generation_config.max_length is not None:
+                logger.warning(
+                    f"Both `max_new_tokens` (={generation_config.max_new_tokens}) and `max_length`(="
+                    f"{generation_config.max_length}) seem to have been set. `max_new_tokens` will take precedence."
+                )
+            generation_config.max_length = (
+                generation_config.max_new_tokens + input_ids_length
+            )
+        elif has_default_max_length:
+            if (
+                generation_config.max_length
+                == MaskedDiffusionGenerationConfig().max_length
+            ):
+                generation_config.max_length = (
+                    generation_config.max_length + input_ids_length
+                )
+                max_pos = getattr(self.config, "max_position_embeddings", None)
+                if max_pos is not None:
+                    generation_config.max_length = min(
+                        generation_config.max_length, max_pos
+                    )
+        return generation_config
+
+    def _prepare_generation_config(
+        self, generation_config: Optional[MaskedDiffusionGenerationConfig], **kwargs
+    ) -> MaskedDiffusionGenerationConfig:
+        if generation_config is None:
+            # Build a default config seeded from well-known HF special tokens.
+            # We intentionally do NOT use from_model_config() because HF's
+            # implementation compares against GenerationConfig() attributes and
+            # raises AttributeError for our custom fields (eps, steps, …).
+            init_kwargs = {}
+            model_cfg = getattr(self, "config", None)
+            if model_cfg is not None:
+                for attr in (
+                    "bos_token_id",
+                    "eos_token_id",
+                    "pad_token_id",
+                    "mask_token_id",
+                ):
+                    val = getattr(model_cfg, attr, None)
+                    if val is not None:
+                        init_kwargs[attr] = val
+            generation_config = MaskedDiffusionGenerationConfig(**init_kwargs)
+
+        if not is_torchdynamo_compiling():
+            generation_config = copy.deepcopy(generation_config)
+            generation_config.update(**kwargs)
+
+        return generation_config
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def diffusion_generate(
+        self,
+        inputs: Optional[torch.Tensor] = None,
+        generation_config: Optional[MaskedDiffusionGenerationConfig] = None,
+        **kwargs,
+    ) -> Union[MaskedDiffusionModelOutput, torch.LongTensor]:
+        """Generate sequences via MDLM-style iterative masked-token denoising.
+
+        Parameters
+        ----------
+        inputs : LongTensor of shape ``[B, L]``
+            Prompt token IDs.  Completion positions should already be filled
+            with ``mask_token_id``.
+        generation_config : MaskedDiffusionGenerationConfig, optional
+            Generation parameters.  If ``None``, model defaults are used.
+        **kwargs
+            Forwarded to :class:`MaskedDiffusionGenerationConfig` (e.g.
+            ``steps``, ``temperature``, ``mask_token_id``, ``max_new_tokens``).
+
+        Returns
+        -------
+        MaskedDiffusionModelOutput or LongTensor
+            When ``generation_config.return_dict=True`` returns a
+            :class:`MaskedDiffusionModelOutput`; otherwise returns the
+            token-ID tensor directly.
+        """
+        generation_config = self._prepare_generation_config(generation_config, **kwargs)
+
+        assert inputs is not None, "`inputs` (input_ids) must be provided"
+        input_ids = inputs
+        attention_mask = kwargs.pop("attention_mask", None)
+
+        input_ids_length = input_ids.shape[-1]
+        has_default_max_length = (
+            kwargs.get("max_length") is None
+            and generation_config.max_length is not None
+        )
+        generation_config = self._prepare_generated_length(
+            generation_config=generation_config,
+            has_default_max_length=has_default_max_length,
+            input_ids_length=input_ids_length,
+        )
+        self._validate_generated_length(
+            generation_config, input_ids_length, has_default_max_length
+        )
+
+        if not is_torchdynamo_compiling() and self.device.type != input_ids.device.type:
+            warnings.warn(
+                "You are calling .diffusion_generate() with `input_ids` on a different device type than the model."
+                f" `input_ids` is on {input_ids.device.type}, model is on {self.device.type}.",
+                UserWarning,
+            )
+
+        input_ids, attention_mask = self._expand_inputs_for_generation(
+            expand_size=generation_config.num_return_sequences,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+        )
+
+        return self._sample(
+            input_ids,
+            attention_mask=attention_mask,
+            generation_config=generation_config,
+        )
+
+    def _sample(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.LongTensor],
+        generation_config: MaskedDiffusionGenerationConfig,
+    ) -> Union[MaskedDiffusionModelOutput, torch.LongTensor]:
+        """Core MDLM denoising loop.
+
+        Pads ``input_ids`` to ``max_length`` with ``mask_token_id``, then
+        iterates over ``steps`` timesteps to progressively unmask tokens.
+
+        If ``generation_config.use_cache=True``, delegates to
+        :meth:`_sample_with_cache` for block-wise KV-cache optimization.
+        """
+        if generation_config.use_cache:
+            return self._sample_with_cache(input_ids, attention_mask, generation_config)
+
+        if generation_config.use_block_diffusion:
+            return self._sample_block_diffusion(input_ids, generation_config)
+
+        output_history = generation_config.output_history
+        return_dict_out = generation_config.return_dict
+        max_length = generation_config.max_length
+        mask_token_id = generation_config.mask_token_id
+        steps = generation_config.steps
+        eps = generation_config.eps
+        alg = generation_config.alg
+        alg_temp = generation_config.alg_temp
+        temperature = generation_config.temperature
+        top_p = generation_config.top_p
+        top_k = generation_config.top_k
+
+        if mask_token_id is None:
+            # Try to get from model config as a fallback
+            mask_token_id = getattr(self.config, "mask_token_id", None)
+        if mask_token_id is None:
+            raise ValueError(
+                "`mask_token_id` must be set in `generation_config` or `model.config` before calling "
+                "`diffusion_generate()`.  Pass it explicitly: "
+                "`model.diffusion_generate(inputs, mask_token_id=<id>, ...)`"
+            )
+
+        histories = [] if (return_dict_out and output_history) else None
+
+        # Pad completion region with mask tokens
+        x = F.pad(input_ids, (0, max_length - input_ids.shape[1]), value=mask_token_id)
+
+        if attention_mask is not None and torch.any(attention_mask == 0.0):
+            attention_mask = F.pad(
+                attention_mask, (0, max_length - attention_mask.shape[1]), value=1.0
+            )
+            # Broadcast to [B, 1, L, L] for SDPA
+            attention_mask = torch.logical_and(
+                attention_mask.unsqueeze(1).unsqueeze(-2),
+                attention_mask.unsqueeze(1).unsqueeze(-1),
+            )
+        else:
+            attention_mask = None
+
+        timesteps = torch.linspace(1, eps, steps + 1, device=x.device)
+        step_callback = generation_config.step_callback
+        stream_callback = generation_config.stream_callback
+
+        for i in range(steps):
+            mask_index = x == mask_token_id
+
+            # Forward pass — no logit shift (contrast with DreamGenerationMixin)
+            logits = self(
+                input_ids=x, attention_mask=attention_mask
+            ).logits  # [B, L, V]
+
+            mask_logits = logits[mask_index]  # [N_masked, V]
+            t = timesteps[i]
+            s = timesteps[i + 1]
+
+            if alg == "origin":
+                p_transfer = 1 - s / t if i < steps - 1 else 1.0
+                x0 = torch.full_like(x[mask_index], mask_token_id, dtype=torch.long)
+                transfer = torch.rand(*x0.shape, device=x.device) < p_transfer
+                _, sampled = sample_tokens(
+                    mask_logits[transfer],
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                )
+                x0[transfer] = sampled
+                x[mask_index] = x0
+            else:
+                if alg == "maskgit_plus":
+                    confidence, x0 = sample_tokens(
+                        mask_logits, temperature=temperature, top_p=top_p, top_k=top_k
+                    )
+                elif alg == "topk_margin":
+                    confidence, x0 = sample_tokens(
+                        mask_logits,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        margin_confidence=True,
+                    )
+                elif alg == "entropy":
+                    confidence, x0 = sample_tokens(
+                        mask_logits,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        neg_entropy=True,
+                    )
+                else:
+                    raise RuntimeError(
+                        f"Unknown alg: {alg!r}. Choose from 'origin', 'maskgit_plus', 'topk_margin', 'entropy'."
+                    )
+
+                num_mask_token = mask_index.sum() / mask_index.shape[0]
+                n_transfer = (
+                    int(num_mask_token * (1 - s / t))
+                    if i < steps - 1
+                    else int(num_mask_token)
+                )
+                full_confidence = torch.full_like(x, -torch.inf, dtype=logits.dtype)
+                full_confidence[mask_index] = confidence
+
+                if n_transfer > 0:
+                    if alg_temp is None or alg_temp == 0:
+                        _, transfer_index = torch.topk(full_confidence, n_transfer)
+                    else:
+                        full_confidence = full_confidence / alg_temp
+                        full_confidence = F.softmax(full_confidence, dim=-1)
+                        transfer_index = torch.multinomial(
+                            full_confidence, num_samples=n_transfer
+                        )
+
+                    x_ = torch.full_like(x, mask_token_id, dtype=torch.long)
+                    x_[mask_index] = x0
+                    row_idx = (
+                        torch.arange(x.size(0), device=x.device)
+                        .unsqueeze(1)
+                        .expand_as(transfer_index)
+                    )
+                    x[row_idx, transfer_index] = x_[row_idx, transfer_index]
+
+            if histories is not None:
+                histories.append(x.clone())
+
+            if stream_callback is not None:
+                try:
+                    stream_callback(i + 1, steps, x.detach().clone())
+                except Exception as _cb_exc:
+                    logger.warning(
+                        "stream_callback raised at step %d: %s", i + 1, _cb_exc
+                    )
+
+            if step_callback is not None:
+                try:
+                    step_callback(i + 1, steps)
+                except Exception as _cb_exc:
+                    logger.warning(
+                        "step_callback raised at step %d: %s", i + 1, _cb_exc
+                    )
+
+        if return_dict_out:
+            return MaskedDiffusionModelOutput(
+                sequences=x,
+                history=tuple(histories) if histories is not None else None,
+            )
+        return x
+
+    def _sample_with_cache(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.LongTensor],
+        generation_config: MaskedDiffusionGenerationConfig,
+    ) -> Union[MaskedDiffusionModelOutput, torch.LongTensor]:
+        """Block-wise MDLM denoising loop with tuple cache trimming (Phase M.1).
+
+        Implements Fast-dLLM-style block-decode:
+        - Divides generation into blocks of ``block_length`` tokens
+        - Initial forward: full sequence → cache
+        - Trim cache to previous blocks only
+        - Denoising loop: forward from ``current_block_start`` with trimmed cache
+        - Cache stays constant during denoising (not updated per step)
+
+        .. note::
+           Phase M.1 implementation:
+           - ``output_history`` is not supported (always returns ``history=None``)
+           - Only ``alg='origin'`` supported (confidence-aware algorithms in M.2+)
+           - Target speedup: ≥2.0x vs Phase L baseline
+
+        Parameters
+        ----------
+        input_ids : LongTensor of shape [B, L]
+            Prompt token IDs.
+        attention_mask : LongTensor or None
+            Attention mask (currently unused in cache path).
+        generation_config : MaskedDiffusionGenerationConfig
+            Generation config with ``use_cache=True`` and ``block_length``.
+
+        Returns
+        -------
+        MaskedDiffusionModelOutput or LongTensor
+            Generated sequences (with or without history, per ``return_dict``).
+        """
+        return_dict_out = generation_config.return_dict
+        max_length = generation_config.max_length
+        mask_token_id = generation_config.mask_token_id
+        steps = generation_config.steps
+        eps = generation_config.eps
+        alg = generation_config.alg
+        alg_temp = generation_config.alg_temp
+        temperature = generation_config.temperature
+        top_p = generation_config.top_p
+        top_k = generation_config.top_k
+        block_length = generation_config.block_length
+        parallel_decode = generation_config.parallel_decode
+        confidence_threshold = generation_config.confidence_threshold
+        if parallel_decode and alg == "origin":
+            raise ValueError(
+                "`parallel_decode=True` does not support `alg='origin'`. "
+                "Use one of 'maskgit_plus', 'topk_margin', or 'entropy'."
+            )
+
+        if mask_token_id is None:
+            mask_token_id = getattr(self.config, "mask_token_id", None)
+        if mask_token_id is None:
+            raise ValueError(
+                "`mask_token_id` must be set in `generation_config` or `model.config` before calling "
+                "`diffusion_generate()` with `use_cache=True`."
+            )
+
+        # Warn if output_history is requested (not yet supported in cache path)
+        if return_dict_out and generation_config.output_history:
+            warnings.warn(
+                "`output_history=True` is not yet supported with `use_cache=True` (Phase L). "
+                "History will be None. Full history tracking will be implemented in Phase M.",
+                UserWarning,
+            )
+
+        # Pad completion region with mask tokens
+        x = F.pad(input_ids, (0, max_length - input_ids.shape[1]), value=mask_token_id)
+        prompt_len = input_ids.shape[1]
+        gen_length = max_length - prompt_len
+
+        # Note: attention_mask handling for cache path is simplified in Phase M.1.
+        # Bidirectional models typically do not need explicit masks for generation.
+        attention_mask = None
+
+        # Block-decode setup
+        if block_length is None:
+            block_length = gen_length  # Default: single block
+
+        if gen_length % block_length != 0:
+            raise ValueError(
+                f"`gen_length` ({gen_length}) must be divisible by `block_length` ({block_length}). "
+                f"Adjust `max_new_tokens` or `block_length` to satisfy this constraint."
+            )
+
+        num_blocks = gen_length // block_length
+        steps_per_block = steps // num_blocks
+        timesteps = torch.linspace(1, eps, steps_per_block + 1, device=x.device)
+        step_callback = generation_config.step_callback
+        stream_callback = generation_config.stream_callback
+        total_steps = num_blocks * steps_per_block
+        global_step = 0
+
+        # Block-decode loop (Phase M.1: tuple cache with trimming)
+        past_key_values = None
+
+        for num_block in range(num_blocks):
+            current_block_start = prompt_len + num_block * block_length
+            current_block_end = current_block_start + block_length
+
+            # Initial forward: full sequence (including all previous blocks)
+            outputs = self(input_ids=x, attention_mask=attention_mask, use_cache=True)
+            past_key_values = outputs.past_key_values
+
+            # Trim cache to previous blocks only (Fast-dLLM approach)
+            if past_key_values is not None:
+                past_key_values = _trim_kv_cache(past_key_values, current_block_start)
+
+            # Denoising loop for current block
+            step_idx = 0
+            max_block_iterations = block_length if parallel_decode else steps_per_block
+            while step_idx < max_block_iterations:
+                # Mask index for current block only
+                mask_index_block = (
+                    x[:, current_block_start:current_block_end] == mask_token_id
+                )
+
+                # Check if all tokens in block are unmasked
+                n_masked_block = mask_index_block.sum().item()
+                if n_masked_block == 0:
+                    break  # Block complete
+
+                # Forward pass with cache (from current_block_start onwards)
+                if isinstance(past_key_values, tuple):
+                    cache_obj = _tuple_to_cache(past_key_values, x.device)
+                else:
+                    cache_obj = past_key_values
+
+                x_forward = x[:, current_block_start:]
+                attn_mask_forward = (
+                    attention_mask[:, current_block_start:]
+                    if attention_mask is not None
+                    else None
+                )
+
+                # Create cache_position for transformers compatibility
+                # Tells the model where these tokens sit in the full sequence
+                cache_position = torch.arange(
+                    current_block_start,
+                    current_block_start + x_forward.shape[1],
+                    device=x.device,
+                    dtype=torch.long,
+                )
+
+                outputs = self(
+                    input_ids=x_forward,
+                    attention_mask=attn_mask_forward,
+                    past_key_values=cache_obj,
+                    cache_position=cache_position,
+                    use_cache=True,
+                )
+                logits = outputs.logits  # [B, L_block+, V]
+
+                # Extract logits for current block
+                block_logits = logits[:, :block_length, :]  # [B, block_length, V]
+                mask_logits = block_logits[mask_index_block]  # [N_masked, V]
+                if parallel_decode and 0 <= mask_token_id < mask_logits.shape[-1]:
+                    mask_logits = mask_logits.clone()
+                    mask_logits[:, mask_token_id] = torch.finfo(mask_logits.dtype).min
+
+                # Do NOT update past_key_values here - it stays constant for all steps in this block
+
+                if parallel_decode:
+                    if alg == "maskgit_plus":
+                        confidence, sampled = sample_tokens(
+                            mask_logits,
+                            temperature=temperature,
+                            top_p=top_p,
+                            top_k=top_k,
+                            confidence_type="max_prob",
+                        )
+                    elif alg == "topk_margin":
+                        confidence, sampled = sample_tokens(
+                            mask_logits,
+                            temperature=temperature,
+                            top_p=top_p,
+                            top_k=top_k,
+                            confidence_type="margin",
+                        )
+                    elif alg == "entropy":
+                        confidence, sampled = sample_tokens(
+                            mask_logits,
+                            temperature=temperature,
+                            top_p=top_p,
+                            top_k=top_k,
+                            confidence_type="neg_entropy",
+                        )
+                    else:
+                        raise RuntimeError(
+                            f"Unknown alg: {alg!r}. Choose from 'maskgit_plus', 'topk_margin', 'entropy'."
+                        )
+
+                    current_block = x[:, current_block_start:current_block_end]
+                    masked_confidence = torch.zeros(
+                        current_block.shape,
+                        dtype=logits.dtype,
+                        device=current_block.device,
+                    )
+                    masked_confidence[mask_index_block] = confidence
+
+                    transfer_index = select_threshold_transfer_mask(
+                        masked_confidence=masked_confidence,
+                        mask_index_block=mask_index_block,
+                        threshold=confidence_threshold,
+                    )
+
+                    selected_mask = mask_index_block & transfer_index
+                    if selected_mask.any():
+                        current_block[selected_mask] = sampled[
+                            selected_mask[mask_index_block]
+                        ]
+                else:
+                    t = timesteps[step_idx]
+                    s = timesteps[step_idx + 1]
+
+                    if alg == "origin":
+                        p_transfer = (
+                            1 - s / t if step_idx < steps_per_block - 1 else 1.0
+                        )
+                        # Start from current block state (not all-mask) so previously
+                        # unmasked tokens are preserved across denoising steps.
+                        current_block = x[
+                            :, current_block_start:current_block_end
+                        ].clone()
+                        masked_flat = current_block[
+                            mask_index_block
+                        ]  # 1-D, len = n_masked
+                        transfer = (
+                            torch.rand(masked_flat.shape[0], device=x.device)
+                            < p_transfer
+                        )
+                        _, sampled = sample_tokens(
+                            mask_logits[transfer],
+                            temperature=temperature,
+                            top_p=top_p,
+                            top_k=top_k,
+                        )
+                        masked_flat[transfer] = sampled
+                        current_block[mask_index_block] = masked_flat
+                        x[:, current_block_start:current_block_end] = current_block
+                    else:
+                        if alg == "maskgit_plus":
+                            confidence, sampled = sample_tokens(
+                                mask_logits,
+                                temperature=temperature,
+                                top_p=top_p,
+                                top_k=top_k,
+                                confidence_type="max_prob",
+                            )
+                        elif alg == "topk_margin":
+                            confidence, sampled = sample_tokens(
+                                mask_logits,
+                                temperature=temperature,
+                                top_p=top_p,
+                                top_k=top_k,
+                                confidence_type="margin",
+                            )
+                        elif alg == "entropy":
+                            confidence, sampled = sample_tokens(
+                                mask_logits,
+                                temperature=temperature,
+                                top_p=top_p,
+                                top_k=top_k,
+                                confidence_type="neg_entropy",
+                            )
+                        else:
+                            raise RuntimeError(
+                                f"Unknown alg: {alg!r}. Choose from 'origin', 'maskgit_plus', 'topk_margin', 'entropy'."
+                            )
+
+                        num_mask_token = (
+                            mask_index_block.sum() / mask_index_block.shape[0]
+                        )
+                        n_transfer = (
+                            int(num_mask_token * (1 - s / t))
+                            if step_idx < steps_per_block - 1
+                            else int(num_mask_token)
+                        )
+                        full_confidence = torch.full_like(
+                            x[:, current_block_start:current_block_end],
+                            -torch.inf,
+                            dtype=logits.dtype,
+                        )
+                        full_confidence[mask_index_block] = confidence
+
+                        if n_transfer > 0:
+                            if alg_temp is None or alg_temp == 0:
+                                _, transfer_index = torch.topk(
+                                    full_confidence, n_transfer
+                                )
+                            else:
+                                full_confidence = full_confidence / alg_temp
+                                full_confidence = F.softmax(full_confidence, dim=-1)
+                                transfer_index = torch.multinomial(
+                                    full_confidence, num_samples=n_transfer
+                                )
+
+                            sampled_block = torch.full_like(
+                                x[:, current_block_start:current_block_end],
+                                mask_token_id,
+                                dtype=torch.long,
+                            )
+                            sampled_block[mask_index_block] = sampled
+                            row_idx = (
+                                torch.arange(x.size(0), device=x.device)
+                                .unsqueeze(1)
+                                .expand_as(transfer_index)
+                            )
+                            x[:, current_block_start:current_block_end][
+                                row_idx, transfer_index
+                            ] = sampled_block[row_idx, transfer_index]
+
+                global_step += 1
+                if stream_callback is not None:
+                    try:
+                        stream_callback(global_step, total_steps, x.detach().clone())
+                    except Exception as _cb_exc:
+                        logger.warning(
+                            "stream_callback raised at step %d: %s",
+                            global_step,
+                            _cb_exc,
+                        )
+                if step_callback is not None:
+                    try:
+                        step_callback(global_step, total_steps)
+                    except Exception as _cb_exc:
+                        logger.warning(
+                            "step_callback raised at step %d: %s", global_step, _cb_exc
+                        )
+                step_idx += 1
+
+        if return_dict_out:
+            return MaskedDiffusionModelOutput(sequences=x, history=None)
+        return x
+
+
+__all__ = [
+    "MaskedDiffusionGenerationConfig",
+    "MaskedDiffusionGenerationMixin",
+    "MaskedDiffusionModelOutput",
+    "sample_tokens",
+    "top_p_logits",
+    "top_k_logits",
+    "prepare_for_sampling",
+]

--- a/unturtle/models/generation/masked_diffusion_block_mixin.py
+++ b/unturtle/models/generation/masked_diffusion_block_mixin.py
@@ -1,0 +1,458 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared masked-diffusion block generation mixin (block-decode + MDLM + BD3LM).
+
+MaskedDiffusionBlockGenerationMixin inherits both BlockDecodeMixin (Fast-dLLM KV-cache block-decode
+for use_cache=True) and MaskedDiffusionGenerationMixin (standard MDLM generation).
+BD3LM block-diffusion generation is added via _sample_block_diffusion()
+(use_block_diffusion=True).
+"""
+
+import math
+from types import SimpleNamespace
+
+import torch
+from transformers.utils import logging
+
+from unturtle.models.generation.block_decode_mixin import BlockDecodeMixin
+from unturtle.models.generation.diffusion_generation_utils import (
+    MaskedDiffusionGenerationConfig,
+    MaskedDiffusionGenerationMixin,
+    MaskedDiffusionModelOutput,
+)
+
+logger = logging.get_logger(__name__)
+
+
+class MaskedDiffusionBlockGenerationConfig(MaskedDiffusionGenerationConfig):
+    """Generation config for Tiny-A2D models (currently identical to the shared config)."""
+
+    pass
+
+
+def _snapshot_prefix_cache(past_key_values):
+    if past_key_values is None:
+        return None
+    if isinstance(past_key_values, tuple):
+        return past_key_values
+    if hasattr(past_key_values, "layers"):
+        return tuple((layer.keys, layer.values) for layer in past_key_values.layers)
+    raise TypeError(
+        f"Unsupported cache type for BD3LM prefix snapshot: {type(past_key_values).__name__}"
+    )
+
+
+def _rewrap_prefix_cache(past_key_values, device):
+    if past_key_values is None:
+        return None
+
+    from unturtle.models.generation.cache_utils import tuple_to_cache
+
+    if isinstance(past_key_values, tuple):
+        return tuple_to_cache(past_key_values, device)
+    return past_key_values
+
+
+class MaskedDiffusionBlockGenerationMixin(
+    BlockDecodeMixin, MaskedDiffusionGenerationMixin
+):
+    """Generation mixin for Tiny-A2D models.
+
+    Inherits:
+    - BlockDecodeMixin: Fast-dLLM style block-decode KV-cache generation
+      (activated via ``use_cache=True``). Resolves #182 — Tiny-A2D now uses the
+      same ``_block_decode_loop`` as LLaDA and Dream.
+    - MaskedDiffusionGenerationMixin: standard MDLM no-cache generation loop.
+
+    BD3LM block-diffusion generation (``use_block_diffusion=True``) is
+    provided by :meth:`_sample_block_diffusion`.
+    """
+
+    def _model_forward_with_cache(
+        self,
+        input_ids,
+        attention_mask,
+        past_key_values,
+        use_cache: bool,
+        replace_position=None,
+    ):
+        """Standard HF forward with cache — required by BlockDecodeMixin.
+
+        ``replace_position`` is accepted for API compatibility but ignored:
+        Tiny-A2D models (LLaMA/Qwen) do not implement dual-cache replace_position.
+
+        Tuple caches (returned by ``trim_kv_cache``) are converted to
+        ``DynamicCache`` before the forward call because HF LLaMA/Qwen
+        models expect a cache object with ``.get_seq_length()``.
+        """
+        # Convert raw tuple cache to DynamicCache (HF LLaMA/Qwen requirement).
+        # trim_kv_cache returns 2-tuples per layer; HF models need a DynamicCache
+        # with .get_seq_length(), so we convert before the forward call.
+        if isinstance(past_key_values, tuple) and len(past_key_values) > 0:
+            from unturtle.models.generation.cache_utils import tuple_to_cache
+
+            past_key_values = tuple_to_cache(past_key_values, input_ids.device)
+
+        outputs = self(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+        )
+        # Return DynamicCache as-is so trim_kv_cache can use the .layers interface.
+        # BlockDecodeMixin only stores and trims the cache — it never iterates it
+        # as a tuple, so we can keep the native DynamicCache format here.
+        cache = outputs.past_key_values
+        return SimpleNamespace(logits=outputs.logits, past_key_values=cache)
+
+    def _sample_with_cache(
+        self,
+        input_ids,
+        attention_mask,
+        generation_config: "MaskedDiffusionGenerationConfig",
+    ):
+        """Block-decode generation with KV cache for Tiny-A2D (delegates to BlockDecodeMixin).
+
+        Resolves #182 — Tiny-A2D now uses the same ``_block_decode_loop`` as LLaDA
+        and Dream instead of the previously duplicated ``_sample_with_cache``
+        implementation in ``MaskedDiffusionGenerationMixin``.
+        """
+        if getattr(generation_config, "use_replace_cache", False):
+            generation_config.use_replace_cache = False
+
+        block_decode_output = self._block_decode_loop(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            generation_config=generation_config,
+        )
+        timing = None
+        if isinstance(block_decode_output, tuple):
+            x, timing = block_decode_output
+        else:
+            x = block_decode_output
+
+        if generation_config.return_dict:
+            return MaskedDiffusionModelOutput(sequences=x, history=None, timing=timing)
+        return x
+
+    @torch.no_grad()
+    def _sample_block_diffusion(
+        self,
+        input_ids: torch.Tensor,
+        generation_config: "MaskedDiffusionGenerationConfig",
+    ) -> torch.Tensor:
+        """BD3LM block-diffusion generation loop.
+
+        Generates tokens block-by-block using a bidirectional block-causal
+        attention mask (``prepare_for_sampling``).  This is the correct
+        generation algorithm for Tiny-A2D models — causal AR models converted to
+        bidirectional masked diffusion.
+
+        Called by :meth:`MaskedDiffusionGenerationMixin._sample` when
+        ``generation_config.use_block_diffusion=True``.
+        """
+        from unturtle.models.generation.diffusion_generation_utils import (
+            _add_gumbel_noise,
+            _diffusion_step_block,
+            _get_num_transfer_tokens,
+            prepare_for_sampling,
+        )
+
+        block_size = generation_config.bd3lm_block_size
+        steps = generation_config.steps
+        max_new_tokens = generation_config.max_new_tokens
+        temperature = generation_config.temperature
+        cfg_scale = generation_config.cfg_scale
+        right_shift_logits = generation_config.right_shift_logits
+        step_callback = generation_config.step_callback
+        stream_callback = generation_config.stream_callback
+
+        # Resolve special token IDs (config → model config fallback)
+        mask_id = generation_config.mask_token_id
+        if mask_id is None:
+            mask_id = getattr(self.config, "mask_token_id", None)
+        if mask_id is None:
+            raise ValueError(
+                "`mask_token_id` must be set in `generation_config` or `model.config` "
+                "before calling `diffusion_generate(use_block_diffusion=True)`."
+            )
+
+        pad_id = generation_config.pad_token_id
+        if pad_id is None:
+            pad_id = getattr(self.config, "pad_token_id", None)
+        if pad_id is None:
+            raise ValueError(
+                "`pad_token_id` must be set in `generation_config` or `model.config` "
+                "before calling `diffusion_generate(use_block_diffusion=True)`."
+            )
+
+        eos_id = generation_config.eos_token_id
+        if eos_id is None:
+            eos_id = getattr(self.config, "eos_token_id", None)
+
+        device = input_ids.device
+        B, prompt_len = input_ids.shape
+
+        if max_new_tokens is None:
+            if generation_config.max_length is None:
+                raise ValueError(
+                    "`use_block_diffusion=True` requires `max_new_tokens` or `max_length`."
+                )
+            max_new_tokens = generation_config.max_length - prompt_len
+
+        if max_new_tokens <= 0:
+            raise ValueError(
+                f"BD3LM generation requires positive generation length, got max_new_tokens={max_new_tokens}."
+            )
+
+        # Left-pad prompt to a multiple of block_size
+        padded_prompt_len = math.ceil(prompt_len / block_size) * block_size
+        prompt_left_pad = padded_prompt_len - prompt_len
+        x = torch.full((B, padded_prompt_len), pad_id, dtype=torch.long, device=device)
+        for b in range(B):
+            offset = padded_prompt_len - prompt_len
+            x[b, offset : offset + prompt_len] = input_ids[b]
+
+        # Track "given" tokens for CFG unconditional branch
+        unmasked_index = (x != mask_id) & (x != pad_id)
+
+        done = torch.zeros(B, dtype=torch.bool, device=device)
+
+        num_blocks = math.ceil(max_new_tokens / block_size)
+        steps_per_block = max(1, math.ceil(steps / num_blocks))
+        total_steps = num_blocks * steps_per_block
+
+        generated = 0
+        global_step = 0
+
+        for _ in range(num_blocks):
+            if done.all():
+                break
+
+            cur_block_len = min(block_size, max_new_tokens - generated)
+            if cur_block_len <= 0:
+                break
+
+            T_prefix = x.shape[1]
+
+            # Build block-causal attention mask + logical position IDs for prefix
+            prefix_attn, prefix_pos = prepare_for_sampling(x, block_size, pad_id)
+
+            # Try to obtain KV cache for prefix; fall back to full-seq silently
+            cond_past = None
+            cond_prefix_last_logits = None
+            uncond_past = None
+            uncond_prefix_last_logits = None
+
+            try:
+                out_prefix = self(
+                    x,
+                    attention_mask=prefix_attn,
+                    position_ids=prefix_pos,
+                    use_cache=True,
+                )
+                if (
+                    hasattr(out_prefix, "past_key_values")
+                    and out_prefix.past_key_values is not None
+                ):
+                    cond_past = _snapshot_prefix_cache(out_prefix.past_key_values)
+                    cond_prefix_last_logits = out_prefix.logits[:, -1:, :]
+
+                if cfg_scale > 0.0:
+                    un_x = x.clone()
+                    un_x[unmasked_index] = mask_id
+                    out_un = self(
+                        un_x,
+                        attention_mask=prefix_attn,
+                        position_ids=prefix_pos,
+                        use_cache=True,
+                    )
+                    if (
+                        hasattr(out_un, "past_key_values")
+                        and out_un.past_key_values is not None
+                    ):
+                        uncond_past = _snapshot_prefix_cache(out_un.past_key_values)
+                        uncond_prefix_last_logits = out_un.logits[:, -1:, :]
+            except TypeError:
+                cond_past = None
+
+            # Append masked block
+            new_block = torch.full(
+                (B, cur_block_len), mask_id, dtype=torch.long, device=device
+            )
+            new_block[done] = pad_id
+            x = torch.cat([x, new_block], dim=1)
+            unmasked_index = torch.cat(
+                [
+                    unmasked_index,
+                    torch.zeros(B, cur_block_len, dtype=torch.bool, device=device),
+                ],
+                dim=1,
+            )
+
+            T_total = x.shape[1]
+            block_mask_index = x[:, T_prefix:T_total] == mask_id
+
+            num_transfer_tokens = _get_num_transfer_tokens(
+                block_mask_index, steps_per_block
+            )
+            effective_steps = num_transfer_tokens.shape[1]
+
+            full_attn, full_pos = prepare_for_sampling(x, block_size, pad_id)
+            attn_block = full_attn[:, :, T_prefix:T_total, :]
+            pos_block = full_pos[:, T_prefix:T_total]
+
+            use_kv_cache = cond_past is not None
+
+            for i_step in range(effective_steps):
+                x_block = x[:, T_prefix:T_total]
+                mask_block = x_block == mask_id
+
+                if not mask_block.any():
+                    break
+
+                if use_kv_cache:
+                    try:
+                        cond_out = self(
+                            x_block,
+                            attention_mask=attn_block,
+                            position_ids=pos_block,
+                            past_key_values=_rewrap_prefix_cache(
+                                cond_past, x_block.device
+                            ),
+                            use_cache=False,
+                        )
+                        cond_logits = cond_out.logits
+
+                        if cfg_scale > 0.0 and uncond_past is not None:
+                            uncond_out = self(
+                                x_block,
+                                attention_mask=attn_block,
+                                position_ids=pos_block,
+                                past_key_values=_rewrap_prefix_cache(
+                                    uncond_past, x_block.device
+                                ),
+                                use_cache=False,
+                            )
+                            logits_block = uncond_out.logits + (cfg_scale + 1.0) * (
+                                cond_logits - uncond_out.logits
+                            )
+                        else:
+                            logits_block = cond_logits
+
+                    except (TypeError, RuntimeError):
+                        use_kv_cache = False
+                        cond_past = None
+
+                if not use_kv_cache:
+                    full_attn_step, full_pos_step = prepare_for_sampling(
+                        x, block_size, pad_id
+                    )
+                    try:
+                        out = self(
+                            x, attention_mask=full_attn_step, position_ids=full_pos_step
+                        )
+                    except TypeError:
+                        out = self(x, attention_mask=full_attn_step)
+
+                    if right_shift_logits and T_prefix > 0:
+                        cond_prefix_last_logits = out.logits[
+                            :, T_prefix - 1 : T_prefix, :
+                        ]
+
+                    logits_block = out.logits[:, T_prefix:T_total, :]
+
+                    if cfg_scale > 0.0:
+                        un_x = x.clone()
+                        un_x[unmasked_index] = mask_id
+                        try:
+                            un_out = self(
+                                un_x,
+                                attention_mask=full_attn_step,
+                                position_ids=full_pos_step,
+                            )
+                        except TypeError:
+                            un_out = self(un_x, attention_mask=full_attn_step)
+                        un_logits = un_out.logits[:, T_prefix:T_total, :]
+                        if right_shift_logits and T_prefix > 0:
+                            uncond_prefix_last_logits = un_out.logits[
+                                :, T_prefix - 1 : T_prefix, :
+                            ]
+                        logits_block = un_logits + (cfg_scale + 1.0) * (
+                            logits_block - un_logits
+                        )
+
+                # Dream-compat right-shift
+                if right_shift_logits and cond_prefix_last_logits is not None:
+                    if cfg_scale > 0.0 and uncond_prefix_last_logits is not None:
+                        prefix_last = uncond_prefix_last_logits + (cfg_scale + 1.0) * (
+                            cond_prefix_last_logits - uncond_prefix_last_logits
+                        )
+                    else:
+                        prefix_last = cond_prefix_last_logits
+                    shifted = torch.empty_like(logits_block)
+                    shifted[:, 0:1, :] = prefix_last
+                    shifted[:, 1:, :] = logits_block[:, :-1, :]
+                    logits_block = shifted
+
+                x_block_updated = _diffusion_step_block(
+                    logits=logits_block,
+                    x_block=x_block,
+                    mask_block=mask_block,
+                    num_transfer_step=num_transfer_tokens[:, i_step],
+                    temperature=temperature,
+                )
+                x[:, T_prefix:T_total] = x_block_updated
+                global_step += 1
+
+                if stream_callback is not None:
+                    try:
+                        stream_callback(
+                            global_step,
+                            total_steps,
+                            x[:, prompt_left_pad:].detach().clone(),
+                        )
+                    except Exception as _cb_exc:
+                        logger.warning(
+                            "stream_callback raised at step %d: %s",
+                            global_step,
+                            _cb_exc,
+                        )
+
+                if step_callback is not None:
+                    try:
+                        step_callback(global_step, total_steps)
+                    except Exception as _cb_exc:
+                        logger.warning(
+                            "step_callback raised at step %d: %s", global_step, _cb_exc
+                        )
+
+            if eos_id is not None:
+                eos_in_block = (x[:, T_prefix:T_total] == eos_id).any(dim=1)
+                done = done | eos_in_block
+
+            generated += cur_block_len
+
+        if prompt_left_pad > 0:
+            x = x[:, prompt_left_pad:]
+
+        return x
+
+
+__all__ = [
+    "MaskedDiffusionBlockGenerationConfig",
+    "MaskedDiffusionBlockGenerationMixin",
+    "MaskedDiffusionModelOutput",
+]

--- a/unturtle/models/generation/sampler.py
+++ b/unturtle/models/generation/sampler.py
@@ -1,0 +1,80 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Decoding-algorithm selection for Unturtle dLLM generation.
+
+Makes the decoding algorithm an explicit, first-class choice instead of an implicit
+combination of ``MaskedDiffusionGenerationConfig`` flags. Each named algorithm maps to the
+flag set that the existing ``diffusion_generate`` dispatch already understands — so this is
+pure *selection*, with no generation logic of its own.
+
+Algorithms (discrete masked diffusion):
+  - ``mdlm``         : plain MDLM denoising loop
+  - ``block_decode`` : Fast-dLLM KV-cache block decode (parallel decode is an option within)
+  - ``bd3lm``        : BD3LM block diffusion
+
+The registry is intentionally open: continuous-diffusion algorithms (e.g. ``continuous_*``)
+would be added to a separate table when continuous diffusion LMs land. The current loops are
+discrete-masked-only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Discrete masked-diffusion algorithms -> the diffusion_generate flag set each selects.
+DISCRETE_ALGORITHMS: dict[str, dict[str, bool]] = {
+    "mdlm": {"use_cache": False, "use_block_diffusion": False},
+    "block_decode": {"use_cache": True, "use_block_diffusion": False},
+    "bd3lm": {"use_cache": False, "use_block_diffusion": True},
+}
+
+
+def algorithm_to_flags(algorithm: str) -> dict[str, bool]:
+    """Return the diffusion_generate flag set for a named discrete algorithm."""
+    try:
+        return dict(DISCRETE_ALGORITHMS[algorithm])
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown decoding algorithm {algorithm!r}. "
+            f"Supported: {sorted(DISCRETE_ALGORITHMS)}."
+        ) from exc
+
+
+def _supports_block_decode(model: Any) -> bool:
+    """True if the model implements the Fast-dLLM block-decode cache hook."""
+    return callable(getattr(model, "_model_forward_with_cache", None))
+
+
+def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> str:
+    """Resolve ``algorithm`` to a concrete discrete algorithm name.
+
+    ``auto`` picks the fastest discrete path the model supports:
+      - BD3LM if requested,
+      - else block-decode (Fast-dLLM) when the model supports the cache hook,
+      - else plain MDLM.
+    An explicit algorithm name is validated and returned as-is.
+    """
+    if algorithm == "auto":
+        if bd3lm_requested:
+            return "bd3lm"
+        if _supports_block_decode(model):
+            return "block_decode"
+        return "mdlm"
+    if algorithm not in DISCRETE_ALGORITHMS:
+        raise ValueError(
+            f"Unknown decoding algorithm {algorithm!r}. "
+            f"Supported: {sorted(DISCRETE_ALGORITHMS)} (or 'auto')."
+        )
+    return algorithm


### PR DESCRIPTION
Closes #5

## 概要
クリーン移植 Task 3。全バックボーンが依存する共有生成インフラを移植。

- `unturtle/models/generation/`（BlockKVCache / cache_utils / block_decode_mixin / masked_diffusion_block_mixin / diffusion_generation_utils / sampler registry）を legacy からバイト一致で移植（diff -r 検証済み）
- `unturtle/models/__init__.py` は generation のみの最小版を新規作成 — 非推奨エイリアス・legacy `a2d-*` register なし。backbones/conversion の export は Task 4/5 で追加（docstring に明記）
- generation 内の他モジュール依存はすべて遅延 import であることを確認（backbones より先に入れられる根拠）

## テスト
- tests/models/{test_cache,test_sampler}.py 先行コピー → 本体後 **19 passed**（CUDA 上、本体修正ゼロ）
- ruff グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)