### PR TITLE
✨ feat(backbones): port llada / dream / modernbert native backbones (#7)

### DIFF
--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -1,0 +1,697 @@
+"""Tests for Dream diffusion language models.
+
+CPU-only tests covering config instantiation, model instantiation with
+random weights, and forward pass shapes. No pretrained checkpoints required.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+class TestDreamConfig:
+    def test_config_default_fields(self):
+        from unturtle.models.backbones.dream import DreamConfig
+
+        config = DreamConfig()
+        assert config.vocab_size == 151936
+        assert config.hidden_size == 4096
+        assert config.num_hidden_layers == 32
+
+    def test_config_custom_values(self):
+        from unturtle.models.backbones.dream import DreamConfig
+
+        config = DreamConfig(
+            vocab_size=10000,
+            hidden_size=256,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        )
+        assert config.vocab_size == 10000
+        assert config.hidden_size == 256
+        assert config.num_hidden_layers == 4
+
+    def test_config_has_mask_token_id(self):
+        from unturtle.models.backbones.dream import DreamConfig
+
+        config = DreamConfig()
+        assert hasattr(config, "mask_token_id")
+        assert config.mask_token_id == 151666
+
+    def test_config_use_cache_false(self):
+        """Dream configs have use_cache=False by design."""
+        from unturtle.models.backbones.dream import DreamConfig
+
+        config = DreamConfig()
+        assert config.use_cache is False
+
+
+class TestDreamModel:
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.backbones.dream import DreamConfig
+
+        return DreamConfig(
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+            pad_token_id=0,
+            mask_token_id=1,
+        )
+
+    def test_model_instantiation(self, config):
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu()
+        assert model is not None
+
+    def test_forward_logits_shape(self, config):
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu()
+        model.eval()
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+
+    def test_forward_backward(self, config):
+        """Gradients flow through Dream."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu()
+        B, L = 2, 8
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        labels = torch.randint(0, config.vocab_size, (B, L))
+        labels[:, ::2] = -100
+        out = model(input_ids=input_ids, labels=labels)
+        assert out.loss is not None
+        assert not torch.isnan(out.loss)
+        out.loss.backward()
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        assert len(grads) > 0
+
+    def test_forward_use_cache_returns_past_key_values(self, config):
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        input_ids = torch.randint(0, config.vocab_size, (2, 8))
+        with torch.no_grad():
+            out = model(input_ids=input_ids, use_cache=True)
+        assert out.past_key_values is not None
+        assert len(out.past_key_values) == config.num_hidden_layers
+
+
+class TestDreamGenerationUtils:
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.backbones.dream import DreamConfig
+
+        return DreamConfig(
+            vocab_size=64,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+            pad_token_id=0,
+            mask_token_id=1,
+            use_cache=False,
+        )
+
+    def test_generation_config_creation(self):
+        from unturtle.models.backbones.dream import DreamGenerationConfig
+
+        gen_config = DreamGenerationConfig()
+        assert gen_config is not None
+
+    def test_generation_mixin_importable(self):
+        from unturtle.models.backbones.dream import DreamGenerationMixin
+
+        assert DreamGenerationMixin is not None
+        assert hasattr(DreamGenerationMixin, "diffusion_generate")
+
+    def test_cache_block_decode_trim_mode(self, config):
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            block_length=2,
+            use_cache=True,
+            use_replace_cache=False,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            out = model.diffusion_generate(
+                inputs=inputs, generation_config=generation_config
+            )
+        assert out.shape == (1, 8)
+        assert not torch.any(out == config.mask_token_id)
+
+    def test_cache_block_decode_dual_cache_mode(self, config):
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5], [6, 7, 8, 9]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            block_length=2,
+            use_cache=True,
+            use_replace_cache=True,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            out = model.diffusion_generate(
+                inputs=inputs, generation_config=generation_config
+            )
+        assert out.shape == (2, 8)
+        assert not torch.any(out == config.mask_token_id)
+
+    def test_forward_preserves_additive_attention_mask(self, config):
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        input_ids = torch.randint(0, config.vocab_size, (1, 6))
+        additive_mask = torch.zeros(1, 1, 6, 6)
+        additive_mask[:, :, :, -1] = torch.finfo(torch.float32).min
+        with torch.no_grad():
+            out = model(input_ids=input_ids, attention_mask=additive_mask)
+        assert out.logits.shape == (1, 6, config.vocab_size)
+        assert not torch.isnan(out.logits).any()
+
+    def test_forward_accepts_3d_additive_attention_mask_with_attentions(self, config):
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        input_ids = torch.randint(0, config.vocab_size, (1, 6))
+        additive_mask = torch.zeros(1, 6, 6)
+        additive_mask[:, :, -1] = torch.finfo(torch.float32).min
+        with torch.no_grad():
+            out = model(
+                input_ids=input_ids,
+                attention_mask=additive_mask,
+                output_attentions=True,
+            )
+        assert out.logits.shape == (1, 6, config.vocab_size)
+        assert out.attentions is not None
+        assert not torch.isnan(out.logits).any()
+
+    def test_cache_block_decode_accepts_additive_attention_mask(self, config):
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        additive_mask = torch.zeros(1, 1, 8, 8)
+        additive_mask[:, :, :, 3] = torch.finfo(torch.float32).min
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            block_length=2,
+            use_cache=True,
+            use_replace_cache=True,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            out = model.diffusion_generate(
+                inputs=inputs,
+                attention_mask=additive_mask,
+                generation_config=generation_config,
+            )
+        assert out.shape == (1, 8)
+        assert not torch.any(out == config.mask_token_id)
+
+    def test_cache_path_preserves_shifted_logits(self, config):
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        class SpyDreamModel(DreamModel):
+            def __init__(self, cfg):
+                super().__init__(cfg)
+                self.seen_logits = None
+
+            def _postprocess_block_decode_logits(self, logits):
+                shifted = super()._postprocess_block_decode_logits(logits)
+                self.seen_logits = shifted
+                return shifted
+
+        model = SpyDreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=2,
+            steps=2,
+            block_length=2,
+            use_cache=True,
+            use_replace_cache=False,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            _ = model.diffusion_generate(
+                inputs=inputs, generation_config=generation_config
+            )
+        assert model.seen_logits is not None
+
+    def test_dual_cache_query_start_includes_previous_token(self, config):
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        class SpyDreamModel(DreamModel):
+            def __init__(self, cfg):
+                super().__init__(cfg)
+                self.forward_lengths = []
+
+            def _model_forward_with_cache(self, *args, **kwargs):
+                input_ids = kwargs["input_ids"]
+                self.forward_lengths.append(input_ids.shape[1])
+                return super()._model_forward_with_cache(*args, **kwargs)
+
+        model = SpyDreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            block_length=2,
+            use_cache=True,
+            use_replace_cache=True,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            _ = model.diffusion_generate(
+                inputs=inputs, generation_config=generation_config
+            )
+
+        assert 3 in model.forward_lengths
+
+
+class TestDreamFastRoPE:
+    """Tests for DreamAttention_fast_forward Triton RoPE path."""
+
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.backbones.dream import DreamConfig
+
+        return DreamConfig(
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+            pad_token_id=0,
+            mask_token_id=1,
+        )
+
+    def test_fast_forward_importable(self):
+        from unturtle.models.backbones.dream.modeling_dream import (
+            DreamAttention_fast_forward,
+        )
+
+        assert callable(DreamAttention_fast_forward)
+
+    def test_cpu_parity_simple(self, config):
+        """DreamAttention_fast_forward CPU fallback matches original forward."""
+        import types
+
+        from unturtle.models.backbones.dream import DreamModel
+        from unturtle.models.backbones.dream.modeling_dream import (
+            DreamAttention_fast_forward,
+        )
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+
+        # Reference output (original forward)
+        with torch.no_grad():
+            ref_out = model(input_ids=input_ids)
+
+        # Install stubs and fast forward
+        for module in model.modules():
+            if (
+                hasattr(module, "q_proj")
+                and hasattr(module, "o_proj")
+                and not hasattr(module, "apply_qkv")
+            ):
+                from unturtle.fast_diffusion_model import (
+                    _original_apply_o,
+                    _original_apply_qkv,
+                )
+
+                module.apply_qkv = _original_apply_qkv
+                module.apply_o = _original_apply_o
+
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                DreamAttention_fast_forward, layer.self_attn
+            )
+
+        with torch.no_grad():
+            fast_out = model(input_ids=input_ids)
+
+        assert torch.allclose(ref_out.logits, fast_out.logits, atol=1e-5), (
+            f"CPU logits mismatch: max_diff={(ref_out.logits - fast_out.logits).abs().max().item():.2e}"
+        )
+
+    def test_cpu_parity_reset_position_ids(self, config):
+        """CPU fallback is numerically stable with non-monotonic position_ids (packed pattern)."""
+        import types
+
+        from unturtle.models.backbones.dream import DreamModel
+        from unturtle.models.backbones.dream.modeling_dream import (
+            DreamAttention_fast_forward,
+            _apply_dream_rope,
+        )
+
+        torch.manual_seed(1)
+        model = DreamModel(config).cpu().eval()
+
+        # Install stubs
+        for module in model.modules():
+            if (
+                hasattr(module, "q_proj")
+                and hasattr(module, "o_proj")
+                and not hasattr(module, "apply_qkv")
+            ):
+                from unturtle.fast_diffusion_model import (
+                    _original_apply_o,
+                    _original_apply_qkv,
+                )
+
+                module.apply_qkv = _original_apply_qkv
+                module.apply_o = _original_apply_o
+
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                DreamAttention_fast_forward, layer.self_attn
+            )
+
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        # Reset position_ids: row 0 = [0..7, 0..7], row 1 = [0..15]
+        position_ids = torch.cat(
+            [
+                torch.arange(L // 2).repeat(2).unsqueeze(0),
+                torch.arange(L).unsqueeze(0),
+            ],
+            dim=0,
+        )
+
+        with torch.no_grad():
+            out = model(input_ids=input_ids, position_ids=position_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+        assert not torch.isnan(out.logits).any()
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton RoPE requires CUDA"
+    )
+    def test_cuda_parity_vs_cpu(self, config):
+        """CUDA fast_rope_embedding output matches CPU apply_rotary_pos_emb.
+
+        DreamRotaryEmbedding returns cos/sin via cat(freqs, freqs) so the
+        first and second halves are identical — this is the format that
+        fast_rope_embedding requires (it only reads head_dim//2 elements).
+        """
+        from unturtle.models.backbones.dream.modeling_dream import _apply_dream_rope
+
+        torch.manual_seed(42)
+        B, n_heads, L, head_dim = 2, 4, 16, 32
+
+        # Simulate DreamRotaryEmbedding output: cat(freqs, freqs) pattern
+        freqs = torch.randn(B, L, head_dim // 2)
+        cos = torch.cat([freqs.cos(), freqs.cos()], dim=-1)  # (B, L, head_dim)
+        sin = torch.cat([freqs.sin(), freqs.sin()], dim=-1)
+
+        q = torch.randn(B, n_heads, L, head_dim)
+        k = torch.randn(B, n_heads, L, head_dim)
+
+        # CPU reference (clone: fast_rope_embedding is in-place on CUDA)
+        q_cpu, k_cpu = _apply_dream_rope(q.clone(), k.clone(), cos, sin, B, L)
+
+        # CUDA fast path
+        q_cuda, k_cuda = _apply_dream_rope(
+            q.cuda().clone(), k.cuda().clone(), cos.cuda(), sin.cuda(), B, L
+        )
+
+        assert torch.allclose(q_cpu, q_cuda.cpu(), atol=1e-4), (
+            f"Q mismatch: max_diff={(q_cpu - q_cuda.cpu()).abs().max().item():.2e}"
+        )
+        assert torch.allclose(k_cpu, k_cuda.cpu(), atol=1e-4), (
+            f"K mismatch: max_diff={(k_cpu - k_cuda.cpu()).abs().max().item():.2e}"
+        )
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton RoPE requires CUDA"
+    )
+    def test_cuda_no_double_index_reset_positions(self, config):
+        """CUDA path with reset position_ids produces valid output (no NaN, correct shape).
+
+        cos/sin use the cat(freqs, freqs) pattern from DreamRotaryEmbedding
+        and are pre-indexed per batch row to simulate packed/reset positions.
+        """
+        from unturtle.models.backbones.dream.modeling_dream import _apply_dream_rope
+
+        torch.manual_seed(7)
+        B, n_heads, L, head_dim = 2, 4, 8, 32
+
+        q = torch.randn(B, n_heads, L, head_dim).cuda()
+        k = torch.randn(B, n_heads, L, head_dim).cuda()
+
+        # DreamRotaryEmbedding-style cos/sin: cat(freqs, freqs) pattern
+        freqs = torch.randn(B, L, head_dim // 2).cuda()
+        cos = torch.cat([freqs.cos(), freqs.cos()], dim=-1)
+        sin = torch.cat([freqs.sin(), freqs.sin()], dim=-1)
+
+        # Clone before passing to each path (fast_rope_embedding is in-place)
+        q_cuda_in = q.clone()
+        k_cuda_in = k.clone()
+        q_cpu_in = q.cpu().clone()
+        k_cpu_in = k.cpu().clone()
+
+        with torch.no_grad():
+            q_out, k_out = _apply_dream_rope(q_cuda_in, k_cuda_in, cos, sin, B, L)
+            q_cpu, k_cpu = _apply_dream_rope(
+                q_cpu_in, k_cpu_in, cos.cpu(), sin.cpu(), B, L
+            )
+
+        assert q_out.shape == q.shape
+        assert k_out.shape == k.shape
+        assert not torch.isnan(q_out).any()
+        assert not torch.isnan(k_out).any()
+
+        assert torch.allclose(q_cpu, q_out.cpu(), atol=1e-4), (
+            f"CUDA/CPU parity failed: max_diff={(q_cpu - q_out.cpu()).abs().max().item():.2e}"
+        )
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton RoPE requires CUDA"
+    )
+    def test_cuda_parity_with_actual_reset_position_ids(self, config):
+        """CUDA fast path matches CPU for pre-indexed cos/sin derived from reset position_ids.
+
+        This is the exact failure mode from CLAUDE.md gotcha #16/#17:
+        position_ids are non-monotonic (packed/reset), cos/sin are pre-indexed
+        from those ids, and we must not double-index inside fast_rope_embedding.
+        """
+        from unturtle.models.backbones.dream import DreamConfig
+        from unturtle.models.backbones.dream.modeling_dream import (
+            DreamRotaryEmbedding,
+            _apply_dream_rope,
+        )
+
+        torch.manual_seed(3)
+        B, n_heads, L, head_dim = 2, 4, 8, 32
+        n_kv_heads = 4
+
+        # Build reset position_ids: batch 0 = [0,1,2,3,0,1,2,3], batch 1 = [0,1,2,3,4,5,6,7]
+        position_ids = torch.stack(
+            [
+                torch.tensor([0, 1, 2, 3, 0, 1, 2, 3]),
+                torch.arange(L),
+            ]
+        )
+
+        # Derive cos/sin via DreamRotaryEmbedding (same as model would do)
+        cfg = DreamConfig(
+            vocab_size=1000,
+            hidden_size=head_dim * n_heads,
+            intermediate_size=256,
+            num_hidden_layers=1,
+            num_attention_heads=n_heads,
+            num_key_value_heads=n_kv_heads,
+            max_position_embeddings=128,
+            pad_token_id=0,
+            mask_token_id=1,
+        )
+        rotary = DreamRotaryEmbedding(config=cfg)
+        dummy_x = torch.randn(B, L, cfg.hidden_size)
+        cos, sin = rotary(dummy_x, position_ids)  # pre-indexed (B, L, head_dim)
+
+        q = torch.randn(B, n_heads, L, head_dim)
+        k = torch.randn(B, n_kv_heads, L, head_dim)
+
+        # CPU reference
+        q_cpu, k_cpu = _apply_dream_rope(q.clone(), k.clone(), cos, sin, B, L)
+
+        # CUDA fast path
+        q_cuda, k_cuda = _apply_dream_rope(
+            q.cuda().clone(), k.cuda().clone(), cos.cuda(), sin.cuda(), B, L
+        )
+
+        assert torch.allclose(q_cpu, q_cuda.cpu(), atol=1e-4), (
+            f"Q mismatch (reset pos_ids): max_diff={(q_cpu - q_cuda.cpu()).abs().max().item():.2e}"
+        )
+        assert torch.allclose(k_cpu, k_cuda.cpu(), atol=1e-4), (
+            f"K mismatch (reset pos_ids): max_diff={(k_cpu - k_cuda.cpu()).abs().max().item():.2e}"
+        )
+
+    def test_gqa_parity(self, config):
+        """_apply_dream_rope works correctly with GQA (n_kv_heads < n_heads)."""
+        from unturtle.models.backbones.dream import DreamConfig
+        from unturtle.models.backbones.dream.modeling_dream import _apply_dream_rope
+
+        torch.manual_seed(5)
+        B, n_heads, n_kv_heads, L, head_dim = 2, 8, 2, 16, 32
+
+        freqs = torch.randn(B, L, head_dim // 2)
+        cos = torch.cat([freqs.cos(), freqs.cos()], dim=-1)
+        sin = torch.cat([freqs.sin(), freqs.sin()], dim=-1)
+
+        q = torch.randn(B, n_heads, L, head_dim)
+        k = torch.randn(B, n_kv_heads, L, head_dim)
+
+        q_out, k_out = _apply_dream_rope(q.clone(), k.clone(), cos, sin, B, L)
+
+        assert q_out.shape == (B, n_heads, L, head_dim)
+        assert k_out.shape == (B, n_kv_heads, L, head_dim)
+        assert not torch.isnan(q_out).any()
+        assert not torch.isnan(k_out).any()
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton RoPE requires CUDA"
+    )
+    def test_gqa_cuda_parity(self, config):
+        """CUDA and CPU agree for GQA (n_kv_heads < n_heads)."""
+        from unturtle.models.backbones.dream.modeling_dream import _apply_dream_rope
+
+        torch.manual_seed(6)
+        B, n_heads, n_kv_heads, L, head_dim = 2, 8, 2, 16, 32
+
+        freqs = torch.randn(B, L, head_dim // 2)
+        cos = torch.cat([freqs.cos(), freqs.cos()], dim=-1)
+        sin = torch.cat([freqs.sin(), freqs.sin()], dim=-1)
+
+        q = torch.randn(B, n_heads, L, head_dim)
+        k = torch.randn(B, n_kv_heads, L, head_dim)
+
+        q_cpu, k_cpu = _apply_dream_rope(q.clone(), k.clone(), cos, sin, B, L)
+        q_cuda, k_cuda = _apply_dream_rope(
+            q.cuda().clone(), k.cuda().clone(), cos.cuda(), sin.cuda(), B, L
+        )
+
+        assert torch.allclose(q_cpu, q_cuda.cpu(), atol=1e-4), (
+            f"GQA Q mismatch: max_diff={(q_cpu - q_cuda.cpu()).abs().max().item():.2e}"
+        )
+        assert torch.allclose(k_cpu, k_cuda.cpu(), atol=1e-4), (
+            f"GQA K mismatch: max_diff={(k_cpu - k_cuda.cpu()).abs().max().item():.2e}"
+        )
+
+    def test_position_embeddings_none_fallback(self, config):
+        """DreamAttention_fast_forward computes RoPE internally when position_embeddings=None."""
+        import types
+
+        from unturtle.models.backbones.dream import DreamModel
+        from unturtle.models.backbones.dream.modeling_dream import (
+            DreamAttention_fast_forward,
+        )
+
+        torch.manual_seed(9)
+        model = DreamModel(config).cpu().eval()
+
+        for module in model.modules():
+            if (
+                hasattr(module, "q_proj")
+                and hasattr(module, "o_proj")
+                and not hasattr(module, "apply_qkv")
+            ):
+                from unturtle.fast_diffusion_model import (
+                    _original_apply_o,
+                    _original_apply_qkv,
+                )
+
+                module.apply_qkv = _original_apply_qkv
+                module.apply_o = _original_apply_o
+
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                DreamAttention_fast_forward, layer.self_attn
+            )
+
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        # DreamModel.forward computes and passes position_embeddings internally,
+        # but we verify the model still runs without error.
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+        assert not torch.isnan(out.logits).any()
+
+    def test_fast_forward_with_lora_dropout_still_works(self, config):
+        """DreamAttention_fast_forward is injected even when lora_dropout > 0.
+
+        The LoRA Triton kernels are skipped in that case, but the forward
+        (including Triton RoPE on CUDA) must still execute correctly.
+        """
+        import types
+
+        from unturtle.models.backbones.dream import DreamModel
+        from unturtle.models.backbones.dream.modeling_dream import (
+            DreamAttention_fast_forward,
+        )
+
+        torch.manual_seed(11)
+        model = DreamModel(config).cpu().eval()
+
+        for module in model.modules():
+            if (
+                hasattr(module, "q_proj")
+                and hasattr(module, "o_proj")
+                and not hasattr(module, "apply_qkv")
+            ):
+                from unturtle.fast_diffusion_model import (
+                    _original_apply_o,
+                    _original_apply_qkv,
+                )
+
+                module.apply_qkv = _original_apply_qkv
+                module.apply_o = _original_apply_o
+
+        # Inject forward manually (simulates what _patch_dream_peft does
+        # unconditionally before the lora_dropout check)
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                DreamAttention_fast_forward, layer.self_attn
+            )
+
+        B, L = 2, 8
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+        assert not torch.isnan(out.logits).any()

--- a/tests/models/test_llada.py
+++ b/tests/models/test_llada.py
@@ -1,0 +1,1097 @@
+"""Tests for LLaDA models.
+
+CPU-only tests covering config instantiation, model instantiation with
+random weights, and forward pass shapes. No pretrained checkpoints required.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+class TestLLaDAConfig:
+    def test_config_default_fields(self):
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        config = LLaDAConfig()
+        assert config.d_model == 768
+        assert config.n_heads == 12
+        assert config.n_layers == 12
+        assert config.vocab_size == 50257
+
+    def test_config_custom_values(self):
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        config = LLaDAConfig(d_model=128, n_heads=4, n_layers=2, vocab_size=1000)
+        assert config.d_model == 128
+        assert config.n_heads == 4
+        assert config.n_layers == 2
+        assert config.vocab_size == 1000
+
+    def test_config_hf_properties(self):
+        """HF-compatible properties map to internal fields."""
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        config = LLaDAConfig(d_model=256, n_heads=8, n_layers=4)
+        assert config.hidden_size == 256
+        assert config.num_attention_heads == 8
+        assert config.num_hidden_layers == 4
+
+    def test_config_has_mask_token_id(self):
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        config = LLaDAConfig()
+        assert hasattr(config, "mask_token_id")
+
+
+class TestLLaDAModel:
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        return LLaDAConfig(
+            d_model=128,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=1000,
+            mlp_ratio=4,
+            max_sequence_length=64,
+            attention_dropout=0.0,
+            residual_dropout=0.0,
+            embedding_dropout=0.0,
+            rope=True,  # LLaDA requires RoPE for MDM
+            init_device="cpu",
+        )
+
+    def test_model_lm_instantiation(self, config):
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        model = LLaDAModelLM(config).cpu()
+        assert model is not None
+        assert hasattr(model, "model") and hasattr(model.model, "transformer")
+
+    def test_forward_logits_shape(self, config):
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        model = LLaDAModelLM(config).cpu()
+        model.eval()
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        # LLaDA uses embedding_size (next multiple of 128 ≥ vocab_size) for logits
+        effective_vocab = (
+            config.embedding_size if config.embedding_size else config.vocab_size
+        )
+        assert out.logits.shape == (B, L, effective_vocab)
+        assert out.logits.shape[0] == B
+        assert out.logits.shape[1] == L
+
+    def test_forward_backward(self, config):
+        """Gradients flow through LLaDA."""
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        model = LLaDAModelLM(config).cpu()
+        B, L = 2, 8
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        out = model(input_ids=input_ids)
+        # LLaDA does not compute loss internally — compute manually
+        loss = (
+            out.logits[:, :, : config.vocab_size]
+            .reshape(-1, config.vocab_size)
+            .float()
+            .log_softmax(-1)
+            .mean()
+            .neg()
+        )
+        assert not torch.isnan(loss)
+        loss.backward()
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        assert len(grads) > 0
+
+
+# ---------------------------------------------------------------------------
+# LLaDA generation (diffusion_generate)
+# ---------------------------------------------------------------------------
+
+
+class TestLLaDAGeneration:
+    """Tests for LLaDAGenerationMixin.diffusion_generate on tiny CPU models."""
+
+    MASK_TOKEN_ID = 126336  # LLaDA default; overridden via config below
+
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        return LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            mlp_ratio=4,
+            max_sequence_length=64,
+            attention_dropout=0.0,
+            residual_dropout=0.0,
+            embedding_dropout=0.0,
+            rope=True,
+            init_device="cpu",
+            mask_token_id=511,  # use last token as [MASK] for tiny vocab
+        )
+
+    @pytest.fixture
+    def model(self, config):
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        return LLaDAModelLM(config).eval()
+
+    TINY_MASK_ID = 511
+
+    def test_has_diffusion_generate(self, model):
+        from unturtle.models.backbones.llada import LLaDAGenerationMixin
+
+        assert isinstance(model, LLaDAGenerationMixin)
+        assert callable(model.diffusion_generate)
+
+    def test_prepare_inputs_for_generation_removed(self, model):
+        """prepare_inputs_for_generation (AR protocol) must no longer exist."""
+        assert not hasattr(model, "prepare_inputs_for_generation"), (
+            "prepare_inputs_for_generation should be removed from LLaDAModelLM — "
+            "it implemented an AR (KV cache) protocol incompatible with dLLM generation."
+        )
+
+    def test_output_shape(self, model, config):
+        B, L = 2, 10
+        input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
+        with torch.no_grad():
+            out = model.diffusion_generate(
+                input_ids,
+                steps=2,
+                mask_token_id=self.TINY_MASK_ID,
+                max_length=L + 1,
+            )
+        assert out.shape == (B, L + 1)
+
+    def test_deterministic_with_seed(self, model):
+        """Same random seed + same input → identical output."""
+        B, L = 1, 8
+        input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
+        with torch.no_grad():
+            torch.manual_seed(42)
+            out1 = model.diffusion_generate(
+                input_ids.clone(),
+                steps=2,
+                mask_token_id=self.TINY_MASK_ID,
+                temperature=0.0,
+                max_length=L + 1,
+            )
+            torch.manual_seed(42)
+            out2 = model.diffusion_generate(
+                input_ids.clone(),
+                steps=2,
+                mask_token_id=self.TINY_MASK_ID,
+                temperature=0.0,
+                max_length=L + 1,
+            )
+        assert (out1 == out2).all(), "Same seed must produce identical output"
+
+    def test_no_mask_token_id_raises(self, model):
+        """Should raise ValueError if mask_token_id is not provided and not in config."""
+        original = getattr(model.config, "mask_token_id", None)
+        model.config.mask_token_id = None
+        try:
+            with pytest.raises(ValueError, match="mask_token_id"):
+                B, L = 1, 4
+                input_ids = torch.zeros((B, L), dtype=torch.long)
+                model.diffusion_generate(input_ids, steps=1, max_length=L + 1)
+        finally:
+            model.config.mask_token_id = original
+
+    def test_attention_mask_2d(self, model):
+        """Padded attention_mask (2-D) should be forwarded correctly to LLaDA.
+
+        Exercises the LLaDAGenerationMixin override that keeps the mask 2-D
+        instead of expanding to 4-D (which LLaDAModel cannot handle).
+        """
+        B, L = 2, 10
+        # Second sequence is shorter — last 2 positions are padding
+        input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
+        attention_mask = torch.ones((B, L), dtype=torch.long)
+        attention_mask[1, -2:] = 0  # simulate padding in second sample
+        with torch.no_grad():
+            out = model.diffusion_generate(
+                input_ids,
+                attention_mask=attention_mask,
+                steps=2,
+                mask_token_id=self.TINY_MASK_ID,
+                max_length=L + 1,
+            )
+        assert out.shape == (B, L + 1)
+
+    def test_generate_redirects_to_diffusion_generate(self, model):
+        """model.generate() must route to diffusion_generate(), not HF AR generate()."""
+        B, L = 1, 6
+        input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
+        with torch.no_grad():
+            out = model.generate(
+                input_ids,
+                steps=2,
+                mask_token_id=self.TINY_MASK_ID,
+                max_length=L + 1,
+            )
+        assert out.shape == (B, L + 1)
+
+    def test_num_return_sequences(self, model):
+        """num_return_sequences=2 should double the batch dimension."""
+        B, L = 1, 6
+        input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
+        with torch.no_grad():
+            out = model.diffusion_generate(
+                input_ids,
+                steps=2,
+                mask_token_id=self.TINY_MASK_ID,
+                max_length=L + 1,
+                num_return_sequences=2,
+            )
+        assert out.shape == (B * 2, L + 1)
+
+
+# ---------------------------------------------------------------------------
+# LLaDA Triton RoPE fast path (_make_llada_fast_rope_forward)
+# ---------------------------------------------------------------------------
+
+cuda = torch.cuda.is_available()
+
+
+class TestLLaDAFastRoPE:
+    """Tests for _make_llada_fast_rope_forward — CPU parity and CUDA correctness."""
+
+    @pytest.fixture
+    def rotary_emb(self):
+        from collections import defaultdict
+
+        from unturtle.models.backbones.llada import LLaDAConfig
+        from unturtle.models.backbones.llada.modeling_llada import RotaryEmbedding
+
+        config = LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            max_sequence_length=64,
+            rope=True,
+            init_device="cpu",
+        )
+        cache = defaultdict(lambda: None)
+        return RotaryEmbedding(config, cache)
+
+    def test_fast_forward_importable(self):
+        from unturtle.models.backbones.llada.modeling_llada import (
+            _make_llada_fast_rope_forward,
+        )
+
+        assert callable(_make_llada_fast_rope_forward)
+
+    def test_cpu_parity(self, rotary_emb):
+        """CPU fast forward matches original on CPU (falls back to original)."""
+        import types
+
+        from unturtle.models.backbones.llada.modeling_llada import (
+            _make_llada_fast_rope_forward,
+        )
+
+        B, n_heads, T, head_dim = 2, 4, 8, 16
+        q = torch.randn(B, n_heads, T, head_dim)
+        k = torch.randn(B, n_heads, T, head_dim)
+
+        original_forward = type(rotary_emb).forward
+        fast_forward = _make_llada_fast_rope_forward(original_forward)
+        rotary_emb.forward = types.MethodType(fast_forward, rotary_emb)
+
+        q_fast, k_fast = rotary_emb(q.clone(), k.clone())
+        q_orig, k_orig = original_forward(rotary_emb, q.clone(), k.clone())
+
+        assert torch.allclose(q_fast, q_orig, atol=1e-5), (
+            f"Q mismatch: {(q_fast - q_orig).abs().max()}"
+        )
+        assert torch.allclose(k_fast, k_orig, atol=1e-5), (
+            f"K mismatch: {(k_fast - k_orig).abs().max()}"
+        )
+
+    @pytest.mark.skipif(not cuda, reason="Triton fast RoPE requires CUDA")
+    def test_cuda_parity_vs_cpu(self, rotary_emb):
+        """CUDA Triton fast RoPE matches original on CPU (within float32 tolerance)."""
+        import types
+
+        from unturtle.models.backbones.llada.modeling_llada import (
+            _make_llada_fast_rope_forward,
+        )
+
+        B, n_heads, T, head_dim = 2, 4, 8, 16
+        q = torch.randn(B, n_heads, T, head_dim)
+        k = torch.randn(B, n_heads, T, head_dim)
+
+        original_forward = type(rotary_emb).forward
+
+        # CPU reference
+        q_cpu, k_cpu = original_forward(rotary_emb, q.clone(), k.clone())
+
+        # CUDA Triton path
+        rotary_emb_cuda = rotary_emb
+        fast_forward = _make_llada_fast_rope_forward(original_forward)
+        rotary_emb_cuda.forward = types.MethodType(fast_forward, rotary_emb_cuda)
+
+        q_cuda = q.clone().cuda()
+        k_cuda = k.clone().cuda()
+        q_out, k_out = rotary_emb_cuda(q_cuda, k_cuda)
+
+        assert torch.allclose(q_out.cpu(), q_cpu, atol=1e-4), (
+            f"Q max diff: {(q_out.cpu() - q_cpu).abs().max()}"
+        )
+        assert torch.allclose(k_out.cpu(), k_cpu, atol=1e-4), (
+            f"K max diff: {(k_out.cpu() - k_cpu).abs().max()}"
+        )
+
+    @pytest.mark.skipif(not cuda, reason="Triton fast RoPE requires CUDA")
+    def test_patch_applied_via_fast_diffusion_model(self):
+        """_patch_llada_peft injects Triton RoPE into rotary_emb on CUDA."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
+
+        config = LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            max_sequence_length=64,
+            rope=True,
+            block_type="llama",  # LLaDALlamaBlock has split q/k/v + rotary_emb
+            activation_type="silu",  # LLaDALlamaBlock requires silu (not swiglu)
+            init_device="cpu",
+        )
+        model = LLaDAModelLM(config).cuda()
+        peft_model = FastDiffusionModel.get_peft_model(
+            model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "attn_out"],
+            lora_dropout=0,
+            bias="none",
+        )
+        # Check that at least one block's rotary_emb was patched
+        inner = peft_model.base_model.model
+        if hasattr(inner, "model") and hasattr(inner.model, "transformer"):
+            blocks = inner.model.transformer.blocks
+        else:
+            blocks = inner.transformer.blocks
+
+        patched = [
+            b
+            for b in blocks
+            if hasattr(b, "rotary_emb")
+            and getattr(b.rotary_emb, "_fast_rope_patched", False)
+        ]
+        assert len(patched) > 0, (
+            "Expected at least one block to have Triton RoPE patched"
+        )
+
+    def test_kv_cache_fallback_cpu_parity(self, rotary_emb):
+        """query_len < key_len (KV-cache prefix) falls back to original — CPU parity."""
+        import types
+
+        from unturtle.models.backbones.llada.modeling_llada import (
+            _make_llada_fast_rope_forward,
+        )
+
+        B, n_heads, query_len, key_len, head_dim = 2, 4, 3, 8, 16
+        q = torch.randn(B, n_heads, query_len, head_dim)
+        k = torch.randn(B, n_heads, key_len, head_dim)
+
+        original_forward = type(rotary_emb).forward
+        fast_forward = _make_llada_fast_rope_forward(original_forward)
+        rotary_emb.forward = types.MethodType(fast_forward, rotary_emb)
+
+        q_fast, k_fast = rotary_emb(q.clone(), k.clone())
+        q_orig, k_orig = original_forward(rotary_emb, q.clone(), k.clone())
+
+        assert torch.allclose(q_fast, q_orig, atol=1e-6), (
+            f"Q mismatch: {(q_fast - q_orig).abs().max()}"
+        )
+        assert torch.allclose(k_fast, k_orig, atol=1e-6), (
+            f"K mismatch: {(k_fast - k_orig).abs().max()}"
+        )
+
+    @pytest.mark.skipif(not cuda, reason="Triton fast RoPE requires CUDA")
+    def test_kv_cache_fallback_cuda_parity(self, rotary_emb):
+        """query_len < key_len on CUDA also falls back to original (no Triton path)."""
+        import types
+
+        from unturtle.models.backbones.llada.modeling_llada import (
+            _make_llada_fast_rope_forward,
+        )
+
+        B, n_heads, query_len, key_len, head_dim = 2, 4, 3, 8, 16
+        q = torch.randn(B, n_heads, query_len, head_dim)
+        k = torch.randn(B, n_heads, key_len, head_dim)
+
+        original_forward = type(rotary_emb).forward
+        q_ref, k_ref = original_forward(rotary_emb, q.clone(), k.clone())
+
+        fast_forward = _make_llada_fast_rope_forward(original_forward)
+        rotary_emb.forward = types.MethodType(fast_forward, rotary_emb)
+        q_out, k_out = rotary_emb(q.clone().cuda(), k.clone().cuda())
+
+        assert torch.allclose(q_out.cpu(), q_ref, atol=1e-6), (
+            f"Q max diff: {(q_out.cpu() - q_ref).abs().max()}"
+        )
+        assert torch.allclose(k_out.cpu(), k_ref, atol=1e-6), (
+            f"K max diff: {(k_out.cpu() - k_ref).abs().max()}"
+        )
+
+    @pytest.mark.skipif(not cuda, reason="Triton fast RoPE requires CUDA")
+    def test_gqa_cuda_parity(self):
+        """GQA (n_kv_heads=1): CUDA fast RoPE matches original for Q; K passthrough."""
+        import types
+        from collections import defaultdict
+
+        from unturtle.models.backbones.llada import LLaDAConfig
+        from unturtle.models.backbones.llada.modeling_llada import (
+            RotaryEmbedding,
+            _make_llada_fast_rope_forward,
+        )
+
+        config = LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_kv_heads=1,
+            n_layers=2,
+            vocab_size=512,
+            max_sequence_length=64,
+            rope=True,
+            init_device="cpu",
+        )
+        cache = defaultdict(lambda: None)
+        rotary_emb = RotaryEmbedding(config, cache)
+
+        B, n_heads, n_kv_heads, T, head_dim = 2, 4, 1, 8, 16
+        q = torch.randn(B, n_heads, T, head_dim)
+        k = torch.randn(B, n_kv_heads, T, head_dim)
+
+        original_forward = type(rotary_emb).forward
+        q_ref, k_ref = original_forward(rotary_emb, q.clone(), k.clone())
+
+        fast_forward = _make_llada_fast_rope_forward(original_forward)
+        rotary_emb.forward = types.MethodType(fast_forward, rotary_emb)
+        q_out, k_out = rotary_emb(q.clone().cuda(), k.clone().cuda())
+
+        assert torch.allclose(q_out.cpu(), q_ref, atol=1e-4), (
+            f"Q max diff: {(q_out.cpu() - q_ref).abs().max()}"
+        )
+        assert torch.allclose(k_out.cpu(), k_ref, atol=1e-4), (
+            f"K max diff: {(k_out.cpu() - k_ref).abs().max()}"
+        )
+
+    @pytest.mark.skipif(not cuda, reason="Triton fast RoPE requires CUDA")
+    def test_double_patch_idempotent(self):
+        """Calling _patch_llada_peft twice does not stack the fast forward wrapper."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
+
+        config = LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            max_sequence_length=64,
+            rope=True,
+            block_type="llama",
+            activation_type="silu",  # LLaDALlamaBlock requires silu (not swiglu)
+            init_device="cpu",
+        )
+        model = LLaDAModelLM(config).cuda()
+        peft_model = FastDiffusionModel.get_peft_model(
+            model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "attn_out"],
+            lora_dropout=0,
+            bias="none",
+        )
+
+        inner = peft_model.base_model.model
+        blocks = (
+            inner.model.transformer.blocks
+            if hasattr(inner, "model") and hasattr(inner.model, "transformer")
+            else inner.transformer.blocks
+        )
+
+        # Collect forward bindings after first patch
+        forwards_after_first = [
+            id(b.rotary_emb.forward) for b in blocks if hasattr(b, "rotary_emb")
+        ]
+
+        # Simulate a second patch call
+        from unturtle.fast_diffusion_model import _patch_llada_peft
+
+        _patch_llada_peft(peft_model, lora_dropout=0, bias="none")
+
+        forwards_after_second = [
+            id(b.rotary_emb.forward) for b in blocks if hasattr(b, "rotary_emb")
+        ]
+
+        assert forwards_after_first == forwards_after_second, (
+            "double patch changed rotary_emb.forward bindings — wrapper was stacked"
+        )
+
+
+# ---------------------------------------------------------------------------
+# LLaDA Triton MLP LoRA (apply_lora_mlp_swiglu via apply_mlp stub)
+# ---------------------------------------------------------------------------
+
+
+class TestLLaDAFastMLP:
+    """Tests for Triton MLP LoRA patching on LLaDALlamaBlock."""
+
+    @pytest.fixture
+    def llama_config(self):
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        return LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            mlp_ratio=4,
+            max_sequence_length=64,
+            attention_dropout=0.0,
+            residual_dropout=0.0,
+            embedding_dropout=0.0,
+            rope=True,
+            block_type="llama",
+            activation_type="silu",  # LLaDALlamaBlock requires silu (not swiglu)
+            init_device="cpu",
+        )
+
+    def test_apply_mlp_stub_exists(self, llama_config):
+        """LLaDALlamaBlock has apply_mlp stub after instantiation."""
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        model = LLaDAModelLM(llama_config)
+        blocks = model.model.transformer.blocks
+        for block in blocks:
+            assert hasattr(block, "apply_mlp"), (
+                "apply_mlp stub missing from LLaDALlamaBlock"
+            )
+            assert callable(block.apply_mlp)
+
+    def test_cpu_forward_with_stub(self, llama_config):
+        """CPU forward with default apply_mlp stub produces correct output shape."""
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        model = LLaDAModelLM(llama_config).eval()
+        B, L = 2, 8
+        input_ids = torch.randint(0, llama_config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape[:2] == (B, L)
+
+    @pytest.mark.skipif(not cuda, reason="Triton MLP LoRA requires CUDA")
+    def test_mlp_patched_to_triton(self, llama_config):
+        """_patch_llada_peft replaces apply_mlp with apply_lora_mlp_swiglu on CUDA."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.kernels.fast_lora import apply_lora_mlp_swiglu
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        model = LLaDAModelLM(llama_config).cuda()
+        peft_model = FastDiffusionModel.get_peft_model(
+            model,
+            r=4,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "attn_out",
+                "ff_proj",
+                "up_proj",
+                "ff_out",
+            ],
+            lora_dropout=0,
+            bias="none",
+        )
+        inner = peft_model.base_model.model
+        blocks = (
+            inner.model.transformer.blocks
+            if hasattr(inner, "model") and hasattr(inner.model, "transformer")
+            else inner.transformer.blocks
+        )
+
+        patched = [b for b in blocks if b.apply_mlp is apply_lora_mlp_swiglu]
+        assert len(patched) > 0, (
+            "Expected apply_mlp to be replaced with apply_lora_mlp_swiglu"
+        )
+
+    @pytest.mark.skipif(not cuda, reason="Triton MLP LoRA requires CUDA")
+    def test_mlp_gate_down_aliases_set(self, llama_config):
+        """gate_proj and down_proj aliases are set on block after patching."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        model = LLaDAModelLM(llama_config).cuda()
+        peft_model = FastDiffusionModel.get_peft_model(
+            model,
+            r=4,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "attn_out",
+                "ff_proj",
+                "up_proj",
+                "ff_out",
+            ],
+            lora_dropout=0,
+            bias="none",
+        )
+        inner = peft_model.base_model.model
+        blocks = (
+            inner.model.transformer.blocks
+            if hasattr(inner, "model") and hasattr(inner.model, "transformer")
+            else inner.transformer.blocks
+        )
+
+        for block in blocks:
+            assert hasattr(block, "gate_proj"), "gate_proj alias missing"
+            assert hasattr(block, "down_proj"), "down_proj alias missing"
+            assert block.gate_proj is block.ff_proj
+            assert block.down_proj is block.ff_out
+
+    @pytest.mark.skipif(not cuda, reason="Triton MLP LoRA requires CUDA")
+    def test_cuda_forward_with_triton_mlp(self, llama_config):
+        """Full model forward pass works on CUDA with Triton MLP LoRA patched."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        model = LLaDAModelLM(llama_config).cuda()
+        peft_model = FastDiffusionModel.get_peft_model(
+            model,
+            r=4,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "attn_out",
+                "ff_proj",
+                "up_proj",
+                "ff_out",
+            ],
+            lora_dropout=0,
+            bias="none",
+        )
+        peft_model.eval()
+        B, L = 2, 8
+        input_ids = torch.randint(0, llama_config.vocab_size, (B, L)).cuda()
+        with torch.no_grad():
+            out = peft_model(input_ids=input_ids)
+        assert out.logits.shape[:2] == (B, L)
+
+    def test_default_apply_mlp_numerics(self, llama_config):
+        """_default_apply_mlp output matches the original inline MLP formula."""
+        from unturtle.models.backbones.llada import LLaDAModelLM
+        from unturtle.models.backbones.llada.modeling_llada import LLaDALlamaBlock
+
+        model = LLaDAModelLM(llama_config).eval()
+        block = model.model.transformer.blocks[0]
+
+        B, L, d = 2, 8, llama_config.d_model
+        x = torch.randn(B, L, d)
+
+        # Reference: inline formula
+        with torch.no_grad():
+            x_ref = block.ff_norm(x)
+            gate, up = block.ff_proj(x_ref), block.up_proj(x_ref)
+            gate = block.act(gate)
+            ref_out = block.ff_out(gate * up)
+
+        # Via stub
+        with torch.no_grad():
+            stub_out = LLaDALlamaBlock._default_apply_mlp(block, block.ff_norm(x))
+
+        assert torch.allclose(stub_out, ref_out, atol=1e-6), (
+            f"_default_apply_mlp mismatch: {(stub_out - ref_out).abs().max()}"
+        )
+
+    @pytest.mark.skipif(not cuda, reason="Triton MLP LoRA requires CUDA")
+    def test_swiglu_block_not_patched(self):
+        """LLaDALlamaBlock with swiglu activation is NOT patched with Triton MLP."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
+        from unturtle.models.backbones.llada.modeling_llada import LLaDALlamaBlock
+
+        swiglu_config = LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            mlp_ratio=4,
+            max_sequence_length=64,
+            rope=True,
+            block_type="llama",
+            activation_type="swiglu",  # swiglu → ff_out.in_features=128
+            init_device="cpu",
+        )
+        model = LLaDAModelLM(swiglu_config).cuda()
+        peft_model = FastDiffusionModel.get_peft_model(
+            model,
+            r=4,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "attn_out",
+                "ff_proj",
+                "up_proj",
+                "ff_out",
+            ],
+            lora_dropout=0,
+            bias="none",
+        )
+        inner = peft_model.base_model.model
+        blocks = (
+            inner.model.transformer.blocks
+            if hasattr(inner, "model") and hasattr(inner.model, "transformer")
+            else inner.transformer.blocks
+        )
+
+        # No block should have apply_mlp replaced with apply_lora_mlp_swiglu
+        from unturtle.kernels.fast_lora import apply_lora_mlp_swiglu
+
+        patched = [b for b in blocks if b.apply_mlp is apply_lora_mlp_swiglu]
+        assert len(patched) == 0, (
+            "swiglu blocks should NOT be patched with Triton MLP kernel"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase M.1: Block-decode KV cache (replace_position)
+# ---------------------------------------------------------------------------
+
+
+class TestLLaDABlockDecode:
+    """Phase M.1 tests: replace_position cache handling and block-decode generation."""
+
+    @pytest.fixture
+    def tiny_config(self):
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        return LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            mlp_ratio=4,
+            max_sequence_length=64,
+            attention_dropout=0.0,
+            residual_dropout=0.0,
+            embedding_dropout=0.0,
+            rope=True,
+            block_type="llama",
+            activation_type="silu",
+            init_device="cpu",
+            mask_token_id=511,
+        )
+
+    @pytest.fixture
+    def tiny_model(self, tiny_config):
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        torch.manual_seed(42)
+        return LLaDAModelLM(tiny_config).eval()
+
+    def test_replace_position_cache_update(self, tiny_model, tiny_config):
+        """Verify cache replacement logic works within block-decode context.
+
+        This test verifies that replace_kv_cache correctly updates marked positions.
+        Note: replace_position is intended for use within block-decode loops, where
+        query_len matches the block being refined. Testing the full generation loop
+        is covered by test_block_decode_baseline.
+        """
+        from unturtle.models.generation.cache_utils import replace_kv_cache
+
+        B, L = 2, 16
+        input_ids = torch.randint(0, tiny_config.vocab_size, (B, L))
+
+        # Step 1: Initial forward to build cache
+        with torch.no_grad():
+            out1 = tiny_model.model(input_ids=input_ids, use_cache=True)
+        past_kv = out1.attn_key_values
+        assert past_kv is not None
+        assert len(past_kv) == tiny_config.n_layers
+
+        # Step 2: Simulate block-decode update (replace middle 4 positions)
+        block_start, block_end = 8, 12
+        replace_position = torch.zeros(B, L, dtype=torch.bool)
+        replace_position[:, block_start:block_end] = True
+
+        # Generate new K/V for the marked block (simulate denoising step)
+        _new_hidden = torch.randn(B, 4, tiny_config.d_model)  # block_length=4
+        # Project to K/V (simplified: just use random tensors matching cache shape)
+        _, n_heads, _, head_dim = past_kv[0][0].shape
+        new_k = torch.randn(B, n_heads, 4, head_dim)
+        new_v = torch.randn(B, n_heads, 4, head_dim)
+
+        # Apply cache replacement for layer 0
+        updated_cache = replace_kv_cache(
+            past_kv, new_k, new_v, replace_position, layer_idx=0
+        )
+
+        # Verify cache was updated at marked positions
+        old_k, old_v = past_kv[0]
+        upd_k, upd_v = updated_cache[0]
+
+        # Positions outside [block_start, block_end] should be unchanged
+        assert torch.allclose(
+            old_k[:, :, :block_start, :], upd_k[:, :, :block_start, :]
+        )
+        assert torch.allclose(old_k[:, :, block_end:, :], upd_k[:, :, block_end:, :])
+
+        # Positions inside [block_start, block_end] should be updated
+        assert not torch.allclose(
+            old_k[:, :, block_start:block_end, :], upd_k[:, :, block_start:block_end, :]
+        )
+
+    def test_block_decode_baseline(self, tiny_model, tiny_config):
+        """Block-decode generation runs without error (baseline)."""
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        B, prompt_len = 2, 8
+        input_ids = torch.randint(0, tiny_config.vocab_size, (B, prompt_len))
+
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=8,
+            steps=2,
+            alg="origin",
+            mask_token_id=tiny_config.mask_token_id,
+            use_cache=True,
+            block_length=4,
+        )
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=input_ids,
+                generation_config=gen_config,
+            )
+
+        assert output.shape == (B, prompt_len + 8)
+
+    def test_block_decode_correctness(self, tiny_model, tiny_config):
+        """Block-decode generates valid (non-mask) tokens in the generated region.
+
+        Block-decode uses a trimmed KV-cache so attended context differs from the
+        full no-cache forward pass in a bidirectional model — exact value equivalence
+        with the no-cache baseline is not guaranteed.  We verify output correctness:
+        correct shape, prompt preserved, no remaining mask tokens.
+        """
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        B, prompt_len = 1, 6
+        max_new = 8
+        torch.manual_seed(42)
+        input_ids = torch.randint(0, tiny_config.vocab_size, (B, prompt_len))
+
+        gen_config_with_cache = MaskedDiffusionGenerationConfig(
+            max_new_tokens=max_new,
+            steps=4,
+            alg="origin",
+            mask_token_id=tiny_config.mask_token_id,
+            use_cache=True,
+            use_replace_cache=False,
+            block_length=4,
+            temperature=1.0,  # stochastic: argmax on random weights always picks mask_token_id
+        )
+
+        torch.manual_seed(42)
+        with torch.no_grad():
+            output_with_cache = tiny_model.diffusion_generate(
+                inputs=input_ids.clone(),
+                generation_config=gen_config_with_cache,
+            )
+
+        assert output_with_cache.shape == (B, prompt_len + max_new)
+        assert torch.equal(output_with_cache[:, :prompt_len], input_ids)
+        assert not torch.any(
+            output_with_cache[:, prompt_len:] == tiny_config.mask_token_id
+        ), "Block-decode should produce no remaining mask tokens in generated region"
+
+    def test_parallel_decode_trim_cache_runs(self, tiny_model, tiny_config):
+        """LLaDA parallel_decode runs in trim-cache mode."""
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        input_ids = torch.randint(0, tiny_config.vocab_size, (1, 8))
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=8,
+            steps=4,
+            alg="maskgit_plus",
+            mask_token_id=tiny_config.mask_token_id,
+            use_cache=True,
+            use_replace_cache=False,
+            parallel_decode=True,
+            confidence_threshold=0.05,
+            block_length=4,
+            temperature=0.0,
+        )
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=input_ids, generation_config=gen_config
+            )
+
+        assert output.shape == (1, 16)
+        assert not torch.any(output[:, 8:] == tiny_config.mask_token_id)
+
+    def test_parallel_decode_completes_block_when_steps_per_block_is_small(
+        self, tiny_model, tiny_config, monkeypatch
+    ):
+        """Trim-cache threshold mode keeps denoising until the block finishes."""
+        import unturtle.models.generation.block_decode_mixin as block_decode_mixin
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        def select_single_token(masked_confidence, mask_index_block, threshold):
+            transfer_mask = torch.zeros_like(mask_index_block, dtype=torch.bool)
+            for row_idx in range(mask_index_block.shape[0]):
+                masked_positions = mask_index_block[row_idx].nonzero(as_tuple=True)[0]
+                if masked_positions.numel() > 0:
+                    transfer_mask[row_idx, masked_positions[0]] = True
+            return transfer_mask
+
+        monkeypatch.setattr(
+            block_decode_mixin, "select_threshold_transfer_mask", select_single_token
+        )
+
+        input_ids = torch.randint(0, tiny_config.vocab_size, (1, 8))
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=8,
+            steps=2,
+            alg="maskgit_plus",
+            mask_token_id=tiny_config.mask_token_id,
+            use_cache=True,
+            use_replace_cache=False,
+            parallel_decode=True,
+            confidence_threshold=0.99,
+            block_length=4,
+            temperature=0.0,
+        )
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=input_ids, generation_config=gen_config
+            )
+
+        assert output.shape == (1, 16)
+        assert not torch.any(output[:, 8:] == tiny_config.mask_token_id)
+
+    def test_parallel_decode_dual_cache_runs(self, tiny_model, tiny_config):
+        """LLaDA parallel_decode runs in dual-cache replace_position mode."""
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        input_ids = torch.randint(0, tiny_config.vocab_size, (1, 8))
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=8,
+            steps=4,
+            alg="maskgit_plus",
+            mask_token_id=tiny_config.mask_token_id,
+            use_cache=True,
+            use_replace_cache=True,
+            parallel_decode=True,
+            confidence_threshold=0.05,
+            block_length=4,
+            temperature=0.0,
+        )
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=input_ids, generation_config=gen_config
+            )
+
+        assert output.shape == (1, 16)
+        assert not torch.any(output[:, 8:] == tiny_config.mask_token_id)
+
+    def test_parallel_decode_dual_cache_completes_block_when_steps_per_block_is_small(
+        self, tiny_model, tiny_config, monkeypatch
+    ):
+        """Dual-cache threshold mode keeps denoising until the block finishes."""
+        import unturtle.models.generation.block_decode_mixin as block_decode_mixin
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        def select_single_token(masked_confidence, mask_index_block, threshold):
+            transfer_mask = torch.zeros_like(mask_index_block, dtype=torch.bool)
+            for row_idx in range(mask_index_block.shape[0]):
+                masked_positions = mask_index_block[row_idx].nonzero(as_tuple=True)[0]
+                if masked_positions.numel() > 0:
+                    transfer_mask[row_idx, masked_positions[0]] = True
+            return transfer_mask
+
+        monkeypatch.setattr(
+            block_decode_mixin, "select_threshold_transfer_mask", select_single_token
+        )
+
+        input_ids = torch.randint(0, tiny_config.vocab_size, (1, 8))
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=8,
+            steps=2,
+            alg="maskgit_plus",
+            mask_token_id=tiny_config.mask_token_id,
+            use_cache=True,
+            use_replace_cache=True,
+            parallel_decode=True,
+            confidence_threshold=0.99,
+            block_length=4,
+            temperature=0.0,
+        )
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=input_ids, generation_config=gen_config
+            )
+
+        assert output.shape == (1, 16)
+        assert not torch.any(output[:, 8:] == tiny_config.mask_token_id)
+
+    def test_rope_with_replace_position(self, tiny_config):
+        """RoPE with block_end_index bounds position indexing (block-decode context).
+
+        In block-decode, query_len matches the current block being refined, and
+        block_end_index is the end of that block in the full sequence.
+        """
+        from collections import defaultdict
+
+        from unturtle.models.backbones.llada.modeling_llada import RotaryEmbedding
+
+        cache = defaultdict(lambda: None)
+        rotary_emb = RotaryEmbedding(tiny_config, cache)
+
+        B, n_heads, head_dim = 2, 4, 16
+        query_len, key_len = 4, 16
+        q = torch.randn(B, n_heads, query_len, head_dim)
+        k = torch.randn(B, n_heads, key_len, head_dim)
+
+        q1, k1 = rotary_emb(q.clone(), k.clone())
+        q2, k2 = rotary_emb(q.clone(), k.clone(), block_end_index=16)
+        assert torch.allclose(q1, q2, atol=1e-6), (
+            "block_end_index=key_len should match standard RoPE"
+        )
+
+        q3, k3 = rotary_emb(q.clone(), k.clone(), block_end_index=12)
+        assert not torch.allclose(q1, q3, atol=1e-6), (
+            "block_end_index=12 should produce different positions"
+        )

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -1,0 +1,1500 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FastDiffusionModel — analogous to unsloth's FastLanguageModel but for
+Diffusion Language Models (dLLMs).
+
+Applies unsloth's Triton-fused LoRA kernels and Flash Attention with
+bidirectional (non-causal) masking to A2D / LLaDA / Dream models.
+
+Usage::
+
+    from unturtle import FastDiffusionModel
+    from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+    model, tokenizer = FastDiffusionModel.from_pretrained(
+        "GSAI-ML/LLaDA-8B-Instruct",
+        max_seq_length=2048,
+        load_in_4bit=True,
+    )
+    model = FastDiffusionModel.get_peft_model(
+        model,
+        r=16,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                        "gate_proj", "up_proj", "down_proj"],
+        lora_alpha=16,
+    )
+
+    # Switch to inference mode (eval + no_grad context manager)
+    FastDiffusionModel.for_inference(model)
+
+    # Save LoRA-merged weights
+    FastDiffusionModel.save_pretrained_merged(model, "output/merged", tokenizer)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import functools
+import importlib
+import logging
+import types
+from typing import Any, Literal, Optional
+
+import torch
+from peft import LoraConfig, TaskType, get_peft_model
+from peft.tuners.lora import Linear as LoraLinear
+from transformers import AutoConfig, AutoTokenizer
+
+try:
+    from unturtle.kernels.fast_lora import (
+        apply_lora_mlp_swiglu,
+        apply_lora_o,
+        apply_lora_qkv,
+        apply_lora_qkv_with_bias,
+    )
+except (ImportError, OSError, AttributeError) as exc:
+    apply_lora_mlp_swiglu = None
+    apply_lora_o = None
+    apply_lora_qkv = None
+    apply_lora_qkv_with_bias = None
+    _FAST_LORA_IMPORT_ERROR = exc
+else:
+    _FAST_LORA_IMPORT_ERROR = None
+
+from unturtle.models.backbones.dream.modeling_dream import (
+    DreamAttention_fast_forward,
+)
+from unturtle.models.backbones.modernbert._fast_forward import (
+    ModernBertAttention_fast_forward,
+    _install_modernbert_stubs,
+)
+
+try:
+    from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+        TinyA2DAttention_fast_forward,
+    )
+except ImportError:
+    TinyA2DAttention_fast_forward = None  # type: ignore[assignment]  # Task 5 not yet ported
+from unturtle.models.generation.sampler import (
+    algorithm_to_flags,
+    resolve_algorithm,
+)
+from unturtle.save import patch_saving_functions, prepare_model_for_kbit_training
+
+_logger = logging.getLogger(__name__)
+
+
+def _require_fast_lora() -> None:
+    if _FAST_LORA_IMPORT_ERROR is not None:
+        raise ImportError(
+            "FastDiffusionModel requires unturtle.kernels.fast_lora and its optional "
+            "bitsandbytes-backed dependencies to be importable."
+        ) from _FAST_LORA_IMPORT_ERROR
+
+
+def _warn_once(msg: str) -> None:
+    """Log a warning that won't repeat (uses transformers if available)."""
+    try:
+        from transformers.utils import logging as hf_logging
+
+        hf_logger = hf_logging.get_logger(__name__)
+        hf_logger.warning_once(msg)
+    except Exception:  # noqa: BLE001
+        _logger.warning(msg)
+
+
+# Model types that follow the standard LLaMA/Qwen2 layer hierarchy:
+# model.model.model.layers (through PeftModel → base_model → model)
+# The legacy ``a2d-*`` entries are deprecated load-compat for upstream checkpoints whose
+# config.json predates the TinyA2D rename (e.g. dllm-hub); tracked for removal in #301.
+_TINY_A2D_MODEL_TYPES = frozenset(
+    [
+        "tiny-a2d-llama",
+        "tiny-a2d-qwen2",
+        "tiny-a2d-qwen3",
+        "a2d-llama",
+        "a2d-qwen2",
+        "a2d-qwen3",
+        "llama",
+        "qwen2",
+        "qwen3",
+    ]
+)
+
+# Dream model_type (note: Dream uses "Dream" with capital D)
+_DREAM_MODEL_TYPES = frozenset(["dream", "Dream"])
+
+# LLaDA model_type
+_LLADA_MODEL_TYPES = frozenset(["llada"])
+
+# ModernBERT model_type(s) — diffusion wrapper around native bidirectional encoder
+_MODERNBERT_A2D_MODEL_TYPES = frozenset(["modernbert-diffusion"])
+
+
+# ---------------------------------------------------------------------------
+# Internal patching helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_a2d_peft(
+    model: Any, lora_dropout: float, bias: Literal["none", "all", "lora_only"]
+) -> tuple[int, int, int]:
+    """Patch A2D model (standard LLaMA/Qwen2/3 layer layout) with Triton LoRA kernels
+    and inject bidirectional fast attention forward.
+
+    Returns (n_qkv, n_o, n_mlp) — number of patched layer types.
+    """
+    n_qkv = n_o = n_mlp = 0
+
+    # Standard path: PeftModel → base_model → model → model.layers
+    layers = model.base_model.model.model.layers
+
+    # Triton kernels and flash attention require the model to be on CUDA.
+    first_param = next(iter(model.parameters()), None)
+    on_cuda = first_param is not None and first_param.device.type == "cuda"
+
+    if on_cuda and lora_dropout == 0 and bias == "none":
+        _require_fast_lora()
+
+    for layer in layers:
+        # --- fast attention (bidirectional) — GPU only ---
+        if on_cuda and TinyA2DAttention_fast_forward is not None:
+            layer.self_attn.forward = types.MethodType(
+                TinyA2DAttention_fast_forward, layer.self_attn
+            )
+
+        if not on_cuda or lora_dropout != 0 or bias != "none":
+            # Triton custom autograd does not support dropout or bias in LoRA
+            continue
+
+        # --- MLP patching ---
+        mlp = layer.mlp
+        gate_proj = mlp.gate_proj
+        up_proj = mlp.up_proj
+        down_proj = mlp.down_proj
+        if (
+            hasattr(gate_proj, "lora_A")
+            and hasattr(up_proj, "lora_A")
+            and hasattr(down_proj, "lora_A")
+            and _no_bias(gate_proj)
+            and _no_bias(up_proj)
+            and _no_bias(down_proj)
+            and _no_lora_mag(gate_proj)
+            and _no_lora_mag(up_proj)
+            and _no_lora_mag(down_proj)
+        ):
+            mlp.forward = types.MethodType(apply_lora_mlp_swiglu, mlp)
+            n_mlp += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel: cannot patch MLP layer with Triton LoRA kernel "
+                "(LoRA adapters not enabled or bias present)."
+            )
+
+        # --- QKV patching ---
+        q_proj = layer.self_attn.q_proj
+        k_proj = layer.self_attn.k_proj
+        v_proj = layer.self_attn.v_proj
+        if (
+            hasattr(q_proj, "lora_A")
+            and hasattr(k_proj, "lora_A")
+            and hasattr(v_proj, "lora_A")
+            and _no_bias(q_proj)
+            and _no_bias(k_proj)
+            and _no_bias(v_proj)
+            and _no_lora_mag(q_proj)
+            and _no_lora_mag(k_proj)
+            and _no_lora_mag(v_proj)
+        ):
+            layer.self_attn.apply_qkv = apply_lora_qkv
+            n_qkv += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel: cannot patch QKV with Triton kernel "
+                "(LoRA adapters not enabled or bias present — e.g. Dream q/k/v_proj)."
+            )
+
+        # --- O projection patching ---
+        o_proj = layer.self_attn.o_proj
+        if hasattr(o_proj, "lora_A") and _no_bias(o_proj) and _no_lora_mag(o_proj):
+            layer.self_attn.apply_o = apply_lora_o
+            n_o += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel: cannot patch O projection with Triton kernel."
+            )
+
+    return n_qkv, n_o, n_mlp
+
+
+def _patch_dream_peft(
+    model: Any, lora_dropout: float, bias: Literal["none", "all", "lora_only"]
+) -> tuple[int, int, int]:
+    """Patch Dream model with Triton LoRA kernels.
+
+    Dream's q/k/v_proj have ``bias=True``, so the standard ``apply_lora_qkv``
+    is replaced with ``apply_lora_qkv_with_bias`` (``LoRA_QKV_Bias`` kernel).
+    o_proj (bias=False) uses the standard ``apply_lora_o``.
+    MLP (gate/up/down, all bias=False) uses ``apply_lora_mlp_swiglu``.
+
+    Layer layout: ``model.base_model.model.model.layers``
+    (Dream wraps DreamBaseModel as ``self.model``, same depth as LLaMA).
+    """
+    n_qkv = n_o = n_mlp = 0
+
+    # Triton kernels require the model to be on CUDA.
+    first_param = next(iter(model.parameters()), None)
+    if first_param is None or first_param.device.type != "cuda":
+        return n_qkv, n_o, n_mlp
+
+    layers = model.base_model.model.model.layers
+
+    if lora_dropout == 0 and bias == "none":
+        _require_fast_lora()
+
+    for layer in layers:
+        self_attn = layer.self_attn if hasattr(layer, "self_attn") else None
+
+        # Inject Triton RoPE fast forward unconditionally (CUDA already checked above)
+        if self_attn is not None:
+            self_attn.forward = types.MethodType(DreamAttention_fast_forward, self_attn)
+
+        if lora_dropout != 0 or bias != "none":
+            continue
+
+        if self_attn is None:
+            continue
+
+        # --- QKV: Dream has bias=True → use apply_lora_qkv_with_bias ---
+        q_proj = getattr(self_attn, "q_proj", None)
+        k_proj = getattr(self_attn, "k_proj", None)
+        v_proj = getattr(self_attn, "v_proj", None)
+        if (
+            q_proj is not None
+            and k_proj is not None
+            and v_proj is not None
+            and hasattr(q_proj, "lora_A")
+            and hasattr(k_proj, "lora_A")
+            and hasattr(v_proj, "lora_A")
+            and _no_lora_mag(q_proj)
+            and _no_lora_mag(k_proj)
+            and _no_lora_mag(v_proj)
+        ):
+            self_attn.apply_qkv = apply_lora_qkv_with_bias
+            n_qkv += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel (Dream): cannot patch QKV with Triton kernel "
+                "(LoRA adapters not enabled or lora_magnitude_vector present)."
+            )
+
+        # --- O projection (bias=False in Dream) ---
+        o_proj = getattr(self_attn, "o_proj", None)
+        if (
+            o_proj is not None
+            and hasattr(o_proj, "lora_A")
+            and _no_bias(o_proj)
+            and _no_lora_mag(o_proj)
+        ):
+            self_attn.apply_o = apply_lora_o
+            n_o += 1
+
+        # --- MLP: Dream uses gate_proj/up_proj/down_proj (bias=False) ---
+        mlp = layer.mlp if hasattr(layer, "mlp") else None
+        if mlp is not None:
+            gate_proj = getattr(mlp, "gate_proj", None)
+            up_proj = getattr(mlp, "up_proj", None)
+            down_proj = getattr(mlp, "down_proj", None)
+            if (
+                gate_proj is not None
+                and up_proj is not None
+                and down_proj is not None
+                and hasattr(gate_proj, "lora_A")
+                and hasattr(up_proj, "lora_A")
+                and hasattr(down_proj, "lora_A")
+                and _no_bias(gate_proj)
+                and _no_bias(up_proj)
+                and _no_bias(down_proj)
+                and _no_lora_mag(gate_proj)
+                and _no_lora_mag(up_proj)
+                and _no_lora_mag(down_proj)
+            ):
+                mlp.forward = types.MethodType(apply_lora_mlp_swiglu, mlp)
+                n_mlp += 1
+
+    return n_qkv, n_o, n_mlp
+
+
+def _patch_llada_peft(
+    model: Any, lora_dropout: float, bias: Literal["none", "all", "lora_only"]
+) -> tuple[int, int, int]:
+    """Patch LLaDA model with Triton LoRA kernels.
+
+    LLaDA uses a non-standard layer hierarchy:
+      ``model.base_model.model.transformer.blocks`` (list of ``LLaDABlock``).
+
+    ``LLaDALlamaBlock`` has ``q_proj/k_proj/v_proj/attn_out/ff_proj/up_proj``.
+    Other block types (``LLaDASequentialBlock``) use ``att_proj`` (fused QKV)
+    and are not supported by the split QKV kernel — they are skipped with a
+    warning.
+    """
+    from unturtle.models.backbones.llada.modeling_llada import (
+        LLaDALlamaBlock,
+        _make_llada_fast_rope_forward,
+    )
+
+    n_qkv = n_o = n_mlp = 0
+
+    # Triton kernels require the model to be on CUDA.
+    first_param = next(iter(model.parameters()), None)
+    if first_param is None or first_param.device.type != "cuda":
+        return n_qkv, n_o, n_mlp
+
+    # LLaDAModelLM wraps LLaDAModel in self.model, so the path differs:
+    # PeftModel → base_model → model (LLaDAModelLM) → model (LLaDAModel) → transformer
+    inner = model.base_model.model
+    if hasattr(inner, "model") and hasattr(inner.model, "transformer"):
+        transformer = inner.model.transformer
+    elif hasattr(inner, "transformer"):
+        transformer = inner.transformer
+    else:
+        _warn_once(
+            "FastDiffusionModel (LLaDA): could not locate transformer — "
+            "cannot patch LoRA kernels. Is this a supported LLaDA checkpoint?"
+        )
+        return n_qkv, n_o, n_mlp
+
+    if not hasattr(transformer, "blocks"):
+        _warn_once(
+            "FastDiffusionModel (LLaDA): transformer.blocks not found — "
+            "cannot patch LoRA kernels. Is this a supported LLaDA checkpoint?"
+        )
+        return n_qkv, n_o, n_mlp
+
+    blocks = transformer.blocks
+
+    if lora_dropout == 0 and bias == "none":
+        _require_fast_lora()
+
+    for block in blocks:
+        if not isinstance(block, LLaDALlamaBlock):
+            _warn_once(
+                f"FastDiffusionModel (LLaDA): skipping block type {type(block).__name__} "
+                "(only LLaDALlamaBlock is supported for Triton LoRA patching)."
+            )
+            continue
+
+        # Inject Triton RoPE fast forward unconditionally (CUDA already checked above).
+        rotary_emb = getattr(block, "rotary_emb", None)
+        if rotary_emb is not None and not getattr(
+            rotary_emb, "_fast_rope_patched", False
+        ):
+            import types
+
+            rotary_emb.forward = types.MethodType(
+                _make_llada_fast_rope_forward(type(rotary_emb).forward), rotary_emb
+            )
+            rotary_emb._fast_rope_patched = True
+
+        if lora_dropout != 0 or bias != "none":
+            continue
+
+        # LLaDALlamaBlock: q_proj / k_proj / v_proj (bias depends on config)
+        q_proj = getattr(block, "q_proj", None)
+        k_proj = getattr(block, "k_proj", None)
+        v_proj = getattr(block, "v_proj", None)
+        if (
+            q_proj is not None
+            and k_proj is not None
+            and v_proj is not None
+            and hasattr(q_proj, "lora_A")
+            and hasattr(k_proj, "lora_A")
+            and hasattr(v_proj, "lora_A")
+            and _no_bias(q_proj)
+            and _no_bias(k_proj)
+            and _no_bias(v_proj)
+            and _no_lora_mag(q_proj)
+            and _no_lora_mag(k_proj)
+            and _no_lora_mag(v_proj)
+        ):
+            block.apply_qkv = apply_lora_qkv
+            n_qkv += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel (LLaDA): cannot patch QKV with Triton kernel "
+                "(LoRA not enabled or bias present — config.include_qkv_bias=True)."
+            )
+
+        # attn_out (o_proj equivalent)
+        attn_out = getattr(block, "attn_out", None)
+        if (
+            attn_out is not None
+            and hasattr(attn_out, "lora_A")
+            and _no_bias(attn_out)
+            and _no_lora_mag(attn_out)
+        ):
+            block.apply_o = apply_lora_o
+            n_o += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel (LLaDA): cannot patch attn_out with Triton kernel."
+            )
+
+        # ff_proj / up_proj / ff_out — gated MLP (gate/up/down).
+        # apply_lora_mlp_swiglu reads self.gate_proj / self.up_proj / self.down_proj
+        # and uses the SiLU-gated SwiGLU Triton kernel.
+        # Only patch when activation_type is SiLU (output_multiplier==1); with SwiGLU
+        # (output_multiplier==0.5) ff_proj output is halved by chunk(2) while up_proj
+        # stays full-width, producing a shape mismatch in the Triton kernel.
+        block_act = getattr(block, "act", None)
+        act_is_silu = block_act is not None and isinstance(block_act, torch.nn.SiLU)
+        ff_proj = getattr(block, "ff_proj", None)
+        up_proj = getattr(block, "up_proj", None)
+        ff_out = getattr(block, "ff_out", None)
+        if not act_is_silu:
+            _warn_once(
+                f"FastDiffusionModel (LLaDA): skipping Triton MLP patch for "
+                f"{type(block_act).__name__} activation — only SiLU is supported. "
+                "MLP LoRA will use PEFT default path."
+            )
+        elif (
+            ff_proj is not None
+            and up_proj is not None
+            and ff_out is not None
+            and hasattr(ff_proj, "lora_A")
+            and hasattr(up_proj, "lora_A")
+            and hasattr(ff_out, "lora_A")
+            and _no_bias(ff_proj)
+            and _no_bias(up_proj)
+            and _no_bias(ff_out)
+            and _no_lora_mag(ff_proj)
+            and _no_lora_mag(up_proj)
+            and _no_lora_mag(ff_out)
+        ):
+            # Set gate_proj/down_proj aliases for apply_lora_mlp_swiglu compatibility.
+            block.gate_proj = ff_proj
+            block.down_proj = ff_out
+            block.apply_mlp = apply_lora_mlp_swiglu
+            n_mlp += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel (LLaDA): cannot patch MLP with Triton kernel "
+                "(LoRA not enabled, bias present, or magnitude scaling active)."
+            )
+
+    return n_qkv, n_o, n_mlp
+
+
+def _patch_modernbert_peft(
+    model: Any, lora_dropout: float, bias: Literal["none", "all", "lora_only"]
+) -> tuple[int, int, int]:
+    """Patch ModernBERT diffusion model with bidirectional fast attention and Triton O-projection.
+
+    ModernBERT uses fused ``Wqkv`` and ``Wo`` (attention) and ``Wi`` / ``Wo`` (MLP).
+    Unlike the LLaMA/Qwen2 path, QKV and MLP Triton kernels are **not** applied
+    in this initial implementation because the fused projection shapes differ from
+    what ``apply_lora_qkv`` / ``apply_lora_mlp_swiglu`` expect.
+
+    What IS patched:
+    - ``layer.attn.forward`` → ``ModernBertAttention_fast_forward`` (CUDA only)
+    - ``layer.attn.Wo``     → ``apply_lora_o`` when conditions allow (CUDA, no dropout, no bias)
+
+    Layer hierarchy:
+        PeftModel → base_model → model (DiffusionModernBertForMaskedLM)
+
+    Returns (n_qkv_patched=0, n_o_patched, n_mlp_patched=0).
+    """
+    n_o = 0
+
+    first_param = next(iter(model.parameters()), None)
+    on_cuda = first_param is not None and first_param.device.type == "cuda"
+
+    # A2DModernBertForMaskedLM wraps A2DModernBertModel in self.model
+    # Path: PeftModel → base_model → model (LM) → model (encoder) → layers
+    try:
+        layers = model.base_model.model.model.layers
+    except AttributeError:
+        _warn_once(
+            "FastDiffusionModel (ModernBERT): could not locate model.layers — "
+            "is this a valid A2DModernBertForMaskedLM PEFT model?"
+        )
+        return 0, 0, 0
+
+    # Install apply_wo stubs unconditionally (CPU + CUDA) so fast_forward
+    # and downstream code can dispatch through apply_wo regardless of device.
+    _install_modernbert_stubs(model)
+
+    if not on_cuda:
+        return 0, 0, 0
+
+    if lora_dropout == 0 and bias == "none":
+        _require_fast_lora()
+
+    for layer in layers:
+        attn = getattr(layer, "attn", None)
+        if attn is None:
+            continue
+
+        # Always inject bidirectional fast-forward on CUDA
+        attn.forward = types.MethodType(ModernBertAttention_fast_forward, attn)
+
+        if lora_dropout != 0 or bias != "none":
+            continue
+
+        # Wo output projection — apply Triton apply_lora_o when conditions met
+        wo = getattr(attn, "Wo", None)
+        if (
+            wo is not None
+            and hasattr(wo, "lora_A")
+            and _no_bias(wo)
+            and _no_lora_mag(wo)
+        ):
+            # Redirect apply_wo to Triton apply_lora_o.
+            # apply_lora_o reads self.o_proj — we alias Wo as o_proj for compatibility.
+            attn.o_proj = attn.Wo
+            attn.apply_wo = apply_lora_o
+            n_o += 1
+        elif wo is not None and not hasattr(wo, "lora_A"):
+            _warn_once(
+                "FastDiffusionModel (ModernBERT): Wo has no LoRA adapter — "
+                "is 'Wo' in target_modules?"
+            )
+
+    return 0, n_o, 0
+
+
+def _no_bias(proj: Any) -> bool:
+    return getattr(proj, "base_layer", proj).bias is None
+
+
+def _no_lora_mag(proj: Any) -> bool:
+    return len(getattr(proj, "lora_magnitude_vector", []) or []) == 0
+
+
+def _load_model_with_optional_4bit_fallback(
+    loader: Any,
+    model_name: str,
+    load_kwargs: dict[str, Any],
+) -> Any:
+    try:
+        return loader.from_pretrained(model_name, **load_kwargs)
+    except Exception as exc:  # noqa: BLE001
+        if "quantization_config" not in load_kwargs:
+            raise
+
+        fallback_kwargs = dict(load_kwargs)
+        fallback_kwargs.pop("quantization_config", None)
+        fallback_kwargs.pop("device_map", None)
+        _warn_once(
+            "FastDiffusionModel: 4-bit loading failed — retrying with full-precision loading."
+        )
+        _logger.debug(
+            "FastDiffusionModel: retrying without 4-bit quantization after error: %s",
+            exc,
+        )
+        return loader.from_pretrained(model_name, **fallback_kwargs)
+
+
+def _is_dllm_hub_qwen3_diffusion_repo(model_name: str) -> bool:
+    """True for dllm-hub Qwen3 diffusion checkpoints converted for Unturtle A2D.
+
+    ``AutoConfig.from_pretrained(..., trust_remote_code=True)`` on these repos
+    may import optional Hub code that declares a dependency on the ``dllm``
+    PyPI package. Loading via :class:`TinyA2DQwen3LMHeadModel` avoids that path.
+    """
+    m = model_name.strip().lower()
+    return m.startswith("dllm-hub/qwen3") and "diffusion" in m
+
+
+def _load_model_auto(
+    model_name: str, load_kwargs: dict, trust_remote_code: bool
+) -> Any:
+    """Try to load a model via AutoModel, AutoModelForMaskedLM, AutoModelForCausalLM.
+
+    Registers unturtle model types so AutoConfig resolves them before trying.
+    Falls back through the chain and raises if all attempts fail.
+
+    Strategy: peek at the model_type in AutoConfig, and if it matches an unturtle
+    native class (llada, Dream/dream, tiny-a2d-llama, tiny-a2d-qwen2, tiny-a2d-qwen3), use that
+    class directly — bypassing
+    trust_remote_code so the Hub's potentially older modeling code is never loaded.
+    This ensures fixes in unturtle model classes (e.g. _tied_weights_keys) take effect.
+    """
+    from transformers import (
+        AutoModel,
+        AutoModelForCausalLM,
+        AutoModelForMaskedLM,
+    )
+
+    import unturtle.models  # noqa: F401 — registers A2D/LLaDA/Dream AutoConfig entries
+
+    # Map model_type → unturtle model class (bypasses trust_remote_code Hub code).
+    _UNTURTLE_MODEL_CLASSES: dict[str, Any] = {}
+    try:
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        _UNTURTLE_MODEL_CLASSES["llada"] = LLaDAModelLM
+    except ImportError:
+        pass
+    try:
+        from unturtle.models.backbones.dream import DreamModel
+
+        _UNTURTLE_MODEL_CLASSES["dream"] = DreamModel
+        # DreamConfig.model_type is "Dream" (capital D) — match Hub configs.
+        _UNTURTLE_MODEL_CLASSES["Dream"] = DreamModel
+    except ImportError:
+        pass
+    try:
+        from unturtle.models.conversion.a2d.tiny_a2d.modeling_llama import (
+            TinyA2DLlamaLMHeadModel,
+        )
+
+        _UNTURTLE_MODEL_CLASSES["tiny-a2d-llama"] = TinyA2DLlamaLMHeadModel
+        # Legacy load-compat: upstream checkpoints with model_type='a2d-llama' (#301).
+        _UNTURTLE_MODEL_CLASSES["a2d-llama"] = TinyA2DLlamaLMHeadModel
+    except ImportError:
+        pass
+    try:
+        from unturtle.models.conversion.a2d.tiny_a2d.modeling_qwen2 import (
+            TinyA2DQwen2LMHeadModel,
+        )
+
+        _UNTURTLE_MODEL_CLASSES["tiny-a2d-qwen2"] = TinyA2DQwen2LMHeadModel
+        _UNTURTLE_MODEL_CLASSES["a2d-qwen2"] = TinyA2DQwen2LMHeadModel
+    except ImportError:
+        pass
+    try:
+        from unturtle.models.conversion.a2d.tiny_a2d.modeling_qwen3 import (
+            TinyA2DQwen3LMHeadModel,
+        )
+
+        _UNTURTLE_MODEL_CLASSES["tiny-a2d-qwen3"] = TinyA2DQwen3LMHeadModel
+        _UNTURTLE_MODEL_CLASSES["a2d-qwen3"] = TinyA2DQwen3LMHeadModel
+    except ImportError:
+        pass
+
+    # Known Tiny-A2D Qwen3 diffusion repos: skip AutoConfig peek (Hub may require ``dllm``).
+    if (
+        _is_dllm_hub_qwen3_diffusion_repo(model_name)
+        and "tiny-a2d-qwen3" in _UNTURTLE_MODEL_CLASSES
+    ):
+        native_cls = _UNTURTLE_MODEL_CLASSES["tiny-a2d-qwen3"]
+        _logger.debug(
+            "FastDiffusionModel: using native %s for dllm-hub Qwen3 diffusion repo (skip AutoConfig peek)",
+            native_cls.__name__,
+        )
+        return _load_model_with_optional_4bit_fallback(
+            native_cls, model_name, load_kwargs
+        )
+
+    # Peek at model_type without loading weights.
+    try:
+        peek_kwargs: dict[str, Any] = {}
+        if "token" in load_kwargs:
+            peek_kwargs["token"] = load_kwargs["token"]
+        config = AutoConfig.from_pretrained(
+            model_name, trust_remote_code=trust_remote_code, **peek_kwargs
+        )
+        model_type = getattr(config, "model_type", "")
+        if model_type in _UNTURTLE_MODEL_CLASSES:
+            native_cls = _UNTURTLE_MODEL_CLASSES[model_type]
+            _logger.debug(
+                "FastDiffusionModel: using native unturtle class %s for model_type=%r",
+                native_cls.__name__,
+                model_type,
+            )
+            return _load_model_with_optional_4bit_fallback(
+                native_cls, model_name, load_kwargs
+            )
+    except torch.cuda.OutOfMemoryError:
+        raise  # OOM should propagate, not fall through to slower AutoModel loaders
+    except Exception as exc:  # noqa: BLE001
+        _logger.debug("FastDiffusionModel: native class lookup failed: %s", exc)
+
+    loaders = [
+        ("AutoModel", AutoModel),
+        ("AutoModelForMaskedLM", AutoModelForMaskedLM),
+        ("AutoModelForCausalLM", AutoModelForCausalLM),
+    ]
+    last_exc: Exception | None = None
+    for name, loader_cls in loaders:
+        try:
+            return _load_model_with_optional_4bit_fallback(
+                loader_cls, model_name, load_kwargs
+            )
+        except Exception as exc:  # noqa: BLE001
+            _logger.debug("FastDiffusionModel: %s failed: %s", name, exc)
+            last_exc = exc
+
+    raise RuntimeError(
+        f"FastDiffusionModel: could not load {model_name!r} via any AutoModel variant. "
+        f"Pass model_class= explicitly.\nLast error: {last_exc}"
+    ) from last_exc
+
+
+def _load_tokenizer(
+    model_name: str, trust_remote_code: bool, token: Optional[str]
+) -> Any:
+    """Load tokenizer; warn instead of silently returning None."""
+    try:
+        tok_kwargs: dict[str, Any] = {"trust_remote_code": trust_remote_code}
+        if token is not None:
+            tok_kwargs["token"] = token
+        return AutoTokenizer.from_pretrained(model_name, **tok_kwargs)
+    except Exception as exc:  # noqa: BLE001
+        import warnings
+
+        warnings.warn(
+            f"FastDiffusionModel: tokenizer not found for {model_name!r}: {exc}\n"
+            "Pass a tokenizer manually or verify the model path.",
+            stacklevel=3,
+        )
+        return None
+
+
+def _extend_rope_if_possible(model: Any, max_seq_length: int) -> None:
+    """Extend RoPE embeddings to cover ``max_seq_length`` if the model supports it.
+
+    Iterates through all modules looking for a ``rotary_emb`` or
+    ``rotary_embedding`` attribute that exposes ``extend_rope_embedding``.
+    This mirrors unsloth's ``extend_model_function``.
+    """
+    for module in model.modules():
+        for rope_attr in ("rotary_emb", "rotary_embedding"):
+            rope = getattr(module, rope_attr, None)
+            if rope is None:
+                continue
+            if hasattr(rope, "extend_rope_embedding"):
+                try:
+                    rope.extend_rope_embedding(max_seq_length)
+                    _logger.debug(
+                        "FastDiffusionModel: extended RoPE to %d via %s",
+                        max_seq_length,
+                        type(rope).__name__,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    _logger.debug("FastDiffusionModel: RoPE extension failed: %s", exc)
+
+
+def _propagate_max_seq_length(model: Any, max_seq_length: int) -> None:
+    """Set max_seq_length on every nested model attribute (mirrors unsloth)."""
+    internal = model
+    while hasattr(internal, "model"):
+        internal.max_seq_length = max_seq_length
+        internal = internal.model
+    internal.max_seq_length = max_seq_length
+    for module in model.modules():
+        module.max_seq_length = max_seq_length
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class FastDiffusionModel:
+    """Drop-in loader and PEFT helper for diffusion language models."""
+
+    @staticmethod
+    def from_pretrained(
+        model_name: str,
+        max_seq_length: int = 2048,
+        dtype: Optional[torch.dtype] = None,
+        load_in_4bit: bool = True,
+        model_class: Any = None,
+        trust_remote_code: bool = True,
+        token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> tuple[Any, Any]:
+        """Load a dLLM model (optionally 4-bit quantised).
+
+        Does NOT call unsloth's ``pre_patch()`` — that would inject causal
+        fast-forward functions, which is wrong for bidirectional dLLMs.
+
+        Args:
+            model_name:         HuggingFace model id or local path.
+            max_seq_length:     Maximum sequence length.
+            dtype:              Torch dtype.  Defaults to bfloat16 on CUDA GPUs
+                                that support it, float16 on other CUDA GPUs, and
+                                float32 on CPU.
+            load_in_4bit:       Enable 4-bit NF4 quantisation via bitsandbytes.
+                                Silently disabled when running on CPU or when
+                                bitsandbytes is not installed.
+            model_class:        Explicit model class override (e.g.
+                                ``TinyA2DLlamaLMHeadModel``).  When *None* the class
+                                is resolved via a fallback chain:
+                                ``AutoModel`` → ``AutoModelForMaskedLM`` →
+                                ``AutoModelForCausalLM``.
+            trust_remote_code:  Passed to ``from_pretrained``.
+            token:              HuggingFace Hub auth token.
+            **kwargs:           Forwarded to ``from_pretrained``.
+
+        Returns:
+            ``(model, tokenizer)`` tuple.  ``tokenizer`` may be ``None`` with
+            a warning if no tokenizer files are found.
+        """
+        # --- PEFT adapter checkpoint detection (API Gap G3) ---
+        # If the path is a local directory that contains adapter_config.json but
+        # not full model weights, load the base model first then wrap with PEFT.
+        from pathlib import Path as _Path
+
+        _local = _Path(model_name) if not model_name.startswith("http") else None
+        _has_full_weights = False
+        if _local is not None and _local.is_dir():
+            try:
+                _has_full_weights = (
+                    any(
+                        (_local / filename).exists()
+                        for filename in (
+                            "model.safetensors",
+                            "pytorch_model.bin",
+                            "pytorch_model.safetensors",
+                            # Sharded checkpoints use an index file instead of a single weight file
+                            "model.safetensors.index.json",
+                            "pytorch_model.bin.index.json",
+                        )
+                    )
+                    or any(_local.glob("model-*-of-*.safetensors"))
+                    or any(
+                        _local.glob("pytorch_model-*-of-*.bin")
+                    )  # legacy sharded .bin
+                )
+            except OSError as _e:
+                _logger.warning(
+                    "FastDiffusionModel: could not scan %r for weight files (%s). "
+                    "Assuming full weights present to avoid incorrect adapter path.",
+                    str(_local),
+                    _e,
+                )
+                _has_full_weights = True
+        if (
+            _local is not None
+            and _local.is_dir()
+            and (_local / "adapter_config.json").exists()
+            and not _has_full_weights
+        ):
+            import json as _json
+
+            from peft import PeftModel as _PeftModel
+
+            try:
+                _adapter_cfg = _json.loads(
+                    (_local / "adapter_config.json").read_text(encoding="utf-8")
+                )
+            except _json.JSONDecodeError as _e:
+                raise ValueError(
+                    f"FastDiffusionModel: adapter_config.json at {_local} is not valid JSON: {_e}"
+                ) from _e
+            except OSError as _e:
+                raise RuntimeError(
+                    f"FastDiffusionModel: could not read adapter_config.json at {_local}: {_e}"
+                ) from _e
+            _base_model_id = _adapter_cfg.get("base_model_name_or_path", "")
+            if not _base_model_id:
+                raise ValueError(
+                    f"adapter_config.json at {_local} has no base_model_name_or_path."
+                )
+            _logger.info(
+                "FastDiffusionModel: detected PEFT adapter checkpoint at %r; "
+                "loading base model %r first.",
+                str(_local),
+                _base_model_id,
+            )
+            base_model, tokenizer = FastDiffusionModel.from_pretrained(
+                model_name=_base_model_id,
+                max_seq_length=max_seq_length,
+                dtype=dtype,
+                load_in_4bit=load_in_4bit,
+                model_class=model_class,
+                trust_remote_code=trust_remote_code,
+                token=token,
+                **kwargs,
+            )
+            try:
+                model = _PeftModel.from_pretrained(base_model, str(_local))
+            except Exception as _e:
+                raise RuntimeError(
+                    f"FastDiffusionModel: failed to load PEFT adapter from {_local!r} "
+                    f"onto base model {_base_model_id!r}: {_e}"
+                ) from _e
+            _install_apply_stubs(model)
+            model.max_seq_length = max_seq_length
+            _propagate_max_seq_length(model, max_seq_length)
+            _extend_rope_if_possible(model, max_seq_length)
+            _logger.info(
+                "FastDiffusionModel: PEFT adapter loaded from %r.", str(_local)
+            )
+            return model, tokenizer
+
+        # --- dtype auto-detection ---
+        if dtype is None:
+            if torch.cuda.is_available():
+                dtype = (
+                    torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+                )
+            else:
+                dtype = torch.float32
+
+        is_on_cpu = not torch.cuda.is_available()
+
+        load_kwargs: dict[str, Any] = dict(
+            torch_dtype=dtype,
+            trust_remote_code=trust_remote_code,
+            **kwargs,
+        )
+        if token is not None:
+            load_kwargs["token"] = token
+
+        # --- 4-bit quantisation (CUDA only) ---
+        if load_in_4bit and not is_on_cpu:
+            if importlib.util.find_spec("bitsandbytes") is None:
+                _warn_once(
+                    "bitsandbytes not installed — falling back to full-precision loading."
+                )
+            else:
+                try:
+                    from transformers import BitsAndBytesConfig
+
+                    bnb_config = BitsAndBytesConfig(
+                        load_in_4bit=True,
+                        bnb_4bit_quant_type="nf4",
+                        bnb_4bit_compute_dtype=dtype,
+                        bnb_4bit_use_double_quant=True,
+                    )
+                    load_kwargs["quantization_config"] = bnb_config
+                    # device_map="auto" is required for multi-GPU or when GPU 0 is partially occupied.
+                    if "device_map" not in load_kwargs:
+                        load_kwargs["device_map"] = "auto"
+                except ImportError:
+                    _warn_once(
+                        "bitsandbytes not installed — falling back to full-precision loading."
+                    )
+        elif load_in_4bit and is_on_cpu:
+            _warn_once(
+                "FastDiffusionModel: load_in_4bit=True requires CUDA — "
+                "falling back to full-precision loading on CPU."
+            )
+
+        # --- Resolve model class ---
+        if model_class is None:
+            model = _load_model_auto(model_name, load_kwargs, trust_remote_code)
+        else:
+            model = model_class.from_pretrained(model_name, **load_kwargs)
+
+        # --- Apply stubs and sequence length ---
+        _install_apply_stubs(model)
+        model.max_seq_length = max_seq_length
+        _propagate_max_seq_length(model, max_seq_length)
+        _extend_rope_if_possible(model, max_seq_length)
+
+        # --- Tokenizer ---
+        tokenizer = _load_tokenizer(model_name, trust_remote_code, token)
+
+        return model, tokenizer
+
+    @staticmethod
+    def get_peft_model(
+        model: Any,
+        r: int = 16,
+        target_modules: Optional[list[str]] = None,
+        lora_alpha: int = 16,
+        lora_dropout: float = 0,
+        bias: Literal["none", "all", "lora_only"] = "none",
+        use_gradient_checkpointing: str | bool = "unsloth",
+        random_state: int = 3407,
+        **kwargs: Any,
+    ) -> Any:
+        """Apply LoRA and patch with unsloth's Triton kernels.
+
+        Uses ``TaskType.FEATURE_EXTRACTION`` (not CAUSAL_LM) to avoid
+        ``PeftModelForCausalLM`` type guards in unsloth's ``patch_peft_model``.
+
+        Args:
+            model:                      Base model (output of ``from_pretrained``).
+            r:                          LoRA rank.
+            target_modules:             Which linear layers to target.
+            lora_alpha:                 LoRA scaling factor.
+            lora_dropout:               Dropout in LoRA adapters (0 = disabled).
+            bias:                       LoRA bias mode (``"none"``, ``"all"``,
+                                        ``"lora_only"``).
+            use_gradient_checkpointing: ``"unsloth"`` for unsloth-style GC,
+                                        ``True`` for standard, ``False`` to disable.
+            random_state:               Seed passed to PEFT.
+            **kwargs:                   Forwarded to ``LoraConfig``.
+
+        Returns:
+            PEFT model with Triton LoRA kernels patched in.
+        """
+        if target_modules is None:
+            target_modules = [
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+                "gate_proj",
+                "up_proj",
+                "down_proj",
+            ]
+
+        lora_config = LoraConfig(
+            task_type=TaskType.FEATURE_EXTRACTION,
+            r=r,
+            target_modules=target_modules,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            bias=bias,
+            **kwargs,
+        )
+
+        # Install apply_qkv / apply_o stubs before PEFT wrapping so that
+        # fast-forward functions can dispatch even when the model was not
+        # loaded via from_pretrained (e.g. tests using random-weight models).
+        _install_apply_stubs(model)
+
+        quantization_method = getattr(model, "quantization_method", None)
+        is_quantized_model = any(
+            getattr(model, attr, False)
+            for attr in ("is_loaded_in_4bit", "is_loaded_in_8bit", "hqq_quantized")
+        ) or quantization_method in {"gptq", "aqlm", "eetq", "torchao", "hqq"}
+
+        if is_quantized_model:
+            model = prepare_model_for_kbit_training(
+                model,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                use_reentrant=True,
+            )
+        elif bool(use_gradient_checkpointing):
+            if hasattr(model, "enable_input_require_grads"):
+                model.enable_input_require_grads()
+            elif hasattr(model, "get_input_embeddings"):
+                input_embeddings = model.get_input_embeddings()
+                if input_embeddings is not None:
+                    input_embeddings.register_forward_hook(
+                        lambda module, inputs, output: output.requires_grad_(True)
+                    )
+            _apply_gradient_checkpointing_mode(model, use_gradient_checkpointing)
+
+        model = get_peft_model(model, lora_config)
+        model._unturtle_gradient_checkpointing_mode = use_gradient_checkpointing
+
+        FastDiffusionModel.patch_peft_model(model, lora_dropout=lora_dropout, bias=bias)
+        patch_saving_functions(model)
+
+        return model
+
+    @staticmethod
+    def patch_peft_model(
+        model: Any,
+        lora_dropout: float = 0,
+        bias: Literal["none", "all", "lora_only"] = "none",
+    ) -> None:
+        """Inject Triton LoRA kernels and bidirectional attention into a PEFT model.
+
+        Safe to call again after adding new adapters.
+
+        Args:
+            model:          PEFT-wrapped dLLM model.
+            lora_dropout:   Must match the LoRA config used when wrapping.
+            bias:           Must match the LoRA config used when wrapping.
+        """
+        model_type = model.config.model_type
+
+        if model_type in _TINY_A2D_MODEL_TYPES:
+            n_qkv, n_o, n_mlp = _patch_a2d_peft(model, lora_dropout, bias)
+            n_layers = len(model.base_model.model.model.layers)
+            _warn_once(
+                f"FastDiffusionModel patched {n_layers} layers with "
+                f"{n_qkv} QKV layers, {n_o} O layers and {n_mlp} MLP layers "
+                f"(bidirectional, causal=False)."
+            )
+        elif model_type in _DREAM_MODEL_TYPES:
+            n_qkv, n_o, n_mlp = _patch_dream_peft(model, lora_dropout, bias)
+            n_layers = len(model.base_model.model.model.layers)
+            _warn_once(
+                f"FastDiffusionModel (Dream) patched {n_layers} layers with "
+                f"{n_qkv} QKV layers (bias kernel), {n_o} O layers and {n_mlp} MLP layers."
+            )
+        elif model_type in _LLADA_MODEL_TYPES:
+            n_qkv, n_o, n_mlp = _patch_llada_peft(model, lora_dropout, bias)
+            inner = model.base_model.model
+            _llada_transformer = (
+                inner.model.transformer
+                if hasattr(inner, "model") and hasattr(inner.model, "transformer")
+                else getattr(inner, "transformer", None)
+            )
+            n_blocks = (
+                len(_llada_transformer.blocks) if _llada_transformer is not None else 0
+            )
+            _warn_once(
+                f"FastDiffusionModel (LLaDA) patched {n_blocks} blocks with "
+                f"{n_qkv} QKV blocks and {n_o} O (attn_out) blocks."
+            )
+        elif model_type in _MODERNBERT_A2D_MODEL_TYPES:
+            _n_qkv, n_o, _n_mlp = _patch_modernbert_peft(model, lora_dropout, bias)
+            n_layers = len(model.base_model.model.model.layers)
+            _warn_once(
+                f"FastDiffusionModel (ModernBERT) patched {n_layers} layers with "
+                f"{n_o} Wo (output proj) layers. "
+                "Wqkv/MLP Triton kernels not yet supported for ModernBERT — "
+                "see issue #59 Phase 2."
+            )
+        else:
+            raise NotImplementedError(
+                f"FastDiffusionModel does not yet support model_type={model_type!r}. "
+                "Supported types: "
+                + ", ".join(
+                    sorted(
+                        _TINY_A2D_MODEL_TYPES
+                        | _DREAM_MODEL_TYPES
+                        | _LLADA_MODEL_TYPES
+                        | _MODERNBERT_A2D_MODEL_TYPES
+                    )
+                )
+            )
+
+        # Propagate max_seq_length through the wrapped model hierarchy
+        if hasattr(model, "max_seq_length"):
+            _propagate_max_seq_length(model, model.max_seq_length)
+
+    @staticmethod
+    def for_inference(model: Any) -> Any:
+        """Switch model to inference mode.
+
+        Sets ``model.eval()`` and disables gradient checkpointing so that
+        inference is as fast as possible.  Returns the model for convenience.
+
+        Note: dLLMs do not use KV cache, so there is no cache-enabling step
+        unlike ``FastLanguageModel.for_inference`` for AR models.
+
+        Usage::
+
+            FastDiffusionModel.for_inference(model)
+            with torch.no_grad():
+                logits = model(**inputs).logits
+
+        Args:
+            model: A dLLM model (plain or PEFT-wrapped).
+
+        Returns:
+            The same model in eval mode.
+        """
+        model.eval()
+        _apply_gradient_checkpointing_mode(model, False)
+        return model
+
+    @staticmethod
+    def generate(
+        model: Any,
+        inputs: Any = None,
+        *,
+        algorithm: str = "auto",
+        **kwargs: Any,
+    ) -> Any:
+        """Generate from a dLLM with an explicit decoding algorithm.
+
+        High-level, unsloth-style inference entry. ``algorithm`` selects the decoding path:
+
+          - ``"auto"`` (default): fastest discrete algorithm the model supports —
+            block-decode (Fast-dLLM) when available, else MDLM; BD3LM when requested.
+          - ``"mdlm"`` / ``"block_decode"`` / ``"bd3lm"``: force a named path
+            (benchmarking / research / algorithm comparison).
+
+        Delegates to ``model.diffusion_generate(...)`` with the flag set the chosen
+        algorithm implies, so output is identical to calling ``diffusion_generate`` with
+        those flags directly. ``**kwargs`` (steps, temperature, max_new_tokens, ...) are
+        forwarded unchanged.
+
+        Args:
+            model: A dLLM model exposing ``diffusion_generate`` (e.g. from
+                ``FastDiffusionModel.from_pretrained``).
+            inputs: Prompt token IDs (``[B, L]``).
+            algorithm: ``"auto"`` | ``"mdlm"`` | ``"block_decode"`` | ``"bd3lm"``.
+            **kwargs: Forwarded to ``diffusion_generate`` / the generation config.
+
+        Returns:
+            Whatever ``model.diffusion_generate`` returns (token IDs or model output).
+        """
+        if not callable(getattr(model, "diffusion_generate", None)):
+            raise TypeError(
+                f"{type(model).__name__} has no `diffusion_generate` method; "
+                "FastDiffusionModel.generate requires a dLLM model."
+            )
+
+        bd3lm_requested = bool(kwargs.get("use_block_diffusion", False)) or (
+            algorithm == "bd3lm"
+        )
+        resolved = resolve_algorithm(algorithm, model, bd3lm_requested=bd3lm_requested)
+        flags = algorithm_to_flags(resolved)
+
+        # Explicit algorithm flags win over any conflicting legacy flags in kwargs,
+        # so the named algorithm is authoritative.
+        call_kwargs = {**kwargs, **flags}
+        return model.diffusion_generate(inputs=inputs, **call_kwargs)
+
+    @staticmethod
+    def for_training(model: Any, use_gradient_checkpointing: bool | str = True) -> Any:
+        """Switch model back to training mode and re-enable gradient checkpointing.
+
+        Args:
+            model:                      A dLLM model (plain or PEFT-wrapped).
+            use_gradient_checkpointing: ``True`` / ``"unsloth"`` to enable GC,
+                                        ``False`` to leave it disabled.
+
+        Returns:
+            The same model in train mode.
+        """
+        model.train()
+        _apply_gradient_checkpointing_mode(model, use_gradient_checkpointing)
+        return model
+
+    @staticmethod
+    def save_pretrained_merged(
+        model: Any,
+        save_directory: str,
+        tokenizer: Any = None,
+        safe_serialization: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        """Merge LoRA adapters into the base weights and save.
+
+        Calls PEFT's ``merge_and_unload()`` on a copy of the model, then saves
+        the merged weights with ``save_pretrained``.  The original model
+        (with adapters) is left unchanged.
+
+        Args:
+            model:              PEFT-wrapped dLLM model (output of ``get_peft_model``).
+            save_directory:     Local directory path to save the merged model.
+            tokenizer:          Optional tokenizer to save alongside the model.
+            safe_serialization: Use safetensors format (recommended).
+            **kwargs:           Forwarded to ``save_pretrained``.
+        """
+        import copy
+
+        _logger.info("FastDiffusionModel: merging LoRA adapters into base weights …")
+        merged = copy.deepcopy(model)
+        # merge_and_unload returns the unwrapped base model with adapters merged.
+        merged = merged.merge_and_unload()
+        merged.save_pretrained(
+            save_directory,
+            safe_serialization=safe_serialization,
+            **kwargs,
+        )
+        _logger.info("FastDiffusionModel: merged model saved to %r", save_directory)
+        if tokenizer is not None:
+            tokenizer.save_pretrained(save_directory)
+            _logger.info("FastDiffusionModel: tokenizer saved to %r", save_directory)
+
+    @staticmethod
+    def push_to_hub_merged(
+        model: Any,
+        repo_id: str,
+        tokenizer: Any = None,
+        safe_serialization: bool = True,
+        token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Merge LoRA adapters and push merged weights to the HuggingFace Hub.
+
+        Merges adapters via PEFT's ``merge_and_unload()`` then calls
+        ``push_to_hub`` on the merged model.  The original model is unchanged.
+
+        Args:
+            model:              PEFT-wrapped dLLM model.
+            repo_id:            HuggingFace Hub repository id (e.g. ``"user/my-model"``).
+            tokenizer:          Optional tokenizer to push alongside the model.
+            safe_serialization: Use safetensors format.
+            token:              HuggingFace auth token.
+            **kwargs:           Forwarded to ``push_to_hub``.
+        """
+        import copy
+
+        _logger.info("FastDiffusionModel: merging LoRA adapters for Hub push …")
+        merged = copy.deepcopy(model)
+        merged = merged.merge_and_unload()
+
+        push_kwargs: dict[str, Any] = dict(
+            safe_serialization=safe_serialization, **kwargs
+        )
+        if token is not None:
+            push_kwargs["token"] = token
+
+        merged.push_to_hub(repo_id, **push_kwargs)
+        _logger.info("FastDiffusionModel: merged model pushed to %r", repo_id)
+        if tokenizer is not None:
+            tokenizer.push_to_hub(repo_id, **push_kwargs)
+
+    @staticmethod
+    def save_pretrained_gguf(
+        model: Any,
+        save_directory: str,
+        tokenizer: Any = None,
+        quantization_method: str = "q4_k_m",
+        **kwargs: Any,
+    ) -> None:
+        """Convert and save model weights in GGUF format.
+
+        Ensures ``unturtle.save.patch_saving_functions`` has been applied before
+        delegating to the monkey-patched ``model.save_pretrained_gguf``.
+
+        Args:
+            model:                A dLLM model (plain or PEFT-wrapped).
+            save_directory:       Local directory path for GGUF output.
+            tokenizer:            Tokenizer to pass to the GGUF converter.
+            quantization_method:  One of ``q4_k_m``, ``q5_k_m``, ``q8_0``, ``f16``.
+            **kwargs:             Forwarded to the underlying GGUF save call.
+        """
+        from unturtle.save import patch_saving_functions
+
+        patch_saving_functions(model)
+        if not hasattr(model, "save_pretrained_gguf"):
+            raise RuntimeError(
+                "save_pretrained_gguf is not available. "
+                "Ensure the llama.cpp GGUF toolchain is installed."
+            )
+        model.save_pretrained_gguf(
+            save_directory,
+            tokenizer,
+            quantization_method=quantization_method,
+            **kwargs,
+        )
+        _logger.info(
+            "FastDiffusionModel: GGUF model saved to %r (quant=%s)",
+            save_directory,
+            quantization_method,
+        )
+
+    @staticmethod
+    def save_lora_adapter(
+        model: Any,
+        save_directory: str,
+        tokenizer: Any = None,
+    ) -> None:
+        """Save LoRA adapter weights only (no base model weights).
+
+        Args:
+            model:          A PEFT-wrapped dLLM model.
+            save_directory: Local directory path for the adapter files.
+            tokenizer:      Optional tokenizer to save alongside the adapter.
+
+        Raises:
+            ValueError: If ``model`` is not a PEFT model.
+        """
+        try:
+            from peft import PeftModel
+        except ImportError as exc:
+            raise RuntimeError("peft is required for save_lora_adapter") from exc
+
+        if not isinstance(model, PeftModel):
+            raise ValueError(
+                "save_lora_adapter requires a PEFT-wrapped model. "
+                "The provided model appears to be a merged (non-PEFT) model."
+            )
+        model.save_pretrained(save_directory)
+        _logger.info("FastDiffusionModel: LoRA adapter saved to %r", save_directory)
+        if tokenizer is not None:
+            tokenizer.save_pretrained(save_directory)
+            _logger.info("FastDiffusionModel: tokenizer saved to %r", save_directory)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def inference_context(model: Any):
+        """Context manager that temporarily switches to inference mode.
+
+        Restores training mode on exit.
+
+        Usage::
+
+            with FastDiffusionModel.inference_context(model):
+                logits = model(**inputs).logits
+
+        Args:
+            model: A dLLM model (plain or PEFT-wrapped).
+        """
+        was_training = model.training
+        gc_mode = _get_gradient_checkpointing_mode(model)
+        FastDiffusionModel.for_inference(model)
+        try:
+            with torch.no_grad():
+                yield model
+        finally:
+            if was_training:
+                FastDiffusionModel.for_training(
+                    model, use_gradient_checkpointing=gc_mode
+                )
+            else:
+                model.eval()
+                _apply_gradient_checkpointing_mode(model, gc_mode)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _original_apply_qkv(self: Any, X: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    return self.q_proj(X), self.k_proj(X), self.v_proj(X)
+
+
+def _original_apply_o(self: Any, X: torch.Tensor) -> torch.Tensor:
+    return self.o_proj(X)
+
+
+def _install_apply_stubs(model: Any) -> None:
+    """Set apply_qkv / apply_o stubs on all self_attn layers that lack them.
+
+    unsloth's fast-forward dispatch protocol requires these attributes to exist
+    even before PEFT is applied, so the fast-forward function can call
+    ``self.apply_qkv(self, hidden_states)`` unconditionally.
+    """
+    for module in model.modules():
+        if hasattr(module, "q_proj") and hasattr(module, "o_proj"):
+            if not hasattr(module, "apply_qkv"):
+                module.apply_qkv = _original_apply_qkv
+            if not hasattr(module, "apply_o"):
+                module.apply_o = _original_apply_o
+
+
+def _get_gradient_checkpointing_mode(model: Any) -> bool | str:
+    """Return the current gradient-checkpointing mode tracked by unturtle.
+
+    We explicitly track the requested mode because a temporary inference pass
+    should be reversible: `True`, `False`, and `"unsloth"` need to round-trip.
+    Falling back to module flags loses the distinction between `True` and
+    `"unsloth"`.
+    """
+    if hasattr(model, "_unturtle_gradient_checkpointing_mode"):
+        return model._unturtle_gradient_checkpointing_mode
+
+    for module in model.modules():
+        if hasattr(module, "gradient_checkpointing"):
+            return bool(module.gradient_checkpointing)
+    return False
+
+
+def _apply_gradient_checkpointing_mode(model: Any, mode: bool | str) -> None:
+    """Apply and persist a gradient-checkpointing mode to all reachable modules."""
+    model._unturtle_gradient_checkpointing_mode = mode
+
+    for module in model.modules():
+        if hasattr(module, "gradient_checkpointing"):
+            module.gradient_checkpointing = bool(mode)
+
+    if bool(mode):
+        if hasattr(model, "gradient_checkpointing_enable"):
+            model.gradient_checkpointing_enable()
+    else:
+        if hasattr(model, "gradient_checkpointing_disable"):
+            model.gradient_checkpointing_disable()

--- a/unturtle/models/__init__.py
+++ b/unturtle/models/__init__.py
@@ -14,7 +14,7 @@
 
 """unturtle.models — Diffusion Language Model architectures.
 
-Public API (generation infrastructure — available now)::
+Public API (generation infrastructure + backbones — available now)::
 
     from unturtle.models.generation.cache import BlockKVCache
     from unturtle.models.generation.diffusion_generation_utils import (
@@ -23,11 +23,15 @@ Public API (generation infrastructure — available now)::
         MaskedDiffusionModelOutput,
         prepare_for_sampling,
     )
-
-Backbones and conversion methods will be exported here once Task 4 / Task 5 land:
-
     from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
     from unturtle.models.backbones.dream import DreamConfig, DreamModel
+    from unturtle.models.backbones.modernbert import (
+        DiffusionModernBertConfig,
+        DiffusionModernBertForMaskedLM,
+    )
+
+Conversion methods will be exported here once Task 5 lands:
+
     from unturtle.models.conversion.a2d import (
         TinyA2DLlamaConfig, TinyA2DLlamaLMHeadModel,
         TinyA2DQwen2Config, TinyA2DQwen2LMHeadModel,
@@ -35,6 +39,28 @@ Backbones and conversion methods will be exported here once Task 4 / Task 5 land
     )
 """
 
+from .backbones.dream import (
+    DreamConfig,
+    DreamGenerationConfig,
+    DreamGenerationMixin,
+    DreamModel,
+)
+from .backbones.llada import (
+    LLaDAConfig,
+    LLaDAGenerationConfig,
+    LLaDAGenerationMixin,
+    LLaDAModel,
+    LLaDAModelLM,
+)
+from .backbones.modernbert import (
+    # Backward compat aliases
+    A2DModernBertConfig,
+    A2DModernBertForMaskedLM,
+    A2DModernBertModel,
+    DiffusionModernBertConfig,
+    DiffusionModernBertForMaskedLM,
+    DiffusionModernBertModel,
+)
 from .generation.cache import BlockKVCache
 from .generation.diffusion_generation_utils import (
     MaskedDiffusionGenerationConfig,
@@ -44,10 +70,30 @@ from .generation.diffusion_generation_utils import (
 )
 
 __all__ = [
+    # generation infrastructure
     "BlockKVCache",
     "MaskedDiffusionGenerationConfig",
     "MaskedDiffusionGenerationMixin",
     "MaskedDiffusionModelOutput",
     "prepare_for_sampling",
-    # Backbones (Task 4) and conversion (Task 5) exports will be added here.
+    # LLaDA backbone
+    "LLaDAConfig",
+    "LLaDAGenerationConfig",
+    "LLaDAGenerationMixin",
+    "LLaDAModel",
+    "LLaDAModelLM",
+    # Dream backbone
+    "DreamConfig",
+    "DreamGenerationConfig",
+    "DreamGenerationMixin",
+    "DreamModel",
+    # ModernBERT diffusion backbone
+    "DiffusionModernBertConfig",
+    "DiffusionModernBertModel",
+    "DiffusionModernBertForMaskedLM",
+    # ModernBERT backward compat aliases (A2D-prefixed)
+    "A2DModernBertConfig",
+    "A2DModernBertModel",
+    "A2DModernBertForMaskedLM",
+    # Conversion (Task 5) exports will be added here.
 ]

--- a/unturtle/models/backbones/__init__.py
+++ b/unturtle/models/backbones/__init__.py
@@ -1,0 +1,54 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle.models.backbones — the *architecture* axis of a dLLM.
+
+A concrete dLLM is a point in three orthogonal axes::
+
+    backbone architecture  ×  conversion method  ×  training objective
+    (this package)            (unturtle.models.conversion)  (unturtle.diffusion)
+
+This package is the canonical home for backbone architectures. The native
+bidirectional backbones physically live here as subpackages; their heavy
+implementations (and their one-time ``transformers.AutoConfig.register`` side
+effects) run exactly once on import.
+
+Native bidirectional backbones:
+  - LLaDA  (unturtle.models.backbones.llada)
+  - Dream  (unturtle.models.backbones.dream)
+  - ModernBERT diffusion  (unturtle.models.backbones.modernbert)
+
+AR backbones reachable via the A2D conversion method live under
+``unturtle.models.conversion`` (see unturtle.models.conversion.a2d) — they are a
+conversion *method*, not a peer architecture, so they are not re-exported here.
+"""
+
+from .dream import DreamConfig, DreamModel
+from .llada import LLaDAConfig, LLaDAModel, LLaDAModelLM
+from .modernbert import (
+    DiffusionModernBertConfig,
+    DiffusionModernBertForMaskedLM,
+    DiffusionModernBertModel,
+)
+
+__all__ = [
+    "DreamConfig",
+    "DreamModel",
+    "LLaDAConfig",
+    "LLaDAModel",
+    "LLaDAModelLM",
+    "DiffusionModernBertConfig",
+    "DiffusionModernBertModel",
+    "DiffusionModernBertForMaskedLM",
+]

--- a/unturtle/models/backbones/dream/__init__.py
+++ b/unturtle/models/backbones/dream/__init__.py
@@ -1,0 +1,42 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dream diffusion language models.
+
+Native bidirectional diffusion language model with custom generation utilities.
+Original implementation by The Dream team, HKUNLP Group and the HuggingFace Inc. team.
+
+Usage::
+
+    from unturtle.models.backbones.dream import DreamConfig, DreamModel
+
+    config = DreamConfig(
+        vocab_size=10000, hidden_size=256, num_hidden_layers=4,
+        num_attention_heads=4, num_key_value_heads=4,
+    )
+    model = DreamModel(config)
+"""
+
+from .configuration_dream import DreamConfig
+from .generation_utils import DreamGenerationConfig, DreamGenerationMixin
+from .modeling_dream import DreamBaseModel, DreamModel, DreamPreTrainedModel
+
+__all__ = [
+    "DreamConfig",
+    "DreamPreTrainedModel",
+    "DreamBaseModel",
+    "DreamModel",
+    "DreamGenerationMixin",
+    "DreamGenerationConfig",
+]

--- a/unturtle/models/backbones/dream/configuration_dream.py
+++ b/unturtle/models/backbones/dream/configuration_dream.py
@@ -1,0 +1,85 @@
+# Copyright 2024 The Dream team, HKUNLP Group and the HuggingFace Inc. team. All rights reserved.
+# Ported to Unturtle by nishide-dev & the Unturtle team (2025).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dream model configuration"""
+
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_rope_utils import rope_config_validation
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+
+class DreamConfig(PretrainedConfig):
+    model_type = "Dream"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size=151936,
+        hidden_size=4096,
+        intermediate_size=22016,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        num_key_value_heads=32,
+        hidden_act="silu",
+        max_position_embeddings=32768,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=False,  # cache not used in diffusion
+        tie_word_embeddings=False,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        use_sliding_window=False,
+        sliding_window=4096,
+        max_window_layers=28,
+        attention_dropout=0.0,
+        mask_token_id=151666,
+        pad_token_id=151643,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.use_sliding_window = use_sliding_window
+        self.sliding_window = sliding_window if use_sliding_window else None
+        self.max_window_layers = max_window_layers
+
+        # for backward compatibility
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
+
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.attention_dropout = attention_dropout
+        # Validate the correctness of rotary position embeddings parameters
+        # BC: if there is a 'type' field, move it to 'rope_type'.
+        if self.rope_scaling is not None and "type" in self.rope_scaling:
+            self.rope_scaling["rope_type"] = self.rope_scaling["type"]
+        rope_config_validation(self)
+
+        super().__init__(
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+        self.mask_token_id = mask_token_id
+        self.pad_token_id = pad_token_id

--- a/unturtle/models/backbones/dream/generation_utils.py
+++ b/unturtle/models/backbones/dream/generation_utils.py
@@ -1,0 +1,725 @@
+# Copyright 2024 The Dream team, HKUNLP Group and the HuggingFace Inc. team. All rights reserved.
+# Ported to Unturtle by nishide-dev & the Unturtle team (2025).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import warnings
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Dict, Optional, Tuple, Union, cast
+
+import torch
+import torch.distributions as dists
+from torch.nn import functional as F
+from transformers import __version__
+from transformers.generation.configuration_utils import GenerationConfig
+from transformers.utils import (
+    ModelOutput,
+    is_torchdynamo_compiling,
+    logging,
+)
+
+from unturtle.models.generation.block_decode_mixin import BlockDecodeMixin
+
+logger = logging.get_logger(__name__)
+
+
+def top_p_logits(logits, top_p=None):
+    sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+    cumulative_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1), dim=-1)
+    sorted_indices_to_remove = cumulative_probs > top_p
+    # Shift the indices to the right to keep the first token above the threshold
+    sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
+    sorted_indices_to_remove[..., 0] = 0
+
+    mask = torch.zeros_like(logits, dtype=torch.bool, device=logits.device)
+    mask = mask.scatter_(-1, sorted_indices, sorted_indices_to_remove)
+    logits = logits.masked_fill(mask, torch.finfo(logits.dtype).min)
+    return logits
+
+
+def top_k_logits(logits, top_k=None):
+    if top_k is None:
+        return logits
+    top_k = min(cast(int, top_k), logits.size(-1))  # Safety check
+    # Remove all tokens with a probability less than the last token of the top-k
+    indices_to_remove = logits < torch.topk(logits, top_k)[0][..., -1, None]
+    logits = logits.masked_fill(indices_to_remove, torch.finfo(logits.dtype).min)
+    return logits
+
+
+def sample_tokens(
+    logits,
+    temperature=0.0,
+    top_p=None,
+    top_k=None,
+    margin_confidence=False,
+    neg_entropy=False,
+):
+
+    if temperature > 0:
+        logits = logits / temperature
+    if top_p is not None and top_p < 1:
+        logits = top_p_logits(logits, top_p)
+    if top_k is not None:
+        logits = top_k_logits(logits, top_k)
+    probs = torch.softmax(logits, dim=-1)
+
+    if temperature > 0:
+        try:
+            x0 = dists.Categorical(probs=probs).sample()
+            confidence = torch.gather(probs, -1, x0.unsqueeze(-1)).squeeze(-1)
+        except (ValueError, RuntimeError):
+            # probs may not sum to 1.0 exactly after softmax (ValueError from Categorical
+            # validate_args), or contain NaN/inf when validate_args is disabled (RuntimeError
+            # from torch.multinomial); fall back to argmax
+            confidence, x0 = probs.max(dim=-1)
+    else:
+        confidence, x0 = probs.max(dim=-1)
+
+    if margin_confidence:
+        sorted_probs, _ = torch.sort(probs, dim=-1, descending=True)
+        # Extract top1 and top2 probabilities
+        top1_probs = sorted_probs[:, 0]
+        top2_probs = sorted_probs[:, 1]
+        # Calculate confidence as top1 - top2
+        confidence = top1_probs - top2_probs
+
+    if neg_entropy:
+        epsilon = 1e-10
+        log_probs = torch.log(probs + epsilon)
+        confidence = torch.sum(probs * log_probs, dim=-1)
+
+    return confidence, x0
+
+
+@dataclass
+class DreamModelOutput(ModelOutput):
+    sequences: Optional[torch.LongTensor] = None
+    history: Optional[Tuple[torch.FloatTensor]] = None
+    timing: Optional[Dict[str, Any]] = None
+
+
+class DreamGenerationConfig(GenerationConfig):
+    def __init__(self, **kwargs):
+        self.temperature: float = kwargs.pop("temperature", 0.0)
+        self.top_p: Optional[float] = kwargs.pop("top_p", None)
+        self.top_k: Optional[int] = kwargs.pop("top_k", None)
+        self.max_length = kwargs.pop("max_length", 20)
+        self.max_new_tokens = kwargs.pop("max_new_tokens", None)
+        # diffusion specific params
+        self.eps: float = kwargs.pop("eps", 1e-3)
+        self.steps: int = kwargs.pop("steps", 512)
+        self.alg: str = kwargs.pop("alg", "origin")
+        self.alg_temp: Optional[float] = kwargs.pop("alg_temp", None)
+        # cache control
+        self.use_cache: bool = kwargs.pop("use_cache", False)
+        self.block_length: Optional[int] = kwargs.pop("block_length", None)
+        self.use_replace_cache: bool = kwargs.pop("use_replace_cache", True)
+        # parallel decode
+        self.parallel_decode: bool = kwargs.pop("parallel_decode", False)
+        self.confidence_threshold: float = kwargs.pop("confidence_threshold", 0.9)
+        self.confidence_type: str = kwargs.pop("confidence_type", "max_prob")
+
+        # Parameters that define the output variables of `generate`
+        self.num_return_sequences: int = kwargs.pop("num_return_sequences", 1)
+        self.return_dict: bool = kwargs.pop("return_dict", False)
+        self.output_history: bool = kwargs.pop("output_history", False)
+        self.output_timing: bool = kwargs.pop("output_timing", False)
+
+        # Special tokens that can be used at generation time
+        self.mask_token_id = kwargs.pop("mask_token_id", None)
+        self.pad_token_id = kwargs.pop("pad_token_id", None)
+        self.bos_token_id = kwargs.pop("bos_token_id", None)
+        self.eos_token_id = kwargs.pop("eos_token_id", None)
+
+        # Wild card
+        self.generation_kwargs = kwargs.pop("generation_kwargs", {})
+
+        # The remaining attributes do not parametrize `.generate()`, but are informative and/or used by the hub
+        # interface.
+        self._from_model_config = kwargs.pop("_from_model_config", False)
+        self._commit_hash = kwargs.pop("_commit_hash", None)
+        self.transformers_version = kwargs.pop("transformers_version", __version__)
+
+        # Additional attributes without default values
+        if not self._from_model_config:
+            for key, value in kwargs.items():
+                try:
+                    setattr(self, key, value)
+                except AttributeError as err:
+                    logger.error(f"Can't set {key} with value {value} for {self}")
+                    raise err
+
+        self.validate(is_init=True)
+
+    def validate(self, is_init: bool = False):
+        if self.parallel_decode and not self.use_cache:
+            raise ValueError("`parallel_decode=True` requires `use_cache=True`.")
+        if self.parallel_decode and self.alg == "origin":
+            raise ValueError("`parallel_decode=True` does not support `alg='origin'`.")
+        if not 0.0 <= self.confidence_threshold <= 1.0:
+            raise ValueError(
+                f"confidence_threshold must be in [0, 1], got {self.confidence_threshold}"
+            )
+        if self.confidence_type not in {"max_prob", "margin", "neg_entropy"}:
+            raise ValueError(
+                f"Unknown confidence_type={self.confidence_type!r}. Choose from 'max_prob', 'margin', 'neg_entropy'."
+            )
+
+
+class DreamGenerationMixin(BlockDecodeMixin):
+    config: Any
+    generation_config: Any
+
+    @staticmethod
+    def _expand_inputs_for_generation(
+        expand_size: int = 1,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.LongTensor] = None,
+    ) -> Tuple[Optional[torch.LongTensor], Optional[torch.LongTensor]]:
+        """Expands tensors from [batch_size, ...] to [batch_size * expand_size, ...]"""
+        # Do not call torch.repeat_interleave if expand_size is 1 because it clones
+        # the input tensor and thus requires more memory although no change is applied
+        if expand_size == 1:
+            return input_ids, attention_mask
+        if input_ids is not None:
+            input_ids = input_ids.repeat_interleave(expand_size, dim=0)
+        if attention_mask is not None:
+            attention_mask = attention_mask.repeat_interleave(expand_size, dim=0)
+        return input_ids, attention_mask
+
+    def _validate_generated_length(
+        self, generation_config, input_ids_length, has_default_max_length
+    ):
+        """Performs validation related to the resulting generated length"""
+
+        # Can't throw warnings/exceptions during compilation
+        if is_torchdynamo_compiling():
+            return
+
+        # 1. Max length warnings related to poor parameterization
+        if (
+            has_default_max_length
+            and generation_config.max_new_tokens is None
+            and generation_config.max_length == 20
+        ):
+            # 20 is the default max_length of the generation config
+            warnings.warn(
+                f"Using the model-agnostic default `max_length` (={generation_config.max_length}) to control the "
+                "generation length. We recommend setting `max_new_tokens` to control the maximum length of the "
+                "generation.",
+                UserWarning,
+            )
+        if input_ids_length >= generation_config.max_length:
+            input_ids_string = "input_ids"
+            raise ValueError(
+                f"Input length of {input_ids_string} is {input_ids_length}, but `max_length` is set to"
+                f" {generation_config.max_length}. This can lead to unexpected behavior. You should consider"
+                " increasing `max_length` or, better yet, setting `max_new_tokens`."
+            )
+
+    def _prepare_generated_length(
+        self,
+        generation_config,
+        has_default_max_length,
+        input_ids_length,
+    ):
+        """Prepared max and min length in generation configs to avoid clashes between similar attributes"""
+
+        if generation_config.max_new_tokens is not None:
+            if not has_default_max_length and generation_config.max_length is not None:
+                logger.warning(
+                    f"Both `max_new_tokens` (={generation_config.max_new_tokens}) and `max_length`(="
+                    f"{generation_config.max_length}) seem to have been set. `max_new_tokens` will take precedence. "
+                    "Please refer to the documentation for more information. "
+                    "(https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)"
+                )
+            generation_config.max_length = (
+                generation_config.max_new_tokens + input_ids_length
+            )
+
+        elif has_default_max_length:
+            if generation_config.max_length == DreamGenerationConfig().max_length:
+                generation_config.max_length = (
+                    generation_config.max_length + input_ids_length
+                )
+                max_position_embeddings = getattr(
+                    self.config, "max_position_embeddings", None
+                )
+                if max_position_embeddings is not None:
+                    generation_config.max_length = min(
+                        generation_config.max_length, max_position_embeddings
+                    )
+
+        return generation_config
+
+    def _prepare_generation_config(
+        self, generation_config: Optional[DreamGenerationConfig], **kwargs: Dict
+    ) -> DreamGenerationConfig:
+        """
+        Prepares the base generation config, then applies any generation configuration options from kwargs. This
+        function handles retrocompatibility with respect to configuration files.
+        """
+        # priority: `generation_config` argument > `model.generation_config` (the default generation config)
+        using_model_generation_config = False
+        if generation_config is None:
+            generation_config = cast(
+                DreamGenerationConfig,
+                DreamGenerationConfig.from_model_config(self.config),
+            )
+            using_model_generation_config = True
+
+        # `torch.compile` can't compile `copy.deepcopy`, arguments in `kwargs` that are part of `generation_config`
+        # will mutate the object with `.update`. As such, passing these arguments through `kwargs` is disabled -- an
+        # exception will be raised in `_validate_model_kwargs`
+        if not is_torchdynamo_compiling():
+            generation_config = cast(
+                DreamGenerationConfig, copy.deepcopy(generation_config)
+            )
+            _kwargs = generation_config.update(**kwargs)
+            # If `generation_config` is provided, let's fallback ALL special tokens to the default values for the model
+            if not using_model_generation_config:
+                if generation_config.bos_token_id is None:
+                    generation_config.bos_token_id = self.generation_config.bos_token_id
+                if generation_config.eos_token_id is None:
+                    generation_config.eos_token_id = self.generation_config.eos_token_id
+                if generation_config.pad_token_id is None:
+                    generation_config.pad_token_id = self.generation_config.pad_token_id
+                if generation_config.mask_token_id is None:
+                    generation_config.mask_token_id = (
+                        self.generation_config.mask_token_id
+                    )
+
+        return generation_config
+
+    def _prepare_special_tokens(
+        self,
+        generation_config: DreamGenerationConfig,
+        device: Optional[Union[torch.device, str]] = None,
+    ):
+        """
+        Prepares the special tokens for generation, overwriting the generation config with their processed versions
+        converted to tensor.
+
+        Note that `generation_config` is changed in place and stops being serializable after this method is called.
+        That is no problem if called within `generate` (`generation_config` is a local copy that doesn't leave the
+        function). However, if called outside `generate`, consider creating a copy of `generation_config` first.
+        """
+
+        # Convert special tokens to tensors
+        def _tensor_or_none(token, device=None):
+            if token is None:
+                return token
+
+            device = device if device is not None else self.device
+            if isinstance(token, torch.Tensor):
+                return token.to(device)
+            return torch.tensor(token, device=device, dtype=torch.long)
+
+        bos_token_tensor = _tensor_or_none(
+            generation_config.bos_token_id, device=device
+        )
+        eos_token_tensor = _tensor_or_none(
+            generation_config.eos_token_id, device=device
+        )
+        pad_token_tensor = _tensor_or_none(
+            generation_config.pad_token_id, device=device
+        )
+        mask_token_tensor = _tensor_or_none(
+            generation_config.mask_token_id, device=device
+        )
+
+        # We can have more than one eos token. Always treat it as a 1D tensor (when it exists).
+        if eos_token_tensor is not None and eos_token_tensor.ndim == 0:
+            eos_token_tensor = eos_token_tensor.unsqueeze(0)
+
+        # Set pad token if unset (and there are conditions to do so)
+        if pad_token_tensor is None and eos_token_tensor is not None:
+            pad_token_tensor = eos_token_tensor[0]
+            logger.warning(
+                f"Setting `pad_token_id` to `eos_token_id`:{pad_token_tensor} for open-end generation."
+            )
+
+        # Update generation config with the updated special tokens tensors
+        # NOTE: this must be written into a different attribute name than the one holding the original special tokens
+        # (in their non-tensor form), in order to enable end-to-end compilation. See
+        # https://pytorch.org/docs/stable/torch.compiler_cudagraph_trees.html#limitations
+        generation_config._bos_token_tensor = bos_token_tensor
+        generation_config._eos_token_tensor = eos_token_tensor
+        generation_config._pad_token_tensor = pad_token_tensor
+        generation_config._mask_token_tensor = mask_token_tensor
+
+    @torch.no_grad()
+    def diffusion_generate(
+        self,
+        inputs: Optional[torch.Tensor] = None,
+        generation_config: Optional[DreamGenerationConfig] = None,
+        **kwargs,
+    ) -> Union[DreamModelOutput, torch.LongTensor]:
+        # 1. Handle `generation_config` and kwargs that might update it, and validate the `.generate()` call
+        generation_config = self._prepare_generation_config(generation_config, **kwargs)
+        generation_tokens_hook_func = kwargs.pop("generation_tokens_hook_func", None)
+        generation_logits_hook_func = kwargs.pop("generation_logits_hook_func", None)
+        has_tokens_hook = generation_tokens_hook_func is not None
+        has_logits_hook = generation_logits_hook_func is not None
+        if generation_tokens_hook_func is None:
+            generation_tokens_hook_func = lambda step, x, logits: x
+        if generation_logits_hook_func is None:
+            generation_logits_hook_func = lambda step, x, logits: logits
+
+        # 2. Define model inputs
+        assert inputs is not None
+        input_ids = inputs
+        device = input_ids.device
+        attention_mask = kwargs.pop("attention_mask", None)
+        self._prepare_special_tokens(generation_config, device=device)
+
+        # 3. Prepare `max_length`.
+        input_ids_length = input_ids.shape[-1]
+        has_default_max_length = (
+            kwargs.get("max_length") is None
+            and generation_config.max_length is not None
+        )
+        generation_config = self._prepare_generated_length(
+            generation_config=generation_config,
+            has_default_max_length=has_default_max_length,
+            input_ids_length=input_ids_length,
+        )
+
+        self._validate_generated_length(
+            generation_config, input_ids_length, has_default_max_length
+        )
+
+        # 4. Check input_ids
+        if not is_torchdynamo_compiling() and self.device.type != input_ids.device.type:
+            warnings.warn(
+                "You are calling .generate() with the `input_ids` being on a device type different"
+                f" than your model's device. `input_ids` is on {input_ids.device.type}, whereas the model"
+                f" is on {self.device.type}. You may experience unexpected behaviors or slower generation."
+                " Please make sure that you have put `input_ids` to the"
+                f" correct device by calling for example input_ids = input_ids.to('{self.device.type}') before"
+                " running `.generate()`.",
+                UserWarning,
+            )
+        if (
+            hasattr(generation_config, "pad_token_id")
+            and torch.any(input_ids == generation_config.pad_token_id)
+            and attention_mask is None
+        ):
+            warnings.warn(
+                "Padding was detected but no attention mask is passed here. For correct "
+                "generation results, please set `attention_mask` when batch-padding inputs.",
+                UserWarning,
+            )
+
+        input_ids, attention_mask = self._expand_inputs_for_generation(
+            expand_size=generation_config.num_return_sequences,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+        )
+
+        if generation_config.use_cache:
+            if has_tokens_hook:
+                raise NotImplementedError(
+                    "Dream cache-enabled block decode does not support generation_tokens_hook_func."
+                )
+            if has_logits_hook:
+                raise NotImplementedError(
+                    "Dream cache-enabled block decode does not support generation_logits_hook_func."
+                )
+            return self._sample_with_cache(
+                input_ids,
+                attention_mask=attention_mask,
+                generation_config=generation_config,
+            )
+
+        result = self._sample(
+            input_ids,
+            attention_mask=attention_mask,
+            generation_config=generation_config,
+            generation_tokens_hook_func=generation_tokens_hook_func,
+            generation_logits_hook_func=generation_logits_hook_func,
+        )
+        return result
+
+    def _sample_with_cache(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.LongTensor],
+        generation_config: DreamGenerationConfig,
+    ) -> Union[DreamModelOutput, torch.LongTensor]:
+        if attention_mask is not None:
+            max_length = generation_config.max_length
+            prompt_len = input_ids.shape[1]
+            gen_length = max_length - prompt_len
+            if attention_mask.dim() == 2:
+                if attention_mask.dtype == torch.bool:
+                    padded_mask = F.pad(
+                        attention_mask.to(input_ids.device), (0, gen_length), value=True
+                    )
+                    attention_mask = torch.logical_and(
+                        padded_mask.unsqueeze(1).unsqueeze(-2),
+                        padded_mask.unsqueeze(1).unsqueeze(-1),
+                    )
+                elif torch.is_floating_point(attention_mask):
+                    if torch.any(attention_mask != 0.0):
+                        raise ValueError(
+                            "Dream cache-enabled block decode expects a boolean padding mask for 2D attention masks; "
+                            "pass an expanded 4D additive mask instead."
+                        )
+                    attention_mask = None
+                elif torch.any(attention_mask == 0):
+                    padded_mask = F.pad(
+                        attention_mask.to(input_ids.device), (0, gen_length), value=1
+                    )
+                    attention_mask = torch.logical_and(
+                        padded_mask.unsqueeze(1).unsqueeze(-2),
+                        padded_mask.unsqueeze(1).unsqueeze(-1),
+                    )
+                else:
+                    attention_mask = None
+            elif attention_mask.dim() == 3:
+                attention_mask = attention_mask.unsqueeze(1).to(input_ids.device)
+            elif attention_mask.dim() == 4:
+                attention_mask = attention_mask.to(input_ids.device)
+            else:
+                raise ValueError(
+                    f"Unexpected attention_mask shape: {attention_mask.shape}"
+                )
+
+            if attention_mask is not None and attention_mask.shape[-1] == prompt_len:
+                if attention_mask.dtype == torch.bool:
+                    expanded_mask = torch.ones(
+                        attention_mask.shape[:2] + (max_length, max_length),
+                        dtype=torch.bool,
+                        device=attention_mask.device,
+                    )
+                    expanded_mask[:, :, :prompt_len, :prompt_len] = attention_mask
+                    expanded_mask[:, :, prompt_len:, :prompt_len] = attention_mask[
+                        :, :, -1:, :
+                    ]
+                    attention_mask = expanded_mask
+                else:
+                    raise ValueError(
+                        "Dream cache-enabled block decode requires expanded additive masks to already cover max_length."
+                    )
+        else:
+            attention_mask = None
+
+        if generation_config.output_history:
+            raise NotImplementedError(
+                "Dream cache-enabled block decode does not support output_history."
+            )
+
+        block_decode_output = self._block_decode_loop(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            generation_config=generation_config,
+        )
+        timing = None
+        if isinstance(block_decode_output, tuple):
+            x, timing = block_decode_output
+        else:
+            x = block_decode_output
+
+        if generation_config.return_dict:
+            return DreamModelOutput(sequences=x, history=None, timing=timing)
+        return x
+
+    def _get_block_decode_query_start(
+        self,
+        current_block_start: int,
+        current_block_end: int,
+        use_replace_cache: bool,
+    ) -> int:
+        del current_block_end, use_replace_cache
+        return max(0, current_block_start - 1)
+
+    def _postprocess_block_decode_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        return torch.cat([logits[:, :1], logits[:, :-1]], dim=1)
+
+    def _model_forward_with_cache(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Any],
+        use_cache: bool,
+        replace_position: Optional[torch.Tensor] = None,
+    ):
+        dual_cache = replace_position is not None
+        outputs = self(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            dual_cache=dual_cache,
+            replace_position=replace_position,
+        )
+        cache = outputs.past_key_values
+        if cache is not None and not isinstance(cache, tuple):
+            cache = tuple(cache)
+        return SimpleNamespace(logits=outputs.logits, past_key_values=cache)
+
+    def _sample(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.LongTensor],
+        generation_config: DreamGenerationConfig,
+        generation_tokens_hook_func,
+        generation_logits_hook_func,
+    ) -> Union[DreamModelOutput, torch.LongTensor]:
+        # init values
+
+        output_history = generation_config.output_history
+        return_dict = generation_config.return_dict
+        max_length = generation_config.max_length
+        mask_token_id = generation_config.mask_token_id
+        steps = generation_config.steps
+        eps = generation_config.eps
+        alg = generation_config.alg
+        alg_temp = generation_config.alg_temp
+        temperature = generation_config.temperature
+        top_p = generation_config.top_p
+        top_k = generation_config.top_k
+
+        histories = [] if (return_dict and output_history) else None
+
+        # pad input_ids to max_length
+        x = F.pad(input_ids, (0, max_length - input_ids.shape[1]), value=mask_token_id)
+
+        if attention_mask is not None and torch.any(attention_mask == 0.0):
+            # we do not mask the [MASK] tokens so value = 1.0
+            attention_mask = F.pad(
+                attention_mask, (0, max_length - attention_mask.shape[1]), value=1.0
+            )
+            tok_idx = attention_mask.long().cumsum(-1) - 1
+            tok_idx.masked_fill_(attention_mask == 0, 1)
+            # attention_mask is of shape [B, N]
+            # broadcast to [B, 1, N, N]
+            attention_mask = torch.logical_and(
+                attention_mask.unsqueeze(1).unsqueeze(-2),
+                attention_mask.unsqueeze(1).unsqueeze(-1),
+            )
+        else:
+            tok_idx = None
+            attention_mask = "full"
+
+        timesteps = torch.linspace(1, eps, steps + 1, device=x.device)
+
+        # this allows user-defined token control of the intermediate steps
+        x = generation_tokens_hook_func(None, x, None)
+        for i in range(steps):
+            mask_index = x == mask_token_id
+            logits = self(x, attention_mask, tok_idx).logits
+            # Intentional right-shift from the original Dream implementation:
+            # Dream's training uses a shifted-logits objective where logit[i]
+            # is trained to predict the token *before* position i (see Dream
+            # paper / official repo). This shift is required for correct
+            # sampling even though Dream uses bidirectional attention.
+            logits = torch.cat([logits[:, :1], logits[:, :-1]], dim=1)
+            # this allows user-defined logits control of the intermediate steps
+            logits = generation_logits_hook_func(i, x, logits)
+
+            mask_logits = logits[mask_index]
+            t = timesteps[i]
+            s = timesteps[i + 1]
+
+            if alg == "origin":
+                p_transfer = 1 - s / t if i < steps - 1 else 1
+                x0 = (
+                    torch.zeros_like(
+                        x[mask_index], device=self.device, dtype=torch.long
+                    )
+                    + mask_token_id
+                )
+                transfer_index_t_s = (
+                    torch.rand(*x0.shape, device=self.device) < p_transfer
+                )
+                _, x0[transfer_index_t_s] = sample_tokens(
+                    mask_logits[transfer_index_t_s],
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                )
+                x[mask_index] = x0.clone()
+            else:
+                if alg == "maskgit_plus":
+                    confidence, x0 = sample_tokens(
+                        mask_logits, temperature=temperature, top_p=top_p, top_k=top_k
+                    )
+                elif alg == "topk_margin":
+                    confidence, x0 = sample_tokens(
+                        mask_logits,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        margin_confidence=True,
+                    )
+                elif alg == "entropy":
+                    confidence, x0 = sample_tokens(
+                        mask_logits,
+                        temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        neg_entropy=True,
+                    )
+                else:
+                    raise RuntimeError(f"Unknown alg: {alg}")
+                num_mask_token = mask_index.sum() / mask_index.shape[0]
+                number_transfer_tokens = (
+                    int(num_mask_token * (1 - s / t))
+                    if i < steps - 1
+                    else int(num_mask_token)
+                )
+                full_confidence = torch.full_like(
+                    x, -torch.inf, device=self.device, dtype=logits.dtype
+                )
+                full_confidence[mask_index] = confidence
+                if number_transfer_tokens > 0:
+                    if alg_temp is None or alg_temp == 0:
+                        _, transfer_index = torch.topk(
+                            full_confidence, number_transfer_tokens
+                        )
+                    else:
+                        full_confidence = full_confidence / alg_temp
+                        full_confidence = F.softmax(full_confidence, dim=-1)
+                        transfer_index = torch.multinomial(
+                            full_confidence, num_samples=number_transfer_tokens
+                        )
+                    x_ = (
+                        torch.zeros_like(x, device=self.device, dtype=torch.long)
+                        + mask_token_id
+                    )
+                    x_[mask_index] = x0.clone()
+                    row_indices = (
+                        torch.arange(x.size(0), device=self.device)
+                        .unsqueeze(1)
+                        .expand_as(transfer_index)
+                    )
+                    x[row_indices, transfer_index] = x_[row_indices, transfer_index]
+
+            # this allows user-defined token control of the intermediate steps
+            x = generation_tokens_hook_func(i, x, logits)
+
+            if histories is not None:
+                histories.append(x.clone())
+
+        if return_dict:
+            return DreamModelOutput(
+                sequences=x,
+                history=histories,
+            )
+        else:
+            return x

--- a/unturtle/models/backbones/dream/modeling_dream.py
+++ b/unturtle/models/backbones/dream/modeling_dream.py
@@ -1,0 +1,1245 @@
+# Copyright 2024 The Dream team, HKUNLP Group and the HuggingFace Inc. team. All rights reserved.
+# Ported to Unturtle by nishide-dev & the Unturtle team (2025).
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT and Qwen implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT and Qwen used by the Meta AI and Qwen team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch Dream model."""
+
+import math
+import os
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.utils.checkpoint
+from torch import nn
+from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.modeling_outputs import (
+    BaseModelOutput,
+    BaseModelOutputWithPast,
+    MaskedLMOutput,
+)
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS as _ROPE_INIT_FUNCTIONS
+
+# transformers 5.x removed "default" from ROPE_INIT_FUNCTIONS.
+# Provide a plain standard RoPE implementation under that key if missing.
+if "default" not in _ROPE_INIT_FUNCTIONS:
+
+    def _rope_default_init(config, device, **kwargs):
+        import torch
+
+        base = (
+            getattr(config, "rope_theta", 10000.0)
+            if config is not None
+            else kwargs.get("base", 10000.0)
+        )
+        dim = getattr(config, "head_dim", None) or (
+            config.hidden_size // config.num_attention_heads
+            if config is not None
+            else kwargs.get("dim")
+        )
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+        )
+        return inv_freq, 1.0
+
+    _ROPE_INIT_FUNCTIONS = dict(_ROPE_INIT_FUNCTIONS)
+    _ROPE_INIT_FUNCTIONS["default"] = _rope_default_init
+
+ROPE_INIT_FUNCTIONS = _ROPE_INIT_FUNCTIONS
+from transformers import PretrainedConfig  # noqa: E402
+from transformers.modeling_utils import PreTrainedModel  # noqa: E402
+from transformers.utils import (  # noqa: E402
+    add_start_docstrings,
+    add_start_docstrings_to_model_forward,
+    is_flash_attn_2_available,
+    is_flash_attn_greater_or_equal_2_10,
+    logging,
+)
+
+from .configuration_dream import DreamConfig  # noqa: E402
+from .generation_utils import DreamGenerationConfig, DreamGenerationMixin  # noqa: E402
+
+try:
+    from unsloth.kernels.rope_embedding import (
+        fast_rope_embedding as _fast_rope_embedding,
+    )
+
+    _HAS_FAST_ROPE = True
+except ImportError:
+    _HAS_FAST_ROPE = False
+
+if is_flash_attn_2_available():
+    from transformers.modeling_flash_attention_utils import _flash_attention_forward
+
+
+logger = logging.get_logger(__name__)
+
+
+@dataclass
+class DreamMaskedLMOutputWithPast(MaskedLMOutput):
+    past_key_values: Optional[List[Tuple[torch.FloatTensor, torch.FloatTensor]]] = None
+
+
+_CHECKPOINT_FOR_DOC = "Dream-7B"
+_CONFIG_FOR_DOC = "DreamConfig"
+
+
+# Copied from transformers.models.llama.modeling_llama.LlamaRMSNorm with Llama->Dream
+class DreamRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        DreamRMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+# Copied from transformers.models.llama.modeling_llama.LlamaRotaryEmbedding with Llama->Dream
+class DreamRotaryEmbedding(nn.Module):
+    def __init__(
+        self,
+        dim=None,
+        max_position_embeddings=2048,
+        base=10000,
+        device=None,
+        scaling_factor=1.0,
+        rope_type="default",
+        config: Optional[DreamConfig] = None,
+    ):
+        super().__init__()
+        # TODO (joao): remove the `if` below, only used for BC
+        self.rope_kwargs = {}
+        if config is None:
+            logger.warning_once(
+                "`DreamRotaryEmbedding` can now be fully parameterized by passing the model config through the "
+                "`config` argument. All other arguments will be removed in v4.46"
+            )
+            self.rope_kwargs = {
+                "rope_type": rope_type,
+                "factor": scaling_factor,
+                "dim": dim,
+                "base": base,
+                "max_position_embeddings": max_position_embeddings,
+            }
+            self.rope_type = rope_type
+            self.max_seq_len_cached = max_position_embeddings
+            self.original_max_seq_len = max_position_embeddings
+        else:
+            # BC: "rope_type" was originally "type"
+            if config.rope_scaling is not None:
+                self.rope_type = config.rope_scaling.get(
+                    "rope_type", config.rope_scaling.get("type")
+                )
+            else:
+                self.rope_type = "default"
+            self.max_seq_len_cached = config.max_position_embeddings
+            self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+
+        inv_freq, self.attention_scaling = self.rope_init_fn(
+            self.config, device, **self.rope_kwargs
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    def reset_parameters(self):
+        inv_freq, self.attention_scaling = self.rope_init_fn(
+            self.config, self.inv_freq.device, **self.rope_kwargs
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    def _dynamic_frequency_update(self, position_ids, device):
+        """
+        dynamic RoPE layers should recompute `inv_freq` in the following situations:
+        1 - growing beyond the cached sequence length (allow scaling)
+        2 - the current sequence length is in the original scale (avoid losing precision with small sequences)
+        """
+        seq_len = torch.max(position_ids) + 1
+        if seq_len > self.max_seq_len_cached:  # growth
+            inv_freq, self.attention_scaling = self.rope_init_fn(
+                self.config, device, seq_len=seq_len, **self.rope_kwargs
+            )
+            self.register_buffer(
+                "inv_freq", inv_freq, persistent=False
+            )  # TODO joao: may break with compilation
+            self.max_seq_len_cached = seq_len
+
+        if (
+            seq_len < self.original_max_seq_len
+            and self.max_seq_len_cached > self.original_max_seq_len
+        ):  # reset
+            self.register_buffer("inv_freq", self.original_inv_freq, persistent=False)
+            self.max_seq_len_cached = self.original_max_seq_len
+
+    @torch.no_grad()
+    def forward(self, x, position_ids):
+        if "dynamic" in self.rope_type:
+            self._dynamic_frequency_update(position_ids, device=x.device)
+
+        # Core RoPE block
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        )
+        position_ids_expanded = position_ids[:, None, :].float()
+        # Force float32 (see https://github.com/huggingface/transformers/pull/29285)
+        device_type = x.device.type
+        device_type = (
+            device_type
+            if isinstance(device_type, str) and device_type != "mps"
+            else "cpu"
+        )
+        with torch.autocast(device_type=device_type, enabled=False):
+            freqs = (
+                inv_freq_expanded.float() @ position_ids_expanded.float()
+            ).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+
+        # Advanced RoPE types (e.g. yarn) apply a post-processing scaling factor, equivalent to scaling attention
+        cos = cos * self.attention_scaling
+        sin = sin * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+# Copied from transformers.models.llama.modeling_llama.rotate_half
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+# Copied from transformers.models.llama.modeling_llama.apply_rotary_pos_emb
+def apply_rotary_pos_emb(
+    q, k, cos, sin, position_ids=None, unsqueeze_dim=1, block_end_index=None
+):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`, *optional*):
+            Deprecated and unused.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+        block_end_index (`int`, *optional*):
+            When provided, align the query RoPE slice to the absolute end position of the replaced block.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    if block_end_index is not None:
+        q_cos = cos[:, :, block_end_index - q.shape[-2] : block_end_index, :]
+        q_sin = sin[:, :, block_end_index - q.shape[-2] : block_end_index, :]
+        q_embed = (q * q_cos) + (rotate_half(q) * q_sin)
+    else:
+        q_embed = (q * cos[:, :, -q.shape[-2] :, :]) + (
+            rotate_half(q) * sin[:, :, -q.shape[-2] :, :]
+        )
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+# Copied from transformers.models.mistral.modeling_mistral.MistralMLP with Mistral->Dream
+class DreamMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_state):
+        return self.down_proj(
+            self.act_fn(self.gate_proj(hidden_state)) * self.up_proj(hidden_state)
+        )
+
+
+# Copied from transformers.models.llama.modeling_llama.repeat_kv
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+class DreamAttention(nn.Module):
+    """
+    Multi-headed attention from 'Attention Is All You Need' paper. Modified to use sliding window attention: Longformer
+    and "Generating Long Sequences with Sparse Transformers".
+    """
+
+    def __init__(self, config: DreamConfig, layer_idx: Optional[int] = None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        if layer_idx is None:
+            logger.warning_once(
+                f"Instantiating {self.__class__.__name__} without passing `layer_idx` is not recommended and will "
+                "to errors during the forward call, if caching is used. Please make sure to provide a `layer_idx` "
+                "when creating this class."
+            )
+
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.max_position_embeddings = config.max_position_embeddings
+        self.rope_theta = config.rope_theta
+        self.is_causal = False
+        self.attention_dropout = config.attention_dropout
+
+        if (self.head_dim * self.num_heads) != self.hidden_size:
+            raise ValueError(
+                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
+                f" and `num_heads`: {self.num_heads})."
+            )
+        self.q_proj = nn.Linear(
+            self.hidden_size, self.num_heads * self.head_dim, bias=True
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, self.hidden_size, bias=False
+        )
+
+        self.rotary_emb = DreamRotaryEmbedding(config=self.config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[
+            Tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # will become mandatory in v4.46
+        replace_position: Optional[torch.Tensor] = None,
+        dual_cache: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        bsz, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        if past_key_value is not None:
+            if dual_cache:
+                past_key, past_value = past_key_value
+                if replace_position is None:
+                    raise ValueError(
+                        "dual_cache=True requires replace_position to be provided"
+                    )
+                if replace_position.ndim != 2 or replace_position.shape[0] != bsz:
+                    raise ValueError(
+                        f"replace_position must have shape [batch, seq_len], got {replace_position.shape}"
+                    )
+                if not torch.equal(
+                    replace_position, replace_position[:1].expand_as(replace_position)
+                ):
+                    raise ValueError(
+                        "dual_cache expects the same replace_position block across the batch"
+                    )
+                replace_indices = replace_position[0].nonzero(as_tuple=True)[0]
+                block_len = replace_indices.numel()
+                key_update = key_states[:, -block_len:, :]
+                value_update = value_states[:, -block_len:, :]
+                for batch_idx in range(bsz):
+                    past_key[batch_idx, replace_indices, :] = key_update[batch_idx]
+                    past_value[batch_idx, replace_indices, :] = value_update[batch_idx]
+                key_states = past_key
+                value_states = past_value
+            else:
+                past_key, past_value = past_key_value
+                key_states = torch.cat([past_key, key_states], dim=1)
+                value_states = torch.cat([past_value, value_states], dim=1)
+
+        past_key_value = (key_states, value_states) if use_cache else None
+
+        query_states = query_states.view(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(1, 2)
+        key_states = key_states.view(
+            bsz, -1, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+        value_states = value_states.view(
+            bsz, -1, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+
+        if position_embeddings is None:
+            logger.warning_once(
+                "The attention layers in this model are transitioning from computing the RoPE embeddings internally "
+                "through `position_ids` (2D tensor with the indexes of the tokens), to using externally computed "
+                "`position_embeddings` (Tuple of tensors, containing cos and sin). In v4.46 `position_ids` will be "
+                "removed and `position_embeddings` will be mandatory."
+            )
+            cos, sin = self.rotary_emb(value_states, position_ids)
+        else:
+            cos, sin = position_embeddings
+        if dual_cache:
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states,
+                key_states,
+                cos,
+                sin,
+                block_end_index=replace_indices.max().item() + 1,
+            )
+        else:
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states, key_states, cos, sin
+            )
+
+        # repeat k/v heads if n_kv_heads < n_heads
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        attn_weights = torch.matmul(
+            query_states, key_states.transpose(2, 3)
+        ) / math.sqrt(self.head_dim)
+        if attention_mask is not None:  # no matter the length, we just slice it
+            causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+            attn_weights = attn_weights + causal_mask
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(
+            attn_weights, dim=-1, dtype=torch.float32
+        ).to(query_states.dtype)
+        attn_weights = nn.functional.dropout(
+            attn_weights, p=self.attention_dropout, training=self.training
+        )
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
+
+        attn_output = self.o_proj(attn_output)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights, past_key_value
+
+
+class DreamSdpaAttention(DreamAttention):
+    """
+    Dream attention module using torch.nn.functional.scaled_dot_product_attention. This module inherits from
+    `DreamAttention` as the weights of the module stays untouched. The only changes are on the forward pass to adapt to
+    SDPA API.
+    """
+
+    # Adapted from DreamAttention.forward
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[
+            Tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # will become mandatory in v4.46
+        replace_position: Optional[torch.Tensor] = None,
+        dual_cache: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        if output_attentions:
+            # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
+            logger.warning_once(
+                "DreamModel is using DreamSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to the manual attention implementation, "
+                'but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
+            )
+            return super().forward(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                replace_position=replace_position,
+                dual_cache=dual_cache,
+            )
+
+        bsz, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        if past_key_value is not None:
+            if dual_cache:
+                past_key, past_value = past_key_value
+                if replace_position is None:
+                    raise ValueError(
+                        "dual_cache=True requires replace_position to be provided"
+                    )
+                if replace_position.ndim != 2 or replace_position.shape[0] != bsz:
+                    raise ValueError(
+                        f"replace_position must have shape [batch, seq_len], got {replace_position.shape}"
+                    )
+                if not torch.equal(
+                    replace_position, replace_position[:1].expand_as(replace_position)
+                ):
+                    raise ValueError(
+                        "dual_cache expects the same replace_position block across the batch"
+                    )
+                replace_indices = replace_position[0].nonzero(as_tuple=True)[0]
+                block_len = replace_indices.numel()
+                key_update = key_states[:, -block_len:, :]
+                value_update = value_states[:, -block_len:, :]
+                for batch_idx in range(bsz):
+                    past_key[batch_idx, replace_indices, :] = key_update[batch_idx]
+                    past_value[batch_idx, replace_indices, :] = value_update[batch_idx]
+                key_states = past_key
+                value_states = past_value
+            else:
+                past_key, past_value = past_key_value
+                key_states = torch.cat([past_key, key_states], dim=1)
+                value_states = torch.cat([past_value, value_states], dim=1)
+
+        past_key_value = (key_states, value_states) if use_cache else None
+
+        query_states = query_states.view(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(1, 2)
+        key_states = key_states.view(
+            bsz, -1, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+        value_states = value_states.view(
+            bsz, -1, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+
+        if position_embeddings is None:
+            logger.warning_once(
+                "The attention layers in this model are transitioning from computing the RoPE embeddings internally "
+                "through `position_ids` (2D tensor with the indexes of the tokens), to using externally computed "
+                "`position_embeddings` (Tuple of tensors, containing cos and sin). In v4.46 `position_ids` will be "
+                "removed and `position_embeddings` will be mandatory."
+            )
+            cos, sin = self.rotary_emb(value_states, position_ids)
+        else:
+            cos, sin = position_embeddings
+        if dual_cache:
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states,
+                key_states,
+                cos,
+                sin,
+                block_end_index=replace_indices.max().item() + 1,
+            )
+        else:
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states, key_states, cos, sin
+            )
+
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
+        # Reference: https://github.com/pytorch/pytorch/issues/112577.
+        if query_states.device.type == "cuda" and attention_mask is not None:
+            query_states = query_states.contiguous()
+            key_states = key_states.contiguous()
+            value_states = value_states.contiguous()
+
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            attn_mask=attention_mask
+            if isinstance(attention_mask, torch.Tensor)
+            else None,
+            dropout_p=self.attention_dropout if self.training else 0.0,
+            is_causal=False,
+        )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.view(bsz, q_len, self.hidden_size)
+
+        attn_output = self.o_proj(attn_output)
+
+        return attn_output, None, past_key_value
+
+
+class DreamDecoderLayer(nn.Module):
+    def __init__(self, config: DreamConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        if config.sliding_window and config._attn_implementation != "flash_attention_2":
+            logger.warning_once(
+                f"Sliding Window Attention is enabled but not implemented for `{config._attn_implementation}`; "
+                "unexpected results may be encountered."
+            )
+
+        # self.self_attn = Dream_ATTENTION_CLASSES[config._attn_implementation](config, layer_idx)
+        self.self_attn = DreamSdpaAttention(config, layer_idx)
+
+        self.mlp = DreamMLP(config)
+        self.input_layernorm = DreamRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = DreamRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[
+            Tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # will become mandatory in v4.46
+        **kwargs,
+    ) -> Tuple[
+        torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]
+    ]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`, *optional*): attention mask of size
+                `(batch, sequence_length)` where padding elements are indicated by 0.
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            use_cache (`bool`, *optional*):
+                If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding
+                (see `past_key_values`).
+            past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
+            cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+                Indices depicting the position of the input sequence tokens in the sequence.
+            position_embeddings (`Tuple[torch.FloatTensor, torch.FloatTensor]`, *optional*):
+                Tuple containing the cosine and sine positional embeddings of shape `(batch_size, seq_len, head_dim)`,
+                with `head_dim` being the embedding dimension of each attention head.
+            kwargs (`dict`, *optional*):
+                Arbitrary kwargs to be ignored, used for FSDP and other methods that injects code
+                into the model
+        """
+
+        residual = hidden_states
+
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Self Attention
+        hidden_states, self_attn_weights, present_key_value = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (self_attn_weights,)
+
+        if use_cache:
+            outputs += (present_key_value,)
+
+        return outputs
+
+
+class DreamPreTrainedModel(PreTrainedModel):
+    config_class = DreamConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["DreamDecoderLayer"]
+    _skip_keys_device_placement = "past_key_values"
+    _supports_flash_attn_2 = True
+    _supports_sdpa = True
+    _supports_cache_class = True
+    _supports_quantized_cache = True
+    _supports_static_cache = True
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
+        *model_args,
+        config: Optional[Union[PretrainedConfig, str, os.PathLike]] = None,
+        cache_dir: Optional[Union[str, os.PathLike]] = None,
+        ignore_mismatched_sizes: bool = False,
+        force_download: bool = False,
+        local_files_only: bool = False,
+        token: Optional[Union[str, bool]] = None,
+        revision: str = "main",
+        use_safetensors: Optional[bool] = None,
+        weights_only: bool = True,
+        **kwargs,
+    ):
+        _model = super().from_pretrained(
+            pretrained_model_name_or_path,
+            *model_args,
+            config=config,
+            cache_dir=cache_dir,
+            ignore_mismatched_sizes=ignore_mismatched_sizes,
+            force_download=force_download,
+            local_files_only=local_files_only,
+            token=token,
+            revision=revision,
+            use_safetensors=use_safetensors,
+            weights_only=weights_only,
+            **kwargs,
+        )
+        # NOTE(Lin): we need to override the generation config
+        # because the generation config loaded in `from_pretrained`
+        # does not include all the attributes of DreamGenerationConfig
+        resume_download = kwargs.get("resume_download")
+        proxies = kwargs.get("proxies")
+        subfolder = kwargs.get("subfolder", "")
+        from_auto_class = kwargs.get("_from_auto", False)
+        from_pipeline = kwargs.get("_from_pipeline")
+        _model.generation_config = DreamGenerationConfig.from_pretrained(
+            pretrained_model_name_or_path,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            resume_download=resume_download,
+            proxies=proxies,
+            local_files_only=local_files_only,
+            token=token,
+            revision=revision,
+            subfolder=subfolder,
+            _from_auto=from_auto_class,
+            _from_pipeline=from_pipeline,
+        )
+        return _model
+
+
+class DreamBaseModel(DreamPreTrainedModel):
+    """
+    Transformer decoder consisting of *config.num_hidden_layers* layers. Each layer is a [`DreamDecoderLayer`]
+
+    Args:
+        config: DreamConfig
+    """
+
+    def __init__(self, config: DreamConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, self.padding_idx
+        )
+        self.layers = nn.ModuleList(
+            [
+                DreamDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self._attn_implementation = config._attn_implementation
+        self.norm = DreamRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = DreamRotaryEmbedding(config=config)
+
+        self.gradient_checkpointing = False
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        dual_cache: Optional[bool] = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Union[Tuple, BaseModelOutput]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds"
+            )
+
+        if self.gradient_checkpointing and self.training and use_cache:
+            logger.warning_once(
+                "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
+            )
+            use_cache = False
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        past_seen_tokens = (
+            past_key_values[0][0].shape[1] if past_key_values is not None else 0
+        )
+        if not dual_cache:
+            position_ids = torch.arange(
+                past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            ).unsqueeze(0)
+        else:
+            if past_key_values is not None:
+                position_ids = torch.arange(
+                    past_seen_tokens, device=inputs_embeds.device
+                ).unsqueeze(0)
+            else:
+                position_ids = torch.arange(
+                    inputs_embeds.shape[1], device=inputs_embeds.device
+                ).unsqueeze(0)
+
+        hidden_states = inputs_embeds
+        attn_key_values = [] if use_cache else None
+
+        # create position embeddings to be shared across the decoder layers
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if position_embeddings[0].shape[0] == 1 and hidden_states.shape[0] > 1:
+            position_embeddings = (
+                position_embeddings[0].expand(hidden_states.shape[0], -1, -1),
+                position_embeddings[1].expand(hidden_states.shape[0], -1, -1),
+            )
+
+        # decoder layers
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attns = () if output_attentions else None
+
+        for layer_idx, decoder_layer in enumerate(self.layers):
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            layer_past_key_value = (
+                past_key_values[layer_idx] if past_key_values is not None else None
+            )
+
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    decoder_layer.__call__,
+                    hidden_states,
+                    attention_mask,
+                    position_ids,
+                    layer_past_key_value,
+                    output_attentions,
+                    use_cache,
+                    cache_position,
+                    position_embeddings,
+                    dual_cache,
+                    replace_position,
+                )
+            else:
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_value=layer_past_key_value,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                    position_embeddings=position_embeddings,
+                    dual_cache=dual_cache,
+                    replace_position=replace_position,
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_self_attns += (layer_outputs[1],)
+            if use_cache:
+                attn_key_values.append(layer_outputs[2 if output_attentions else 1])
+
+        hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(
+                v
+                for v in [
+                    hidden_states,
+                    attn_key_values,
+                    all_hidden_states,
+                    all_self_attns,
+                ]
+                if v is not None
+            )
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attns,
+            past_key_values=attn_key_values,
+        )
+
+
+class DreamModel(DreamGenerationMixin, DreamPreTrainedModel):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = DreamBaseModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def reset_rope_parameters(self):
+        self.model.rotary_emb.reset_parameters()
+        for layer in self.model.layers:
+            layer.self_attn.rotary_emb.reset_parameters()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        num_logits_to_keep: int = 0,
+        dual_cache: Optional[bool] = False,
+        replace_position: Optional[torch.Tensor] = None,
+        **loss_kwargs,
+    ) -> Union[Tuple, DreamMaskedLMOutputWithPast]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if (
+            isinstance(attention_mask, str)
+            and attention_mask == "full"
+            or attention_mask is None
+        ):
+            # whether attention_mask is full
+            pass
+
+        elif isinstance(attention_mask, torch.Tensor):
+            if attention_mask.dim() == 2:
+                if not torch.any(attention_mask == 0.0):
+                    attention_mask = "full"
+                else:
+                    # [B, L] → [B, 1, L, L]
+                    attention_mask = torch.logical_and(
+                        attention_mask.unsqueeze(1).unsqueeze(-2),
+                        attention_mask.unsqueeze(1).unsqueeze(-1),
+                    )
+                    attention_mask = attention_mask.to(torch.bool)
+            elif attention_mask.dim() == 3:
+                attention_mask = attention_mask.unsqueeze(1)
+            elif attention_mask.dim() == 4:
+                # already expanded mask; preserve additive float masks as-is
+                pass
+            else:
+                raise ValueError(
+                    f"Unexpected attention_mask shape: {attention_mask.shape}"
+                )
+
+        else:
+            raise TypeError(f"Unsupported attention_mask type: {type(attention_mask)}")
+
+        # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            cache_position=cache_position,
+            dual_cache=dual_cache,
+            replace_position=replace_position,
+        )
+
+        hidden_states = outputs[0]
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(logits, labels, self.vocab_size, **loss_kwargs)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return DreamMaskedLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            past_key_values=outputs.past_key_values,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fast attention forward for Dream — Triton RoPE fast path
+# ---------------------------------------------------------------------------
+
+
+def _apply_dream_rope(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    bsz: int,
+    q_len: int,
+) -> tuple:
+    """Apply RoPE to Dream query/key states.
+
+    ``cos`` / ``sin`` are pre-indexed by ``position_ids`` (shape ``(B, L, head_dim)``
+    or ``(1, L, head_dim)``).  On CUDA we slice the first ``head_dim//2`` elements,
+    flatten to ``(B*L, head_dim//2)``, and use a sequential row-index so that
+    ``fast_rope_embedding`` does not double-index.
+    On CPU we fall back to the plain ``apply_rotary_pos_emb`` path.
+
+    Args:
+        query_states: ``(B, n_heads, L, head_dim)``
+        key_states:   ``(B, n_kv_heads, L, head_dim)``
+        cos, sin:     pre-indexed, shape ``(B, L, head_dim)`` or ``(1, L, head_dim)``
+    """
+    if _HAS_FAST_ROPE and query_states.device.type == "cuda" and cos.ndim == 3:
+        # fast_rope_embedding expects cos/sin of shape (rows, head_dim//2).
+        # DreamRotaryEmbedding returns (B, L, head_dim), so we take the first
+        # half before flattening (the kernel only reads head_dim//2 elements).
+        half = cos.shape[-1] // 2
+        cos_flat = cos[..., :half].reshape(-1, half).contiguous()  # (B*L, head_dim//2)
+        sin_flat = sin[..., :half].reshape(-1, half).contiguous()  # (B*L, head_dim//2)
+        rope_indices = torch.arange(
+            bsz * q_len, device=query_states.device, dtype=torch.long
+        )
+        query_states, key_states = _fast_rope_embedding(
+            query_states, key_states, cos_flat, sin_flat, rope_indices
+        )
+    else:
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin
+        )
+    return query_states, key_states
+
+
+def DreamAttention_fast_forward(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value=None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+    cache_position: Optional[torch.LongTensor] = None,
+    position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    """Drop-in replacement for ``DreamAttention.forward`` with Triton RoPE fast path.
+
+    Replaces ``apply_rotary_pos_emb`` with ``_apply_dream_rope`` which uses
+    ``fast_rope_embedding`` on CUDA (flatten + sequential row index, no double-index).
+    The rest of the forward pass is unchanged.
+
+    Injected by ``FastDiffusionModel._patch_dream_peft`` when the model is on CUDA.
+    """
+    bsz, q_len, _ = hidden_states.size()
+
+    query_states, key_states, value_states = self.apply_qkv(self, hidden_states)
+
+    query_states = query_states.view(
+        bsz, q_len, self.num_heads, self.head_dim
+    ).transpose(1, 2)
+    key_states = key_states.view(
+        bsz, q_len, self.num_key_value_heads, self.head_dim
+    ).transpose(1, 2)
+    value_states = value_states.view(
+        bsz, q_len, self.num_key_value_heads, self.head_dim
+    ).transpose(1, 2)
+
+    if position_embeddings is None:
+        cos, sin = self.rotary_emb(value_states, position_ids)
+    else:
+        cos, sin = position_embeddings
+
+    query_states, key_states = _apply_dream_rope(
+        query_states, key_states, cos, sin, bsz, q_len
+    )
+
+    if past_key_value is not None:
+        if not hasattr(past_key_value, "update"):
+            raise TypeError(
+                "DreamAttention_fast_forward expects a cache object with update(); tuple-based block-decode caches "
+                "should use the standard Dream attention path."
+            )
+        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+        key_states, value_states = past_key_value.update(
+            key_states, value_states, self.layer_idx, cache_kwargs
+        )
+
+    key_states = repeat_kv(key_states, self.num_key_value_groups)
+    value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(
+        self.head_dim
+    )
+    if attention_mask is not None:
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(
+        query_states.dtype
+    )
+    attn_weights = nn.functional.dropout(
+        attn_weights, p=self.attention_dropout, training=self.training
+    )
+    attn_output = torch.matmul(attn_weights, value_states)
+
+    attn_output = self.apply_o(
+        self,
+        attn_output.transpose(1, 2).contiguous().reshape(bsz, q_len, self.hidden_size),
+    )
+
+    if not output_attentions:
+        attn_weights = None
+
+    return attn_output, attn_weights, past_key_value

--- a/unturtle/models/backbones/llada/__init__.py
+++ b/unturtle/models/backbones/llada/__init__.py
@@ -1,0 +1,60 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLaDA (Large Language Diffusion with mAsking) models.
+
+Native bidirectional diffusion language model architecture.
+Reference: https://arxiv.org/abs/2502.09992
+
+Usage::
+
+    from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
+
+    config = LLaDAConfig(d_model=256, n_heads=4, n_layers=4, vocab_size=50257)
+    model = LLaDAModelLM(config)
+    # or load pretrained:
+    # config = LLaDAConfig.from_pretrained("GSAI-ML/LLaDA-8B-Instruct")
+    # model = LLaDAModelLM.from_pretrained("GSAI-ML/LLaDA-8B-Instruct")
+"""
+
+from .configuration_llada import (
+    ActivationCheckpointingStrategy,
+    ActivationType,
+    BlockType,
+    InitFnType,
+    LayerNormType,
+    LLaDAConfig,
+    ModelConfig,
+)
+from .generation_utils import LLaDAGenerationConfig, LLaDAGenerationMixin
+from .modeling_llada import (
+    LLaDAModel,
+    LLaDAModelLM,
+    LLaDAPreTrainedModel,
+)
+
+__all__ = [
+    "LLaDAGenerationConfig",
+    "LLaDAGenerationMixin",
+    "LLaDAConfig",
+    "ModelConfig",
+    "LayerNormType",
+    "ActivationType",
+    "BlockType",
+    "InitFnType",
+    "ActivationCheckpointingStrategy",
+    "LLaDAPreTrainedModel",
+    "LLaDAModel",
+    "LLaDAModelLM",
+]

--- a/unturtle/models/backbones/llada/configuration_llada.py
+++ b/unturtle/models/backbones/llada/configuration_llada.py
@@ -1,0 +1,473 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Ported from zhziszz/dllm (dllm/pipelines/llada/models/configuration_llada.py).
+
+"""
+LLaDA configuration
+"""
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from glob import glob
+from os import PathLike
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from transformers import PretrainedConfig
+
+__all__ = [
+    "ActivationType",
+    "ActivationCheckpointingStrategy",
+    "BlockType",
+    "LayerNormType",
+    "InitFnType",
+    "ModelConfig",
+]
+
+PathOrStr = Union[str, PathLike]
+
+
+class StrEnum(str, Enum):
+    """
+    This is equivalent to Python's :class:`enum.StrEnum` since version 3.11.
+    We include this here for compatibility with older version of Python.
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return f"'{str(self)}'"
+
+
+class LayerNormType(StrEnum):
+    default = "default"
+    """
+    The default LayerNorm implementation, equivalent to PyTorch's built-in version.
+    """
+
+    low_precision = "low_precision"
+    """
+    A low-precision version of the default LayerNorm.
+    """
+
+    rms = "rms"
+    """
+    An RMSNorm implementation. When using ``torch.compile`` this is
+    probably the fastest implementation.
+    """
+
+    gemma_rms = "gemma_rms"
+    """
+    An RMSNorm implementation by gemmma. When using ``torch.compile`` this is
+    probably the fastest implementation.
+    """
+
+    amd_compatible = "amd_compatible"
+    """
+    LayerNorm implemented manually to work around an issue with ROCm.
+    """
+
+
+class ActivationType(StrEnum):
+    gelu = "gelu"
+    relu = "relu"
+    silu = "silu"
+    swiglu = "swiglu"
+
+
+class BlockType(StrEnum):
+    sequential = "sequential"
+    parallel = "parallel"
+
+    llama = "llama"
+    """
+    A block similar to the sequential block with slightly different
+    implementations of operations like attention to imitate the behavior of Llama.
+    """
+
+
+class InitFnType(StrEnum):
+    mitchell = "mitchell"
+    """
+    The strategy suggested to us by Mitchell Wortsman from UW.
+    This uses a truncated normal distribution with an adaptive standard deviation that depends
+    on the size of the weights as well as the depth of the layer.
+    """
+
+    normal = "normal"
+    """
+    All weights are initialized from the same normal distribution.
+    """
+
+    kaiming_normal = "kaiming_normal"
+    """
+    All weights are initialized with the Kaiming method from a normal distribution.
+    Note this currently won't work with FSDP.
+    """
+
+    fan_in = "fan_in"
+    """
+    "Fan-in variance scaling", i.e. normal with a standard deviation of ``1/sqrt(d_in)`` where ``d_in``
+    is the input dimensionality of the kernel.
+    """
+
+    full_megatron = "full_megatron"
+    """
+    This is what metaseq calls "full megatron init". It is the init used for Llama 2.
+    """
+
+
+@dataclass
+class ModelConfig:
+    """
+    LLaDA (model) configuration.
+    """
+
+    # Note that the defaults for these attributes are equivalent to the base GPT2 model.
+
+    d_model: int = 768
+    """
+    The hidden size of the model.
+    """
+
+    n_heads: int = 12
+    """
+    The number of self-attention heads.
+    """
+
+    n_kv_heads: Optional[int] = None
+    """
+    The number of heads to use for keys and values. Defaults to `n_heads`.
+    Set this to ``None`` or ``n_heads`` for normal multi-head attention.
+    Set this to 1 for multi-query attention.
+    Set it to some in-between value for Llama2-style grouped query attention.
+    """
+
+    n_layers: int = 12
+    """
+    The number of layers/blocks.
+    """
+
+    mlp_ratio: int = 4
+    """
+    The ratio of the inner MLP dimensionality to ``d_model``.
+    This is only used when ``mlp_hidden_size`` is not set.
+    """
+
+    mlp_hidden_size: Optional[int] = None
+    """
+    Set the exact hidden size for the MLP. Otherwise the inner MLP hidden size will be set to `mlp_ratio * d_model`.
+    """
+
+    activation_type: ActivationType = ActivationType.swiglu
+    """
+    The activation function to use within the MLP layers.
+    """
+
+    block_type: BlockType = BlockType.sequential
+    """
+    The transformer block implementation.
+    """
+
+    block_group_size: int = 1
+    """
+    The number of blocks to group together into a single parent block.
+    This has no affect on the number of parameters in the model and is only used to wrap groups
+    of blocks together with a single FSDP wrapper during training.
+    """
+
+    alibi: bool = False
+    """
+    If ``True``, use ALiBi embeddings. Mutually exclusive with ``rope``.
+    """
+
+    alibi_bias_max: float = 8.0
+    """
+    Maximum absolute value of ALiBi bias.
+    """
+
+    rope: bool = False
+    """
+    Use rotary positional embeddings (RoPE). Mutually exclusive with ``alibi``.
+    """
+
+    rope_full_precision: bool = True
+    """
+    If ``True``, apply RoPE embeddings at full precision regardless of the input type. Otherwise,
+    apply RoPE at the precision of the input.
+    """
+
+    flash_attention: bool = False
+    """
+    If ``True``, use ``FlashAttention``.
+    """
+
+    attention_dropout: float = 0.1
+    """
+    The dropout probability within the attention modules.
+    """
+
+    multi_query_attention: Optional[bool] = None
+    """
+    Use the Multi-Query formulation of attention used in PaLM. This reduces the number of parameters
+    and is more efficient during inference.
+    """
+
+    attention_layer_norm: bool = False
+    """
+    Apply layer norm to the keys and queries within the attention mechanism.
+    This can help stabilize training.
+    """
+
+    residual_dropout: float = 0.1
+    """
+    The dropout probability for the MLP and attention output within each block.
+    """
+
+    embedding_dropout: float = 0.1
+    """
+    The dropout probability for embeddings.
+    """
+
+    input_emb_norm: bool = False
+    """
+    An input hidden_states norm implementation by gemmma.
+    """
+
+    layer_norm_type: LayerNormType = LayerNormType.default
+    """
+    The layernorm implementation to use.
+    """
+
+    layer_norm_with_affine: bool = True
+    """
+    Whether to include bias and weight parameters for the layer norms.
+    This only affects layer norms that are immediately followed by a linear layer in the forward pass,
+    so everything except QK-norms. To turn off affines for QK norms as well, set :attr:`attention_layer_norm_with_affine`
+    to ``False``.
+    """
+
+    rms_norm_eps: float = 1e-05
+    """
+    The rms layernorm eps param.
+    """
+
+    attention_layer_norm_with_affine: bool = True
+    """
+    Toggle affine transform for the QK norms.
+    """
+
+    max_sequence_length: int = 1024
+    """
+    The maximum input sequence length supported by the model.
+    """
+
+    rope_theta: float = 10000.0
+    """
+    The rope base param.
+    """
+
+    include_qkv_bias: Optional[bool] = False
+    """
+    Whether or not to include bias parameters in qkv linear layers.
+    """
+
+    include_bias: bool = False
+    """
+    Whether or not to include bias parameters in linear layers.
+    In PaLM, they got rid of all bias terms because they found that large
+    models tend to have near 0 bias terms anyway.
+    """
+
+    bias_for_layer_norm: Optional[bool] = None
+    """
+    Whether or not to include bias parameters in layer norm.
+    This is separate from the include_bias parameter, because of a ROCm crash when biases are disabled in
+    layer norm.
+    When this is None (the default), it inherits the setting from include_bias.
+    """
+
+    scale_logits: bool = False
+    """
+    If ``True``, scale the output logits by ``1 / sqrt(d_model)``.
+    """
+
+    vocab_size: int = 50257
+    """
+    Vocabulary size of the model.
+    """
+
+    embedding_size: Optional[int] = 50304
+    """
+    The number of embeddings, i.e. the number of tokens. If set to ``None`` it will default
+    to ``vocab_size``. If ``vocab_size`` is not a multiple of 128, setting this to the
+    next multiple of 128 that's greater than ``vocab_size`` can improve throughput
+    substantially.
+    """
+
+    weight_tying: bool = True
+    """
+    Whether to tie output linear weights to the input embedding.
+    """
+
+    eos_token_id: int = 50256
+    """
+    The ID of the end-of-sentence special token.
+    """
+
+    pad_token_id: int = 50256
+    """
+    The ID of the token to use for padding. Defaults to the ID of the EOS token.
+    """
+
+    mask_token_id: Optional[int] = 50256
+    """
+    The ID of the token to use for mask token. Defaults to the ID of the EOS token.
+    """
+
+    init_device: Optional[str] = None
+    """
+    The torch device to use when initializing the model parameters, e.g. "cpu", "cuda:0", "meta".
+    """
+
+    init_fn: InitFnType = InitFnType.normal
+    """
+    The weight initialization strategy.
+    """
+
+    init_std: float = 0.02
+    """
+    The standard deviation to use when initializing weights with a "fixed distribution" ``init_fn``, such
+    as "normal".
+    """
+
+    init_cutoff_factor: Optional[float] = None
+    """
+    A positive factor used to scale the cutoff values when initializing weights with a "fixed distribution" ``init_fn``, such
+    as "normal". Setting this to None means values are not cutoff.
+    """
+
+    precision: Optional[str] = None
+    """
+    Precision used to train/evaluate with. You shouldn't set this directly.
+    See :data:`TrainConfig.precision` instead.
+    """
+
+    @property
+    def effective_n_kv_heads(self) -> int:
+        if self.n_kv_heads is None:
+            if self.multi_query_attention is True:
+                return 1
+            else:
+                return self.n_heads
+        else:
+            if self.multi_query_attention is None:
+                return self.n_kv_heads
+            n_kv_heads_should_be = 1 if self.multi_query_attention else self.n_heads
+            if self.n_kv_heads == n_kv_heads_should_be:
+                return n_kv_heads_should_be
+            else:
+                raise Exception(
+                    "You can't set `multi_query_attention` and `n_kv_heads` at the same time."
+                )
+
+
+class ActivationCheckpointingStrategy(StrEnum):
+    whole_layer = "whole_layer"
+    """
+    Checkpoint every transformer layer.
+    """
+
+    one_in_two = "one_in_two"
+    """
+    Checkpoint one in two transformer layers.
+    """
+
+    one_in_three = "one_in_three"
+    """
+    Checkpoint one in three transformer layers.
+    """
+
+    one_in_four = "one_in_four"
+    """
+    Checkpoint one in four transformer layers.
+    """
+
+    two_in_three = "two_in_three"
+    """
+    Checkpoint two out of every three transformer layers.
+    """
+
+    three_in_four = "three_in_four"
+    """
+    Checkpoint three out of four of every transformer layers.
+    """
+
+    four_in_five = "four_in_five"
+    """
+    Checkpoint four out of five of every transformer layers.
+    """
+
+    nine_in_ten = "nine_in_ten"
+    """
+    Checkpoint nine out of ten of every transformer layers.
+    """
+
+    fine_grained = "fine_grained"
+    """
+    Focus checkpointing on where it is cheap to recompute and saves most memory.
+    """
+
+
+class LLaDAConfig(PretrainedConfig):
+    model_type = "llada"
+    keys_to_ignore_at_inference = ["past_key_values"]  # TODO: confirm
+
+    def __init__(self, use_cache: bool = False, **kwargs):
+        model_config = ModelConfig()
+        all_kwargs = model_config.__dict__
+        all_kwargs.update(kwargs)
+        all_kwargs.update({"use_cache": use_cache})
+        all_kwargs.update(
+            {"architectures": all_kwargs.get("architectures", ["LLaDAModelLM"])}
+        )
+        super().__init__(**all_kwargs)
+        # Explicitly store use_cache as an instance attribute so that
+        # self.config.use_cache works in model forward() methods.
+        self.use_cache = use_cache
+
+    @property
+    def num_attention_heads(self):
+        return self.n_heads
+
+    @property
+    def num_hidden_layers(self):
+        return self.n_layers
+
+    @property
+    def hidden_size(self):
+        return self.d_model

--- a/unturtle/models/backbones/llada/generation_utils.py
+++ b/unturtle/models/backbones/llada/generation_utils.py
@@ -1,0 +1,277 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generation utilities for LLaDA models.
+
+LLaDA-specific overrides of the shared MDLM generation kernel.
+
+Key difference from the shared mixin:
+- ``attention_mask`` must stay **2-D** ``[B, L]`` (HF-style padding mask).
+  The shared mixin expands it to 4-D for SDPA; LLaDA's own ``LLaDAModel``
+  expects a flat 2-D mask and performs the expansion itself at line 1329 of
+  ``modeling_llada.py`` via ``.view(batch_size, -1)``.  Pre-expanding to 4-D
+  would break that path.
+
+Phase M.1: Block-decode support via BlockDecodeMixin.
+"""
+
+from typing import Any, Optional, Union
+
+import torch
+import torch.nn.functional as F
+
+from unturtle.models.generation.block_decode_mixin import BlockDecodeMixin
+from unturtle.models.generation.diffusion_generation_utils import (
+    MaskedDiffusionGenerationConfig,
+    MaskedDiffusionGenerationMixin,
+    MaskedDiffusionModelOutput,
+    sample_tokens,
+)
+
+
+class LLaDAGenerationConfig(MaskedDiffusionGenerationConfig):
+    """Generation config for LLaDA models (currently identical to the shared config)."""
+
+    pass
+
+
+class LLaDAGenerationMixin(BlockDecodeMixin, MaskedDiffusionGenerationMixin):
+    """Generation mixin for LLaDA models with block-decode support.
+
+    Phase M.1: Inherits BlockDecodeMixin for Fast-dLLM style block-decode KV cache.
+
+    Overrides :meth:`_sample` to keep ``attention_mask`` as a 2-D HF-style
+    padding mask — ``LLaDAModel`` expects this shape and performs its own
+    internal expansion.  Everything else delegates to the shared mixin.
+    """
+
+    def _sample(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.LongTensor],
+        generation_config: MaskedDiffusionGenerationConfig,
+    ) -> Union[MaskedDiffusionModelOutput, torch.LongTensor]:
+        """MDLM denoising loop for LLaDA.
+
+        Phase M.1: Delegates to block-decode path when use_cache=True.
+
+        Identical to :meth:`MaskedDiffusionGenerationMixin._sample` except that
+        ``attention_mask`` is **not** expanded to 4-D.  LLaDA's internal
+        ``LLaDAModel.forward`` calls ``.view(batch_size, -1)`` on the mask at
+        line 1329 of ``modeling_llada.py`` and then adds it as an additive bias,
+        so it must receive a 2-D ``[B, L]`` tensor.
+        """
+        # Phase M.1: Delegate to block-decode when use_cache=True
+        if generation_config.use_cache:
+            return self._sample_with_cache(input_ids, attention_mask, generation_config)
+        output_history = generation_config.output_history
+        return_dict_out = generation_config.return_dict
+        max_length = generation_config.max_length
+        mask_token_id = generation_config.mask_token_id
+        steps = generation_config.steps
+        eps = generation_config.eps
+        alg = generation_config.alg
+        alg_temp = generation_config.alg_temp
+        temperature = generation_config.temperature
+        top_p = generation_config.top_p
+        top_k = generation_config.top_k
+
+        if mask_token_id is None:
+            mask_token_id = getattr(self.config, "mask_token_id", None)
+        if mask_token_id is None:
+            raise ValueError(
+                "`mask_token_id` must be set in `generation_config` or `model.config` before calling "
+                "`diffusion_generate()`.  Pass it explicitly: "
+                "`model.diffusion_generate(inputs, mask_token_id=<id>, ...)`"
+            )
+
+        histories = [] if (return_dict_out and output_history) else None
+
+        # Pad completion region with mask tokens.
+        x = F.pad(input_ids, (0, max_length - input_ids.shape[1]), value=mask_token_id)
+
+        # Keep attention_mask as 2-D [B, L] — LLaDAModel handles its own expansion.
+        if attention_mask is not None and torch.any(attention_mask == 0.0):
+            attention_mask = F.pad(
+                attention_mask, (0, max_length - attention_mask.shape[1]), value=1.0
+            )
+            # 2-D only — do NOT broadcast to 4-D here.
+        else:
+            attention_mask = None
+
+        timesteps = torch.linspace(1, eps, steps + 1, device=x.device)
+
+        for i in range(steps):
+            mask_index = x == mask_token_id
+
+            # Forward pass — no logit shift (contrast with DreamGenerationMixin).
+            logits = self(
+                input_ids=x, attention_mask=attention_mask
+            ).logits  # [B, L, V]
+
+            mask_logits = logits[mask_index]  # [N_masked, V]
+            t = timesteps[i]
+            s = timesteps[i + 1]
+
+            if alg == "origin":
+                p_transfer = 1 - s / t if i < steps - 1 else 1.0
+                x0 = torch.full_like(x[mask_index], mask_token_id, dtype=torch.long)
+                transfer = torch.rand(*x0.shape, device=x.device) < p_transfer
+                _, sampled = sample_tokens(
+                    mask_logits[transfer],
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                )
+                x0[transfer] = sampled
+                x[mask_index] = x0
+            else:
+                if alg == "maskgit_plus":
+                    confidence, x0 = sample_tokens(
+                        mask_logits, temperature=temperature, top_p=top_p, top_k=top_k
+                    )
+                elif alg == "topk_margin":
+                    confidence, x0 = sample_tokens(
+                        mask_logits,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        margin_confidence=True,
+                    )
+                elif alg == "entropy":
+                    confidence, x0 = sample_tokens(
+                        mask_logits,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        neg_entropy=True,
+                    )
+                else:
+                    raise RuntimeError(
+                        f"Unknown alg: {alg!r}. Choose from 'origin', 'maskgit_plus', 'topk_margin', 'entropy'."
+                    )
+
+                num_mask_token = mask_index.sum() / mask_index.shape[0]
+                n_transfer = (
+                    int(num_mask_token * (1 - s / t))
+                    if i < steps - 1
+                    else int(num_mask_token)
+                )
+                full_confidence = torch.full_like(x, -torch.inf, dtype=logits.dtype)
+                full_confidence[mask_index] = confidence
+
+                if n_transfer > 0:
+                    if alg_temp is None or alg_temp == 0:
+                        _, transfer_index = torch.topk(full_confidence, n_transfer)
+                    else:
+                        full_confidence = full_confidence / alg_temp
+                        full_confidence = F.softmax(full_confidence, dim=-1)
+                        transfer_index = torch.multinomial(
+                            full_confidence, num_samples=n_transfer
+                        )
+
+                    x_ = torch.full_like(x, mask_token_id, dtype=torch.long)
+                    x_[mask_index] = x0
+                    row_idx = (
+                        torch.arange(x.size(0), device=x.device)
+                        .unsqueeze(1)
+                        .expand_as(transfer_index)
+                    )
+                    x[row_idx, transfer_index] = x_[row_idx, transfer_index]
+
+            if histories is not None:
+                histories.append(x.clone())
+
+        if return_dict_out:
+            return MaskedDiffusionModelOutput(
+                sequences=x,
+                history=tuple(histories) if histories is not None else None,
+            )
+        return x
+
+    def _sample_with_cache(
+        self,
+        input_ids: torch.LongTensor,
+        attention_mask: Optional[torch.LongTensor],
+        generation_config: MaskedDiffusionGenerationConfig,
+    ) -> Union[MaskedDiffusionModelOutput, torch.LongTensor]:
+        """Block-decode generation with KV cache for LLaDA.
+
+        Note: attention_mask stays 2-D for LLaDA (see _sample docstring).
+        """
+        block_decode_output = self._block_decode_loop(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            generation_config=generation_config,
+        )
+        timing = None
+        if isinstance(block_decode_output, tuple):
+            x, timing = block_decode_output
+        else:
+            x = block_decode_output
+
+        # Wrap output according to generation_config.return_dict
+        if generation_config.return_dict:
+            return MaskedDiffusionModelOutput(sequences=x, history=None, timing=timing)
+        return x
+
+    def _model_forward_with_cache(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Any],
+        use_cache: bool,
+        replace_position: Optional[torch.Tensor] = None,
+    ):
+        """LLaDA-specific forward with cache.
+
+        Phase M.1: Implements BlockDecodeMixin's abstract method.
+
+        Args:
+            input_ids: Token IDs [batch, seq_len]
+            attention_mask: 2-D attention mask [batch, seq_len] (LLaDA requires 2-D)
+            past_key_values: KV cache (tuple format or DynamicCache)
+            use_cache: Whether to return cache
+            replace_position: Bool tensor [batch, seq_len] for dual-cache mode
+
+        Returns:
+            Object with .past_key_values and .logits attributes
+        """
+        # LLaDAModelLM expects self.model to be LLaDAModel
+        # Forward signature: forward(input_ids, attention_mask, past_key_values, use_cache, replace_position)
+        out = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            replace_position=replace_position,
+        )
+
+        # BlockDecodeMixin expects .past_key_values attribute, but LLaDAOutput has .attn_key_values
+        # Create a simple object with the expected interface
+        class OutputAdapter:
+            def __init__(self, logits, past_key_values):
+                self.logits = logits
+                self.past_key_values = past_key_values
+
+        # Convert list to tuple for cache_utils compatibility
+        cache = tuple(out.attn_key_values) if out.attn_key_values is not None else None
+        return OutputAdapter(logits=out.logits, past_key_values=cache)
+
+
+__all__ = [
+    "LLaDAGenerationConfig",
+    "LLaDAGenerationMixin",
+    "MaskedDiffusionModelOutput",
+]

--- a/unturtle/models/backbones/llada/modeling_llada.py
+++ b/unturtle/models/backbones/llada/modeling_llada.py
@@ -1,0 +1,2062 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Ported from zhziszz/dllm (dllm/pipelines/llada/models/modeling_llada.py).
+
+from __future__ import annotations
+
+import logging
+import math
+import sys
+from abc import abstractmethod
+from collections import defaultdict
+from dataclasses import fields
+from functools import partial
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
+
+import torch
+import torch.backends.cuda
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import einsum
+from transformers import PreTrainedModel
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.models.auto import AutoModel
+
+from .generation_utils import LLaDAGenerationMixin
+
+try:
+    from unsloth.kernels.rope_embedding import (
+        fast_rope_embedding as _fast_rope_embedding,
+    )
+
+    _HAS_FAST_ROPE = True
+except ImportError:
+    _HAS_FAST_ROPE = False
+
+from .configuration_llada import (
+    ActivationCheckpointingStrategy,
+    ActivationType,
+    BlockType,
+    InitFnType,
+    LayerNormType,
+    LLaDAConfig,
+    ModelConfig,
+    StrEnum,
+)
+
+if sys.version_info.minor > 8:
+    from collections.abc import MutableMapping
+elif sys.version_info.minor == 8:
+    from typing import MutableMapping
+else:
+    raise SystemExit("This script supports Python 3.8 or higher")
+
+__all__ = [
+    "LayerNormBase",
+    "LayerNorm",
+    "RMSLayerNorm",
+    "GemmaRMSLayerNorm",
+    "RotaryEmbedding",
+    "Activation",
+    "GELU",
+    "ReLU",
+    "SwiGLU",
+    "LLaDABlock",
+    "LLaDASequentialBlock",
+    "LLaDAPreTrainedModel",
+    "LLaDAModel",
+    "LLaDAOutput",
+    "LLaDAGenerateOutput",
+]
+
+
+log = logging.getLogger(__name__)
+
+
+class ModuleType(StrEnum):
+    in_module = "in"
+    out_module = "out"
+    emb = "emb"
+    final_out = "final_out"
+
+
+def init_weights(
+    config: ModelConfig,
+    module: Union[nn.Linear, nn.Embedding],
+    d: Optional[int] = None,
+    layer_id: Optional[int] = None,
+    std_factor: float = 1.0,
+    type_of_module: Optional[ModuleType] = None,
+) -> None:
+    """
+    Initialize weights of a linear or embedding module.
+    :param config: The model config.
+    :param module: The linear or embedding submodule to initialize.
+    :param d: The effective input dimensionality of the weights. This could be smaller than the actual dimensions
+        for fused layers.
+    :param layer_id: When set, the standard deviation for the "mitchell" method will be adjusted by
+        ``1 / sqrt(2 * (layer_id + 1))``.
+    """
+    d = d if d is not None else config.d_model
+    if config.init_fn == InitFnType.normal:
+        std = config.init_std * std_factor
+        if config.init_cutoff_factor is not None:
+            cutoff_value = config.init_cutoff_factor * std
+            nn.init.trunc_normal_(
+                module.weight, mean=0.0, std=std, a=-cutoff_value, b=cutoff_value
+            )
+        else:
+            nn.init.normal_(module.weight, mean=0.0, std=std)
+    elif config.init_fn == InitFnType.mitchell:
+        std = std_factor / math.sqrt(d)
+        if layer_id is not None:
+            std = std / math.sqrt(2 * (layer_id + 1))
+        nn.init.trunc_normal_(module.weight, mean=0.0, std=std, a=-3 * std, b=3 * std)
+    elif config.init_fn == InitFnType.kaiming_normal:
+        nn.init.kaiming_normal_(module.weight, nonlinearity="relu")
+    elif config.init_fn == InitFnType.fan_in:
+        std = std_factor / math.sqrt(d)
+        nn.init.normal_(module.weight, mean=0.0, std=std)
+    elif config.init_fn == InitFnType.full_megatron:
+        if type_of_module is None:
+            raise RuntimeError(
+                f"When using the {InitFnType.full_megatron} init, every module must have a type."
+            )
+
+        cutoff_factor = config.init_cutoff_factor
+        if cutoff_factor is None:
+            cutoff_factor = 3
+
+        if type_of_module == ModuleType.in_module:
+            # for att_proj (same as QKV), ff_proj
+            std = config.init_std
+        elif type_of_module == ModuleType.out_module:
+            # for attn_out, ff_out
+            std = config.init_std / math.sqrt(2.0 * config.n_layers)
+        elif type_of_module == ModuleType.emb:
+            # positional embeddings (wpe)
+            # token embeddings (wte)
+            std = config.init_std
+        elif type_of_module == ModuleType.final_out:
+            # final output (ff_out)
+            std = config.d_model**-0.5
+        else:
+            raise RuntimeError(f"Unknown module type '{type_of_module}'")
+        nn.init.trunc_normal_(
+            module.weight,
+            mean=0.0,
+            std=std,
+            a=-cutoff_factor * std,
+            b=cutoff_factor * std,
+        )
+    else:
+        raise NotImplementedError(config.init_fn)
+
+    if isinstance(module, nn.Linear):
+        if module.bias is not None:
+            nn.init.zeros_(module.bias)
+
+        if config.init_fn == InitFnType.normal and getattr(
+            module, "_is_residual", False
+        ):
+            with torch.no_grad():
+                module.weight.div_(math.sqrt(2 * config.n_layers))
+
+
+def ensure_finite_(
+    x: torch.Tensor, check_neg_inf: bool = True, check_pos_inf: bool = False
+):
+    """
+    Modify ``x`` in place to replace ``float("-inf")`` with the minimum value of the dtype when ``check_neg_inf``
+    is ``True`` and to replace ``float("inf")`` with the maximum value of the dtype when ``check_pos_inf`` is ``True``.
+    """
+    if check_neg_inf:
+        x.masked_fill_(x == float("-inf"), torch.finfo(x.dtype).min)
+    if check_pos_inf:
+        x.masked_fill_(x == float("inf"), torch.finfo(x.dtype).max)
+
+
+def activation_checkpoint_function(cfg: ModelConfig):
+    preserve_rng_state = (
+        (cfg.attention_dropout == 0.0)
+        and (cfg.embedding_dropout == 0.0)
+        and (cfg.residual_dropout == 0.0)
+    )
+    from torch.utils.checkpoint import checkpoint
+
+    return partial(
+        checkpoint,
+        preserve_rng_state=preserve_rng_state,
+        use_reentrant=False,
+    )
+
+
+class BufferCache(dict, MutableMapping[str, torch.Tensor]):
+    """
+    Cache for attention biases and other things that would normally be stored as buffers.
+    We avoid using buffers because we've run into various issues doing so with FSDP.
+    In general it appears the way FSDP handles buffers is not well-defined.
+    It doesn't shard them but apparently it does synchronize them across processes, which we want to avoid
+    since (A) it isn't necessary, and (B) we sometimes have `-inf` in these biases which might get turned into
+    NaNs when they're synchronized due to casting or some other issue.
+    """
+
+
+def _non_meta_init_device(config: ModelConfig) -> torch.device:
+    if config.init_device is not None and config.init_device != "meta":
+        return torch.device(config.init_device)
+    else:
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+class Dropout(nn.Dropout):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.p == 0.0:
+            return input
+        else:
+            return F.dropout(input, self.p, self.training, self.inplace)
+
+
+class LayerNormBase(nn.Module):
+    def __init__(
+        self,
+        config: ModelConfig,
+        *,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = True,
+        eps: float = 1e-05,
+    ):
+        super().__init__()
+        self.config = config
+        self.eps = eps
+        self.normalized_shape = (size or config.d_model,)
+        if elementwise_affine or (
+            elementwise_affine is None and self.config.layer_norm_with_affine
+        ):
+            self.weight = nn.Parameter(
+                torch.ones(self.normalized_shape, device=config.init_device)
+            )
+            use_bias = self.config.bias_for_layer_norm
+            if use_bias is None:
+                use_bias = self.config.include_bias
+            if use_bias:
+                self.bias = nn.Parameter(
+                    torch.zeros(self.normalized_shape, device=config.init_device)
+                )
+            else:
+                self.register_parameter("bias", None)
+        else:
+            self.register_parameter("bias", None)
+            self.register_parameter("weight", None)
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    @classmethod
+    def build(
+        cls, config: ModelConfig, size: Optional[int] = None, **kwargs
+    ) -> LayerNormBase:
+        if config.layer_norm_type == LayerNormType.default:
+            return LayerNorm(config, size=size, low_precision=False, **kwargs)
+        elif config.layer_norm_type == LayerNormType.low_precision:
+            return LayerNorm(config, size=size, low_precision=True, **kwargs)
+        elif config.layer_norm_type == LayerNormType.rms:
+            return RMSLayerNorm(config, size=size, **kwargs)
+        elif config.layer_norm_type == LayerNormType.gemma_rms:
+            return GemmaRMSLayerNorm(config, size=size, **kwargs)
+        else:
+            raise NotImplementedError(
+                f"Unknown LayerNorm type: '{config.layer_norm_type}'"
+            )
+
+    def _cast_if_autocast_enabled(
+        self, tensor: torch.Tensor, dtype: Optional[torch.dtype] = None
+    ) -> torch.Tensor:
+        # NOTE: `is_autocast_enabled()` only checks for CUDA autocast, so we use the separate function
+        # `is_autocast_cpu_enabled()` for CPU autocast.
+        # See https://github.com/pytorch/pytorch/issues/110966.
+        if tensor.device.type == "cuda" and torch.is_autocast_enabled():
+            return tensor.to(
+                dtype=dtype if dtype is not None else torch.get_autocast_gpu_dtype()
+            )
+        elif tensor.device.type == "cpu" and torch.is_autocast_cpu_enabled():
+            return tensor.to(
+                dtype=dtype if dtype is not None else torch.get_autocast_cpu_dtype()
+            )
+        else:
+            return tensor
+
+    def reset_parameters(self):
+        if self.weight is not None:
+            torch.nn.init.ones_(self.weight)  # type: ignore
+        if self.bias is not None:
+            torch.nn.init.zeros_(self.bias)  # type: ignore
+
+
+class LayerNorm(LayerNormBase):
+    """
+    The default :class:`LayerNorm` implementation which can optionally run in low precision.
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        low_precision: bool = False,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-05,
+    ):
+        super().__init__(
+            config, size=size, elementwise_affine=elementwise_affine, eps=eps
+        )
+        self.low_precision = low_precision
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.low_precision:
+            module_device = x.device
+            downcast_x = self._cast_if_autocast_enabled(x)
+            downcast_weight = (
+                self._cast_if_autocast_enabled(self.weight)
+                if self.weight is not None
+                else self.weight
+            )
+            downcast_bias = (
+                self._cast_if_autocast_enabled(self.bias)
+                if self.bias is not None
+                else self.bias
+            )
+            with torch.autocast(enabled=False, device_type=module_device.type):
+                return F.layer_norm(
+                    downcast_x,
+                    self.normalized_shape,
+                    weight=downcast_weight,
+                    bias=downcast_bias,
+                    eps=self.eps,
+                )
+        else:
+            return F.layer_norm(
+                x,
+                self.normalized_shape,
+                weight=self.weight,
+                bias=self.bias,
+                eps=self.eps,
+            )
+
+
+class RMSLayerNorm(LayerNormBase):
+    """
+    RMS layer norm, a simplified :class:`LayerNorm` implementation
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-5,
+    ):
+        super().__init__(
+            config,
+            size=size,
+            elementwise_affine=elementwise_affine,
+            eps=config.rms_norm_eps,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        with torch.autocast(enabled=False, device_type=x.device.type):
+            og_dtype = x.dtype
+            x = x.to(torch.float32)
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x = x * torch.rsqrt(variance + self.eps)
+            x = x.to(og_dtype)
+
+        if self.weight is not None:
+            if self.bias is not None:
+                return self.weight * x + self.bias
+            else:
+                return self.weight * x
+        else:
+            return x
+
+
+class GemmaRMSLayerNorm(LayerNormBase):
+    """
+    Gemma RMS layer norm, a simplified :class:`LayerNorm` implementation
+    """
+
+    def __init__(
+        self,
+        config: ModelConfig,
+        size: Optional[int] = None,
+        elementwise_affine: Optional[bool] = None,
+        eps: float = 1e-5,
+    ):
+        super().__init__(
+            config,
+            size=size,
+            elementwise_affine=elementwise_affine,
+            eps=config.rms_norm_eps,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        with torch.autocast(enabled=False, device_type=x.device.type):
+            og_dtype = x.dtype
+            x = x.to(torch.float32)
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x = x * torch.rsqrt(variance + self.eps)
+            x = x.to(og_dtype)
+
+        if self.weight is not None:
+            if self.bias is not None:
+                return x * (1 + self.weight) + self.bias
+            else:
+                return x * (1 + self.weight)
+        else:
+            return x
+
+
+class RotaryEmbedding(nn.Module):
+    """
+    [Rotary positional embeddings (RoPE)](https://arxiv.org/abs/2104.09864).
+    """
+
+    def __init__(self, config: ModelConfig, cache: BufferCache):
+        super().__init__()
+        self.config = config
+        self.__cache = cache
+        # Warm up cache.
+        self.rope_theta = config.rope_theta
+        self.get_rotary_embedding(
+            config.max_sequence_length, _non_meta_init_device(config)
+        )
+
+    def get_rotary_embedding(
+        self, seq_len: int, device: torch.device
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if (
+            (pos_sin := self.__cache.get("rope_pos_sin")) is not None
+            and (pos_cos := self.__cache.get("rope_pos_cos")) is not None
+            and pos_sin.shape[-2] >= seq_len
+            and pos_cos.shape[-2] >= seq_len
+        ):
+            if pos_sin.device != device:
+                pos_sin = pos_sin.to(device)
+                self.__cache["rope_pos_sin"] = pos_sin
+            if pos_cos.device != device:
+                pos_cos = pos_cos.to(device)
+                self.__cache["rope_pos_cos"] = pos_cos
+            return pos_sin[:, :, :seq_len, :], pos_cos[:, :, :seq_len, :]
+
+        with torch.autocast(device.type, enabled=False):
+            dim = self.config.d_model // self.config.n_heads
+            inv_freq = 1.0 / (
+                self.rope_theta
+                ** (torch.arange(0, dim, 2, device=device, dtype=torch.float) / dim)
+            )
+            seq = torch.arange(seq_len, device=device, dtype=torch.float)
+            freqs = einsum("i , j -> i j", seq, inv_freq)
+            positions = torch.cat((freqs, freqs), dim=-1)
+            pos_sin, pos_cos = (
+                positions.sin()[None, None, :, :],
+                positions.cos()[None, None, :, :],
+            )
+        self.__cache["rope_pos_sin"] = pos_sin
+        self.__cache["rope_pos_cos"] = pos_cos
+        return pos_sin, pos_cos
+
+    def rotate_half(self, x: torch.Tensor) -> torch.Tensor:
+        B, nh, T, hs = x.size()
+        x = x.view(B, nh, T, 2, hs // 2)
+        x1, x2 = x.unbind(dim=-2)
+        return torch.cat((-x2, x1), dim=-1)
+
+    def apply_rotary_pos_emb(
+        self, pos_sin: torch.Tensor, pos_cos: torch.Tensor, t: torch.Tensor
+    ) -> torch.Tensor:
+        return ((t * pos_cos) + (self.rotate_half(t) * pos_sin)).to(t.dtype)
+
+    def forward(
+        self, q: torch.Tensor, k: torch.Tensor, block_end_index: Optional[int] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Apply RoPE to query and key tensors.
+
+        Args:
+            q: Query tensor [B, n_heads, seq_len, head_dim]
+            k: Key tensor [B, n_kv_heads, seq_len, head_dim]
+            block_end_index: Optional max position for RoPE (Fast-dLLM style).
+                When set, RoPE is bounded to [0, block_end_index).
+
+        Returns:
+            Tuple of (rotated_q, rotated_k)
+        """
+        if self.config.rope_full_precision:
+            q_, k_ = q.float(), k.float()
+        else:
+            q_, k_ = q, k
+
+        with torch.autocast(q.device.type, enabled=False):
+            query_len, key_len = (
+                q_.shape[-2],
+                k_.shape[-2],
+            )  # could be different if layer_past not None
+
+            # Phase M.1: Fast-dLLM style position indexing with block_end_index
+            pos_sin, pos_cos = self.get_rotary_embedding(key_len, q_.device)
+            pos_sin = pos_sin.type_as(q_)
+            pos_cos = pos_cos.type_as(q_)
+
+            if block_end_index is None:
+                # Standard slicing
+                start = key_len - query_len
+                end = key_len
+            else:
+                # Bounded by block_end_index (Fast-dLLM algorithm)
+                # IMPORTANT: block_end_index is absolute position in full sequence,
+                # but RoPE embeddings are relative to current key_len (cache + query)
+                # We need exactly query_len positions for q_
+                start = max(0, min(key_len - query_len, block_end_index - query_len))
+                end = start + query_len
+
+            # Use index_select for tensor-based indexing (Fast-dLLM style)
+            idx = torch.arange(start, end, device=q_.device, dtype=torch.long)
+            pos_sin_slice = pos_sin.index_select(2, idx)
+            pos_cos_slice = pos_cos.index_select(2, idx)
+
+            q_ = self.apply_rotary_pos_emb(pos_sin_slice, pos_cos_slice, q_)
+            k_ = self.apply_rotary_pos_emb(pos_sin, pos_cos, k_)
+        return q_.type_as(q), k_.type_as(k)
+
+
+class Activation(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+
+    @abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def output_multiplier(self) -> float:
+        raise NotImplementedError
+
+    @classmethod
+    def build(cls, config: ModelConfig) -> Activation:
+        if config.activation_type == ActivationType.gelu:
+            return cast(Activation, GELU(approximate="none"))
+        elif config.activation_type == ActivationType.relu:
+            return cast(Activation, ReLU(inplace=False))
+        elif config.activation_type == ActivationType.silu:
+            return cast(Activation, SiLU(inplace=False))
+        elif config.activation_type == ActivationType.swiglu:
+            return SwiGLU(config)
+        else:
+            raise NotImplementedError(f"Unknown activation: '{config.activation_type}'")
+
+
+class GELU(nn.GELU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+
+class ReLU(nn.ReLU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+
+class SiLU(nn.SiLU):
+    @property
+    def output_multiplier(self) -> float:
+        return 1.0
+
+
+class SwiGLU(Activation):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x, gate = x.chunk(2, dim=-1)
+        return F.silu(gate) * x
+
+    @property
+    def output_multiplier(self) -> float:
+        return 0.5
+
+
+def causal_attention_bias(seq_len: int, device: torch.device) -> torch.FloatTensor:
+    att_bias = torch.triu(
+        torch.ones(seq_len, seq_len, device=device, dtype=torch.float),
+        diagonal=1,
+    )
+    att_bias.masked_fill_(att_bias == 1, torch.finfo(att_bias.dtype).min)
+    return att_bias.view(1, 1, seq_len, seq_len)  # type: ignore
+
+
+def get_causal_attention_bias(
+    cache: BufferCache, seq_len: int, device: torch.device
+) -> torch.Tensor:
+    if (
+        causal_bias := cache.get("causal_attention_bias")
+    ) is not None and causal_bias.shape[-1] >= seq_len:
+        if causal_bias.device != device:
+            causal_bias = causal_bias.to(device)
+            cache["causal_attention_bias"] = causal_bias
+        return causal_bias
+    with torch.autocast(device.type, enabled=False):
+        causal_bias = causal_attention_bias(seq_len, device)
+    cache["causal_attention_bias"] = causal_bias
+    return causal_bias
+
+
+def alibi_attention_bias(
+    seq_len: int, config: ModelConfig, device: torch.device
+) -> torch.FloatTensor:
+    alibi_bias = torch.arange(1 - seq_len, 1, dtype=torch.float, device=device).view(
+        1, 1, 1, seq_len
+    )
+
+    # shape: (1, 1, seq_len, seq_len)
+    alibi_bias = alibi_bias - torch.arange(
+        1 - seq_len, 1, dtype=torch.float, device=device
+    ).view(1, 1, seq_len, 1)
+    alibi_bias.abs_().mul_(-1)
+
+    # shape: (n_heads,)
+    m = torch.arange(1, config.n_heads + 1, dtype=torch.float, device=device)
+    m.mul_(config.alibi_bias_max / config.n_heads)
+
+    # shape: (1, n_heads, seq_len, seq_len)
+    return alibi_bias * (1.0 / (2 ** m.view(1, config.n_heads, 1, 1)))  # type: ignore
+
+
+class LLaDABlock(nn.Module):
+    """
+    A base class for transformer block implementations.
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__()
+        self.layer_id = layer_id
+        self.config = config
+        self.hidden_size = (
+            config.mlp_hidden_size
+            if config.mlp_hidden_size is not None
+            else config.mlp_ratio * config.d_model
+        )
+        self.__cache = cache
+        assert config.d_model % config.n_heads == 0
+
+        self._activation_checkpoint_fn = None
+
+        # Dropout.
+        self.dropout = Dropout(config.residual_dropout)
+
+        # Layer norms.
+        self.k_norm: Optional[LayerNormBase] = None
+        self.q_norm: Optional[LayerNormBase] = None
+        if config.attention_layer_norm:
+            self.k_norm = LayerNormBase.build(
+                config,
+                size=(config.d_model // config.n_heads) * config.effective_n_kv_heads,
+                elementwise_affine=config.attention_layer_norm_with_affine,
+            )
+            self.q_norm = LayerNormBase.build(
+                config, elementwise_affine=config.attention_layer_norm_with_affine
+            )
+
+        # Activation function.
+        self.act = Activation.build(config)
+        assert (self.act.output_multiplier * self.hidden_size) % 1 == 0
+
+        # Attention output projection.
+        self.attn_out = nn.Linear(
+            config.d_model,
+            config.d_model,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+
+        # Feed-forward output projection.
+        self.ff_out = nn.Linear(
+            int(self.act.output_multiplier * self.hidden_size),
+            config.d_model,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+        self.ff_out._is_residual = True  # type: ignore
+
+        # Rotary embeddings.
+        if self.config.rope:
+            self.rotary_emb = RotaryEmbedding(config, self.__cache)
+
+        self.flash_attn_func = None
+        if config.flash_attention:
+            try:
+                from flash_attn import flash_attn_func  # type: ignore
+
+                self.flash_attn_func = flash_attn_func
+            except ModuleNotFoundError:
+                pass
+
+    def reset_parameters(self):
+        if self.k_norm is not None:
+            self.k_norm.reset_parameters()
+        if self.q_norm is not None:
+            self.q_norm.reset_parameters()
+        init_weights(
+            self.config,
+            self.attn_out,
+            d=self.config.d_model,
+            layer_id=self.layer_id,
+            type_of_module=ModuleType.out_module,
+        )
+        init_weights(
+            self.config,
+            self.ff_out,
+            d=self.ff_out.in_features,
+            layer_id=self.layer_id,
+            type_of_module=ModuleType.out_module,
+        )
+
+    def set_activation_checkpointing(
+        self, strategy: Optional[ActivationCheckpointingStrategy]
+    ):
+        if strategy == ActivationCheckpointingStrategy.fine_grained:
+            self._activation_checkpoint_fn = activation_checkpoint_function(self.config)
+        else:
+            self._activation_checkpoint_fn = None
+
+    @classmethod
+    def _cast_attn_bias(
+        cls, bias: torch.Tensor, input_dtype: torch.dtype
+    ) -> torch.Tensor:
+        target_dtype = input_dtype
+        # NOTE: `is_autocast_enabled()` only checks for CUDA autocast, so we use the separate function
+        # `is_autocast_cpu_enabled()` for CPU autocast.
+        # See https://github.com/pytorch/pytorch/issues/110966.
+        if bias.device.type == "cuda" and torch.is_autocast_enabled():
+            target_dtype = torch.get_autocast_gpu_dtype()
+        elif bias.device.type == "cpu" and torch.is_autocast_cpu_enabled():
+            target_dtype = torch.get_autocast_cpu_dtype()
+        if bias.dtype != target_dtype:
+            bias = bias.to(target_dtype)
+            ensure_finite_(bias, check_neg_inf=True, check_pos_inf=False)
+        return bias
+
+    def _scaled_dot_product_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+        dropout_p: float = 0.0,
+        is_causal: bool = False,
+    ) -> torch.Tensor:
+        """
+        Computes scaled dot product attention on query, key and value tensors, using an optional
+        attention mask if passed, and applying dropout if a probability greater than 0.0 is specified.
+        """
+        if self.flash_attn_func is not None and attn_mask is None:
+            r = self.flash_attn_func(
+                q.transpose(1, 2),
+                k.transpose(1, 2),
+                v.transpose(1, 2),
+                dropout_p=dropout_p,
+                causal=False,
+            )
+            return r.transpose(1, 2)
+        else:
+            # torch's sdpa doesn't support GQA, so we're doing this
+            assert k.size(1) == v.size(1)
+            num_kv_heads = k.size(1)
+            num_q_heads = q.size(1)
+            if num_q_heads != num_kv_heads:
+                assert num_q_heads % num_kv_heads == 0
+                k = k.repeat_interleave(
+                    num_q_heads // num_kv_heads, dim=1, output_size=num_q_heads
+                )
+                v = v.repeat_interleave(
+                    num_q_heads // num_kv_heads, dim=1, output_size=num_q_heads
+                )
+
+            # Modify: MDM set causal to False.
+            return F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=attn_mask,
+                dropout_p=dropout_p,
+                is_causal=False,
+            )
+
+    def attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        B, T, C = q.size()  # batch size, sequence length, d_model
+        dtype = k.dtype
+
+        # Optionally apply layer norm to keys and queries.
+        if self.q_norm is not None and self.k_norm is not None:
+            q = self.q_norm(q).to(dtype=dtype)
+            k = self.k_norm(k).to(dtype=dtype)
+
+        # Move head forward to be next to the batch dim.
+        # shape: (B, nh, T, hs)
+        q = q.view(B, T, self.config.n_heads, C // self.config.n_heads).transpose(1, 2)
+        # shape: (B, n_kv_h, T, hs)
+        k = k.view(
+            B, T, self.config.effective_n_kv_heads, C // self.config.n_heads
+        ).transpose(1, 2)
+        # shape: (B, n_kv_h, T, hs)
+        v = v.view(
+            B, T, self.config.effective_n_kv_heads, C // self.config.n_heads
+        ).transpose(1, 2)
+
+        # Phase M.1: Cache handling with replace_position support (Fast-dLLM style)
+        if layer_past is not None:
+            past_key, past_value = layer_past
+
+            if replace_position is not None:
+                # Dual-cache mode: replace marked positions in past cache
+                # Fast-dLLM algorithm (lines 732-748 in llada/model/modeling_llada.py)
+                from ...generation.cache_utils import replace_kv_cache
+
+                # Build updated cache as tuple format
+                layer_cache = (past_key, past_value)
+                # replace_kv_cache expects tuple of all layers, but we only have one layer here
+                # So we wrap it and unwrap after
+                cache_tuple = (layer_cache,)
+                cache_tuple = replace_kv_cache(
+                    cache_tuple,
+                    new_key=k,
+                    new_value=v,
+                    replace_position=replace_position,
+                    layer_idx=0,
+                )
+                k, v = cache_tuple[0]
+            else:
+                # Standard mode: concatenate new KV to past cache
+                k = torch.cat((past_key, k), dim=-2)
+                v = torch.cat((past_value, v), dim=-2)
+
+        present = (k, v) if use_cache else None
+        query_len, key_len = (
+            q.shape[-2],
+            k.shape[-2],
+        )  # could be different if layer_past not None
+
+        if self.config.rope:
+            # Phase M.1: RoPE with replace_position conditional (Fast-dLLM style)
+            # When replace_position is set, RoPE should be bounded by max replace position
+            # (Fast-dLLM llada/model/modeling_llada.py lines 719-724)
+            if replace_position is not None:
+                # Find max position that will be replaced (block_end_index in Fast-dLLM)
+                # replace_position: [B, seq_len] bool tensor
+                max_replace_pos = 0
+                for b in range(replace_position.shape[0]):
+                    indices = replace_position[b].nonzero(as_tuple=True)[0]
+                    if len(indices) > 0:
+                        max_replace_pos = max(
+                            max_replace_pos, int(indices.max().item()) + 1
+                        )
+                # Apply RoPE only up to block end
+                q, k = self.rotary_emb(q, k, block_end_index=max_replace_pos)
+            else:
+                # Standard RoPE application
+                q, k = self.rotary_emb(q, k)
+
+        if attention_bias is not None:
+            # Resize and cast attention bias.
+            # The current dtype of the attention bias might not match the dtype that the SDP attn function will
+            # run in if AMP is enabled, and this can be a problem if some tokens are masked out due to padding
+            # as down-casting the attention bias to the autocast precision will result in -infs, which will
+            # cause the SDP attn function to produce NaNs.
+            attention_bias = self._cast_attn_bias(
+                attention_bias[:, :, key_len - query_len : key_len, :key_len], dtype
+            )
+
+        # Get the attention scores.
+        # shape: (B, nh, T, hs)
+        att = self._scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=attention_bias,
+            dropout_p=0.0 if not self.training else self.config.attention_dropout,
+            is_causal=False,
+        )
+
+        # Re-assemble all head outputs side-by-side.
+        att = att.transpose(1, 2).contiguous().view(B, T, C)
+
+        # Apply output projection.
+        return self.attn_out(att), present
+
+    @abstractmethod
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.FloatTensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        raise NotImplementedError
+
+    @classmethod
+    def build(
+        cls, layer_id: int, config: ModelConfig, cache: BufferCache
+    ) -> LLaDABlock:
+        if config.block_type == BlockType.sequential:
+            return LLaDASequentialBlock(layer_id, config, cache)
+        elif config.block_type == BlockType.llama:
+            return LLaDALlamaBlock(layer_id, config, cache)
+        else:
+            raise NotImplementedError(f"Unknown block type: '{config.block_type}'")
+
+
+class LLaDASequentialBlock(LLaDABlock):
+    """
+    This is a typical transformer block where the output is computed as ``MLP(LN(x + Attention(LN(x))))``
+    (plus another skip connection).
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__(layer_id, config, cache)
+        # Layer norms.
+        self.attn_norm = LayerNorm.build(config)
+        self.ff_norm = LayerNorm.build(config)
+        # Attention input projection. Projects x -> (q, k, v)
+        head_dim = config.d_model // config.n_heads
+        self.fused_dims = (
+            config.d_model,
+            config.effective_n_kv_heads * head_dim,
+            config.effective_n_kv_heads * head_dim,
+        )
+        self.att_proj = nn.Linear(
+            config.d_model,
+            sum(self.fused_dims),
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+        # Feed-forward input projection.
+        self.ff_proj = nn.Linear(
+            config.d_model,
+            self.hidden_size,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+
+    def reset_parameters(self):
+        super().reset_parameters()
+        self.attn_norm.reset_parameters()
+        self.ff_norm.reset_parameters()
+        # NOTE: the standard deviation for these weights does not depend on the layer.
+        init_weights(
+            self.config,
+            self.att_proj,
+            d=self.config.d_model,
+            layer_id=None,
+            type_of_module=ModuleType.in_module,
+        )
+        init_weights(
+            self.config,
+            self.ff_proj,
+            d=self.config.d_model,
+            layer_id=None,
+            type_of_module=ModuleType.in_module,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        # Get query, key, value projections.
+        # shape:
+        #  - for regular attn q, k, v: (batch_size, seq_len, d_model)
+        #  - for multi-query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_heads)
+        #  - for group query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_kv_heads)
+        if self._activation_checkpoint_fn is not None:
+            q, k, v = self.att_proj(
+                self._activation_checkpoint_fn(self.attn_norm, x)
+            ).split(self.fused_dims, dim=-1)
+        else:
+            q, k, v = self.att_proj(self.attn_norm(x)).split(self.fused_dims, dim=-1)
+
+        # Get attention scores.
+        if self._activation_checkpoint_fn is not None:
+            att, cache = self._activation_checkpoint_fn(  # type: ignore
+                self.attention,
+                q,
+                k,
+                v,
+                attention_bias,
+                layer_past=layer_past,
+                use_cache=use_cache,
+                replace_position=replace_position,
+            )
+        else:
+            att, cache = self.attention(
+                q,
+                k,
+                v,
+                attention_bias,
+                layer_past=layer_past,
+                use_cache=use_cache,
+                replace_position=replace_position,
+            )
+
+        # Add attention scores.
+        # shape: (B, T, C)
+        x = x + self.dropout(att)
+
+        # Add feed-forward projection.
+        # shape: (batch_size, seq_len, d_model)
+        og_x = x
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.ff_norm, x)  # type: ignore
+        else:
+            x = self.ff_norm(x)
+        x = self.ff_proj(x)
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.act, x)  # type: ignore
+        else:
+            x = self.act(x)
+        x = self.ff_out(x)
+        x = self.dropout(x)
+        x = og_x + x
+
+        return x, cache
+
+
+class LLaDALlamaBlock(LLaDABlock):
+    """
+    This is a transformer block where the output is computed as ``MLP(LN(x + Attention(LN(x))))``
+    (plus another skip connection). This block is similar to `LLaDASequentialBlock`
+    but some operations have slightly different implementations to imitate the
+    behavior of Llama.
+    """
+
+    def __init__(self, layer_id: int, config: ModelConfig, cache: BufferCache):
+        super().__init__(layer_id, config, cache)
+        # Layer norms.
+        self.attn_norm = LayerNorm.build(config)
+        self.ff_norm = LayerNorm.build(config)
+        self.__cache = cache
+
+        # Attention input projection. Projects x -> (q, k, v)
+        head_dim = config.d_model // config.n_heads
+        q_proj_out_dim = config.d_model
+        k_proj_out_dim = config.effective_n_kv_heads * head_dim
+        v_proj_out_dim = config.effective_n_kv_heads * head_dim
+        self.q_proj = nn.Linear(
+            config.d_model,
+            q_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+        self.k_proj = nn.Linear(
+            config.d_model,
+            k_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+        self.v_proj = nn.Linear(
+            config.d_model,
+            v_proj_out_dim,
+            bias=config.include_bias | config.include_qkv_bias,
+            device=config.init_device,
+        )
+
+        # Feed-forward input projection.
+        self.ff_proj = nn.Linear(
+            config.d_model,
+            self.hidden_size,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+        # new add
+        self.up_proj = nn.Linear(
+            config.d_model,
+            self.hidden_size,
+            bias=config.include_bias,
+            device=config.init_device,
+        )
+
+        # apply_mlp stub — replaced by Triton kernel via _patch_llada_peft on CUDA.
+        # Aliased names for apply_lora_mlp_swiglu compatibility:
+        #   gate_proj → ff_proj, down_proj → ff_out (set in _patch_llada_peft)
+        self.apply_mlp = LLaDALlamaBlock._default_apply_mlp
+
+    def reset_parameters(self):
+        super().reset_parameters()
+        self.attn_norm.reset_parameters()
+        self.ff_norm.reset_parameters()
+        # NOTE: the standard deviation for these weights does not depend on the layer.
+        init_weights(self.config, self.q_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.k_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.v_proj, d=self.config.d_model, layer_id=None)
+        init_weights(self.config, self.ff_proj, d=self.config.d_model, layer_id=None)
+        init_weights(
+            self.config, self.up_proj, d=self.config.d_model, layer_id=None
+        )  # new add
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.Tensor] = None,
+        layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        use_cache: bool = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[Tuple[torch.Tensor, torch.Tensor]]]:
+        # Get query, key, value projections.
+        # shape:
+        #  - for regular attn q, k, v: (batch_size, seq_len, d_model)
+        #  - for multi-query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_heads)
+        #  - for group query attn q: (batch_size, seq_len, d_model)
+        #                      k, v: (batch_size, seq_len, d_model // n_kv_heads)
+        x_normed = self.attn_norm(x)
+        q = self.q_proj(x_normed)
+        k = self.k_proj(x_normed)
+        v = self.v_proj(x_normed)
+
+        # Get attention scores.
+        if self._activation_checkpoint_fn is not None:
+            att, cache = self._activation_checkpoint_fn(  # type: ignore
+                self.attention,
+                q,
+                k,
+                v,
+                attention_bias,
+                layer_past=layer_past,
+                use_cache=use_cache,
+                replace_position=replace_position,
+            )
+        else:
+            att, cache = self.attention(
+                q,
+                k,
+                v,
+                attention_bias,
+                layer_past=layer_past,
+                use_cache=use_cache,
+                replace_position=replace_position,
+            )
+
+        # Add attention scores.
+        # shape: (B, T, C)
+        x = x + self.dropout(att)
+
+        # Add feed-forward projection.
+        # shape: (batch_size, seq_len, d_model)
+        og_x = x
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.ff_norm, x)  # type: ignore
+        else:
+            x = self.ff_norm(x)
+        x = self.apply_mlp(self, x)
+        x = self.dropout(x)
+        x = og_x + x
+
+        return x, cache
+
+    @staticmethod
+    def _default_apply_mlp(self, x: torch.Tensor) -> torch.Tensor:
+        """Default (non-Triton) gated MLP: ff_proj(gate) * up_proj → ff_out.
+
+        Replaced by ``apply_lora_mlp_swiglu`` on CUDA when ``activation_type="silu"``.
+        With SwiGLU (default), ``act.chunk(2)`` halves the gate output while
+        ``up_proj`` stays full-width, so Triton patching is skipped for non-SiLU blocks.
+        """
+        x, x_up = self.ff_proj(x), self.up_proj(x)
+        if self._activation_checkpoint_fn is not None:
+            x = self._activation_checkpoint_fn(self.act, x)  # type: ignore
+        else:
+            x = self.act(x)
+        x = x * x_up
+        return self.ff_out(x)
+
+
+class LLaDAOutput(NamedTuple):
+    logits: torch.FloatTensor
+    """
+    A tensor of shape `(batch_size, seq_len, vocab_size)` representing the log probabilities
+    for the next token *before* normalization via (log) softmax.
+    """
+
+    attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]]
+    """
+    Attention keys and values from each block.
+    """
+
+    hidden_states: Optional[Tuple[torch.Tensor]]
+    """
+    Hidden states from each block.
+    """
+
+
+class LLaDAGenerateOutput(NamedTuple):
+    token_ids: torch.LongTensor
+    """
+    The generated token IDs, a tensor of shape `(batch_size, beam_size, max_steps)`.
+    These do *not* include the original input IDs.
+    """
+
+    scores: torch.FloatTensor
+    """
+    The scores of the generated sequences, a tensor of shape `(batch_size, beam_size)`.
+    """
+
+
+class LLaDABlockGroup(nn.ModuleList):
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_offset: int,
+        modules: Optional[Iterable[nn.Module]] = None,
+    ):
+        super().__init__(modules)
+        self.config = config
+        self.layer_offset = layer_offset
+        self.activation_checkpointing_strategy: Optional[
+            ActivationCheckpointingStrategy
+        ] = None
+        self._activation_checkpoint_fn = activation_checkpoint_function(self.config)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        attention_bias: Optional[torch.FloatTensor] = None,
+        layers_past: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: bool = False,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[List[Tuple[torch.Tensor, torch.Tensor]]]]:
+        attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = (
+            [] if use_cache else None
+        )
+        for block_idx, block in enumerate(self):
+            layer_past = None if layers_past is None else layers_past[block_idx]
+            block_idx += self.layer_offset
+            if (
+                (
+                    self.activation_checkpointing_strategy
+                    == ActivationCheckpointingStrategy.whole_layer
+                )
+                or (
+                    self.activation_checkpointing_strategy
+                    == ActivationCheckpointingStrategy.one_in_two
+                    and block_idx % 2 == 0
+                )
+                or (
+                    self.activation_checkpointing_strategy
+                    == ActivationCheckpointingStrategy.one_in_three
+                    and block_idx % 3 == 0
+                )
+                or (
+                    self.activation_checkpointing_strategy
+                    == ActivationCheckpointingStrategy.one_in_four
+                    and block_idx % 4 == 0
+                )
+            ):
+                # shape: (batch_size, seq_len, d_model)
+                x, cache = self._activation_checkpoint_fn(  # type: ignore
+                    block,
+                    x,
+                    attention_bias=attention_bias,
+                    layer_past=layer_past,
+                    use_cache=use_cache,
+                    replace_position=replace_position,
+                )
+            else:
+                # shape: (batch_size, seq_len, d_model)
+                x, cache = block(
+                    x,
+                    attention_bias=attention_bias,
+                    layer_past=layer_past,
+                    use_cache=use_cache,
+                    replace_position=replace_position,
+                )
+            if attn_key_values is not None:
+                assert cache is not None
+                attn_key_values.append(cache)
+        return x, attn_key_values
+
+    def reset_parameters(self):
+        for block in self:
+            block.reset_parameters()
+
+    def set_activation_checkpointing(
+        self, strategy: Optional[ActivationCheckpointingStrategy]
+    ):
+        self.activation_checkpointing_strategy = strategy
+        for block in self:
+            block.set_activation_checkpointing(strategy)
+
+
+class LLaDAPreTrainedModel(PreTrainedModel):
+    """
+    Minimal HF-compatible base to enable gradient checkpointing hooks and centralize
+    parameter initialization.
+    """
+
+    config_class = LLaDAConfig
+    base_model_prefix = "model"
+    _no_split_modules = ["LLaDALlamaBlock"]
+    _supports_gradient_checkpointing = True  # backward compat
+    supports_gradient_checkpointing = True  # transformers >=4.38
+
+    def __init__(self, config, *model_args, **model_kwargs):
+        hf_config = config
+        if not hasattr(hf_config, "to_dict"):
+            hf_config = LLaDAConfig(**config.__dict__)
+        # Strip quantization-related kwargs that transformers may inject (e.g. load_in_4bit).
+        # PreTrainedModel.__init__ does not accept them directly.
+        for _k in ("load_in_4bit", "load_in_8bit", "quantization_config"):
+            model_kwargs.pop(_k, None)
+        super().__init__(hf_config, *model_args, **model_kwargs)
+
+    def _init_weights(self, module):
+        # Avoid double-initializing by short-circuiting once a module (and its children)
+        # have been reset.
+        if getattr(module, "_llada_params_initialized", False):
+            return
+        if hasattr(module, "reset_parameters"):
+            module.reset_parameters()
+            for child in module.modules():
+                child._llada_params_initialized = True
+
+    def _set_gradient_checkpointing(
+        self, enable: bool = True, gradient_checkpointing_func: Callable = None
+    ):
+        """
+        New-format hook expected by `PreTrainedModel.gradient_checkpointing_enable`.
+        Only LLaDAModel (the heavy transformer) actually toggles checkpointing.
+        """
+        from torch.utils.checkpoint import (
+            checkpoint,  # local import to avoid hard dep at import time
+        )
+
+        if gradient_checkpointing_func is None:
+            gradient_checkpointing_func = checkpoint
+
+        # When called on the HF wrapper (LLaDAModelLM), reach into the inner LLaDAModel.
+        target = self.model if isinstance(self, LLaDAModelLM) else self
+
+        if isinstance(target, LLaDAModel):
+            target._gradient_checkpointing_func = gradient_checkpointing_func
+            target.gradient_checkpointing = enable
+            strategy = ActivationCheckpointingStrategy.whole_layer if enable else None
+            target.set_activation_checkpointing(strategy)
+            return
+
+        # Fallback: walk modules to find the core model.
+        for module in self.modules():
+            if isinstance(module, LLaDAModel):
+                module._gradient_checkpointing_func = gradient_checkpointing_func
+                module.gradient_checkpointing = enable
+                strategy = (
+                    ActivationCheckpointingStrategy.whole_layer if enable else None
+                )
+                module.set_activation_checkpointing(strategy)
+                break
+
+
+class LLaDAModel(LLaDAPreTrainedModel):
+    def __init__(self, config: LLaDAConfig | ModelConfig, init_params: bool = True):
+        super().__init__(config)
+        self.gradient_checkpointing: bool = False
+        self.__cache = BufferCache()
+
+        # Validate config.
+        if self.config.alibi and self.config.flash_attention:
+            raise Exception("ALiBi is currently not supported with FlashAttention")
+
+        if self.config.alibi and self.config.rope:
+            raise Exception("ALiBi and RoPE are mutually exclusive")
+
+        if (
+            self.config.embedding_size is not None
+            and self.config.embedding_size != self.config.vocab_size
+        ):
+            if self.config.embedding_size < self.config.vocab_size:
+                raise Exception(
+                    "embedding size should be at least as big as vocab size"
+                )
+            elif self.config.embedding_size % 128 != 0:
+                import warnings
+
+                warnings.warn(
+                    "Embedding size is not a multiple of 128! This could hurt throughput performance.",
+                    UserWarning,
+                )
+
+        self.activation_checkpointing_strategy: Optional[
+            ActivationCheckpointingStrategy
+        ] = None
+        self._activation_checkpoint_fn: Callable = activation_checkpoint_function(
+            self.config
+        )
+
+        if not (
+            0 < self.config.block_group_size <= self.config.n_layers
+            and self.config.n_layers % self.config.block_group_size == 0
+        ):
+            raise Exception("n layers must be divisible by block group size")
+
+        torch.backends.cuda.enable_flash_sdp(True)
+        torch.backends.cuda.enable_mem_efficient_sdp(
+            False
+        )  # this is super slow so make sure torch won't use it
+
+        self.transformer = nn.ModuleDict(
+            dict(
+                wte=nn.Embedding(
+                    config.embedding_size or config.vocab_size,
+                    config.d_model,
+                    device=config.init_device,
+                ),
+                emb_drop=Dropout(config.embedding_dropout),
+                ln_f=LayerNorm.build(config),
+            )
+        )
+
+        blocks = [
+            LLaDABlock.build(i, config, self.__cache) for i in range(config.n_layers)
+        ]
+        if self.config.block_group_size > 1:
+            block_groups = [
+                LLaDABlockGroup(config, i, blocks[i : i + config.block_group_size])
+                for i in range(0, config.n_layers, config.block_group_size)
+            ]
+            self.transformer.update({"block_groups": nn.ModuleList(block_groups)})
+        else:
+            self.transformer.update({"blocks": nn.ModuleList(blocks)})
+
+        if not (self.config.alibi or self.config.rope):
+            self.transformer.update(
+                {
+                    "wpe": nn.Embedding(
+                        config.max_sequence_length,
+                        config.d_model,
+                        device=config.init_device,
+                    )
+                }
+            )
+        if not config.weight_tying:
+            self.transformer.update(
+                {
+                    "ff_out": nn.Linear(
+                        config.d_model,
+                        config.embedding_size or config.vocab_size,
+                        bias=config.include_bias,
+                        device=config.init_device,
+                    )
+                }
+            )
+        # When `init_device="meta"` FSDP will call `reset_parameters()` to initialize weights.
+        if init_params and self.config.init_device != "meta":
+            self.post_init()
+        self.__num_fwd_flops: Optional[int] = None
+
+        # Warm up cache.
+        if self.config.alibi:
+            get_causal_attention_bias(
+                self.__cache, config.max_sequence_length, _non_meta_init_device(config)
+            )
+            self.get_alibi_attention_bias(
+                config.max_sequence_length, _non_meta_init_device(config)
+            )
+
+    def set_activation_checkpointing(
+        self, strategy: Optional[ActivationCheckpointingStrategy]
+    ):
+        self.activation_checkpointing_strategy = strategy
+        if self.config.block_group_size != 1:
+            for block_group in self.transformer.block_groups:
+                block_group.set_activation_checkpointing(strategy)
+        else:
+            for block in self.transformer.blocks:
+                block.set_activation_checkpointing(strategy)
+
+    @property
+    def device(self) -> torch.device:
+        device: torch.device = self.transformer.wte.weight.device  # type: ignore
+        if device.type == "meta":
+            return _non_meta_init_device(self.config)
+        else:
+            return device
+
+    def reset_parameters(self):
+        log.info("Initializing model parameters...")
+        # Top-level embeddings / linear layers.
+        init_weights(
+            self.config,
+            self.transformer.wte,  # type: ignore
+            std_factor=(0.5 * math.sqrt(self.config.d_model))
+            if self.config.scale_logits
+            else 1.0,
+            type_of_module=ModuleType.emb,
+        )
+        if hasattr(self.transformer, "wpe"):
+            init_weights(
+                self.config, self.transformer.wpe, type_of_module=ModuleType.emb
+            )  # type: ignore
+
+        # Top-level layer norm.
+        self.transformer.ln_f.reset_parameters()  # type: ignore
+
+        # Output weights.
+        if hasattr(self.transformer, "ff_out"):
+            init_weights(
+                self.config,
+                self.transformer.ff_out,
+                type_of_module=ModuleType.final_out,
+            )  # type: ignore
+
+        # Let the blocks handle themselves.
+        if self.config.block_group_size == 1:
+            for block in self.transformer.blocks:
+                block.reset_parameters()
+        else:
+            for block_group in self.transformer.block_groups:
+                block_group.reset_parameters()
+
+    def get_alibi_attention_bias(
+        self, seq_len: int, device: torch.device
+    ) -> torch.Tensor:
+        if (
+            alibi_bias := self.__cache.get("alibi_attention_bias")
+        ) is not None and alibi_bias.shape[-1] >= seq_len:
+            if alibi_bias.device != device:
+                alibi_bias = alibi_bias.to(device)
+                self.__cache["alibi_attention_bias"] = alibi_bias
+            return alibi_bias
+        with torch.autocast(device.type, enabled=False):
+            alibi_bias = alibi_attention_bias(seq_len, self.config, device)
+        self.__cache["alibi_attention_bias"] = alibi_bias
+        return alibi_bias
+
+    def get_bidirectional_attention_bias(
+        self, seq_len: int, device: torch.device
+    ) -> torch.Tensor:
+        if (
+            bidirectional_bias := self.__cache.get("bidirectional_attention_bias")
+        ) is not None and bidirectional_bias.shape[-1] >= seq_len:
+            if bidirectional_bias.device != device:
+                bidirectional_bias = bidirectional_bias.to(device)
+                self.__cache["bidirectional_attention_bias"] = bidirectional_bias
+            return bidirectional_bias
+        with torch.autocast(device.type, enabled=False):
+            bidirectional_bias = torch.zeros(
+                (1, 1, seq_len, seq_len), device=device, dtype=torch.float
+            )
+        self.__cache["bidirectional_attention_bias"] = bidirectional_bias
+        return bidirectional_bias
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor,
+        input_embeddings: Optional[torch.FloatTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        attention_bias: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Sequence[Tuple[torch.Tensor, torch.Tensor]]] = None,
+        use_cache: bool = False,
+        last_logits_only: bool = False,
+        output_hidden_states: Optional[bool] = None,
+        replace_position: Optional[torch.Tensor] = None,
+    ) -> LLaDAOutput:
+        """
+        :param input_ids: A tensor of shape `(batch_size, seq_len)`.
+        :param input_embeddings: A tensor of shape `(batch_size, seq_len, d_model)` with input
+            embeddings. When provided, it is treated as the output of the input embedding layer.
+        :param attention_mask: A tensor of shape `(batch_size, seq_len)` that indicates
+            which input IDs are masked. A `1` value in the mask means that
+            the corresponding input ID should *not* be ignored. A `0` means
+            that the corresponding input ID is masked.
+            This has the same meaning as the `attention_mask` in HuggingFace's `transformers`
+            library.
+        :param attention_bias: A tensor of shape `(batch_size, 1, seq_len, seq_len)`,
+            `(1, 1, seq_len, seq_len)`, or `(seq_len, seq_len)`. This is used
+            to introduce causal or other biases.
+            If the tensor is a bool or byte tensor, a `True` or `1` at `attention_bias[:, :, i, j]`
+            indicates that the i-th element in the sequence is allowed to attend to the j-th
+            element in the sequence.
+            If the tensor is a float tensor, it will just be added to the attention
+            scores before the softmax.
+            The default is causal, which corresponds to a lower-diagonal byte matrix of ones.
+        :param past_key_values: Pre-computed keys and values for each attention block.
+            Can be used to speed up sequential decoding. The `input_ids` which have
+            their past given to this model should not be passed as `input_ids` as they have already been computed.
+        :param use_cache: If `True`, return key and value tensors for each block.
+        :param last_logits_only: If `True`, only compute the logits for the last token of each sequence.
+            This can speed up decoding when you only care about the next token.
+        :param replace_position: A tensor of shape `(batch_size, seq_len)` with bool values.
+            If provided, enables Fast-dLLM-style dual-cache mode: cache positions where
+            replace_position == 1 will be updated with new key/value representations.
+            This is more efficient than trimming+concatenating for block-decode generation.
+        """
+        # Add Basic MDM Model config check
+        assert not self.config.alibi, (
+            "Alibi length extrapolation is not supported for MDM."
+        )
+        assert self.config.rope, "Rope must be used in Llama-Encoder for MDM."
+        # Phase M.1: Enable KV cache for block-decode (Fast-dLLM style)
+        # assert (past_key_values is None and not use_cache), "The kvcache is not supported for MDM."
+
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else False
+        )
+
+        if past_key_values:
+            assert len(past_key_values) == self.config.n_layers
+
+        batch_size, seq_len = (
+            input_ids.size()
+            if input_embeddings is None
+            else input_embeddings.size()[:2]
+        )
+        past_length = 0 if past_key_values is None else past_key_values[0][0].size(-2)
+
+        # Get embeddings of input.
+        # shape: (batch_size, seq_len, d_model)
+        x = (
+            self.transformer.wte(input_ids)
+            if input_embeddings is None
+            else input_embeddings
+        )  # type: ignore
+
+        if self.config.input_emb_norm:
+            x = x * (self.config.d_model**0.5)
+
+        if not (self.config.alibi or self.config.rope):
+            # Get positional embeddings.
+            # shape: (1, seq_len)
+            pos = torch.arange(
+                past_length, past_length + seq_len, dtype=torch.long, device=x.device
+            ).unsqueeze(0)
+            # shape: (1, seq_len, d_model)
+            pos_emb = self.transformer.wpe(pos)  # type: ignore
+            x = pos_emb + x
+
+        # Add input + positional embeddings and apply dropout.
+        # shape: (batch_size, seq_len, d_model)
+        x = self.transformer.emb_drop(x)  # type: ignore
+
+        # Transform the attention mask into what the blocks expect.
+        if attention_mask is not None and 0.0 in attention_mask:
+            # shape: (batch_size, 1, 1, seq_len)
+            attention_mask = attention_mask.to(dtype=torch.float).view(batch_size, -1)[
+                :, None, None, :
+            ]
+            attention_mask = (1.0 - attention_mask) * torch.finfo(
+                attention_mask.dtype
+            ).min
+        else:
+            attention_mask = None
+
+        # Merge attention mask with attention bias.
+        if (
+            attention_bias is not None
+            or attention_mask is not None
+            or self.config.alibi
+            # NOTE (epwalsh): we need to initialize the attn bias in order for attn to work properly
+            # with key+value cache. Otherwise `F.scaled_dot_product_attention()` doesn't seem to compute
+            # scores correctly.
+            or past_key_values is not None
+        ):
+            if attention_bias is None and self.config.alibi:
+                attention_bias = get_causal_attention_bias(
+                    self.__cache, past_length + seq_len, x.device
+                ) + self.get_alibi_attention_bias(past_length + seq_len, x.device)
+            elif attention_bias is None:
+                attention_bias = self.get_bidirectional_attention_bias(
+                    past_length + seq_len, x.device
+                )
+            elif attention_bias.dtype in (torch.int8, torch.bool):
+                attention_bias = attention_bias.to(dtype=torch.float)
+                attention_bias.masked_fill_(
+                    attention_bias == 0.0, torch.finfo(attention_bias.dtype).min
+                )
+
+            # Transform to the right shape and data type.
+            mask_len = seq_len
+            if attention_mask is not None:
+                mask_len = attention_mask.shape[-1]
+            elif past_key_values is not None:
+                mask_len = past_key_values[0][0].shape[-2] + seq_len
+            attention_bias = attention_bias[:, :, :mask_len, :mask_len].to(
+                dtype=torch.float
+            )
+
+            # Add in the masking bias.
+            if attention_mask is not None:
+                attention_bias = attention_bias + attention_mask
+                # Might get -infs after adding attention mask, since dtype.min + dtype.min = -inf.
+                # `F.scaled_dot_product_attention()` doesn't handle -inf like you'd expect, instead
+                # it can produce NaNs.
+                ensure_finite_(attention_bias, check_neg_inf=True, check_pos_inf=False)
+
+        attn_key_values: Optional[List[Tuple[torch.Tensor, torch.Tensor]]] = (
+            [] if use_cache else None
+        )
+
+        # decoder layers
+        all_hidden_states = []
+
+        # Apply blocks one-by-one.
+        if self.config.block_group_size == 1:
+            for block_idx, block in enumerate(self.transformer.blocks):
+                if output_hidden_states:
+                    # add hidden states
+                    all_hidden_states.append(x)
+
+                layer_past = (
+                    None if past_key_values is None else past_key_values[block_idx]
+                )
+                if (
+                    (
+                        self.activation_checkpointing_strategy
+                        == ActivationCheckpointingStrategy.whole_layer
+                    )
+                    or (
+                        self.activation_checkpointing_strategy
+                        == ActivationCheckpointingStrategy.one_in_two
+                        and block_idx % 2 == 0
+                    )
+                    or (
+                        self.activation_checkpointing_strategy
+                        == ActivationCheckpointingStrategy.one_in_three
+                        and block_idx % 3 == 0
+                    )
+                    or (
+                        self.activation_checkpointing_strategy
+                        == ActivationCheckpointingStrategy.one_in_four
+                        and block_idx % 4 == 0
+                    )
+                ):
+                    # shape: (batch_size, seq_len, d_model)
+                    x, cache = self._activation_checkpoint_fn(
+                        block,
+                        x,
+                        attention_bias=attention_bias,
+                        layer_past=layer_past,
+                        use_cache=use_cache,
+                        replace_position=replace_position,
+                    )
+                else:
+                    # shape: (batch_size, seq_len, d_model)
+                    x, cache = block(
+                        x,
+                        attention_bias=attention_bias,
+                        layer_past=layer_past,
+                        use_cache=use_cache,
+                        replace_position=replace_position,
+                    )
+                if attn_key_values is not None:
+                    assert cache is not None
+                    attn_key_values.append(cache)
+        else:
+            for group_idx, block_group in enumerate(self.transformer.block_groups):
+                if output_hidden_states:
+                    # add hidden states
+                    all_hidden_states.append(x)
+
+                layers_past = (
+                    None
+                    if past_key_values is None
+                    else past_key_values[
+                        group_idx * self.config.block_group_size : (group_idx + 1)
+                        * self.config.block_group_size
+                    ]
+                )
+                x, cache = block_group(
+                    x,
+                    attention_bias=attention_bias,
+                    layers_past=layers_past,
+                    use_cache=use_cache,
+                    replace_position=replace_position,
+                )
+                if attn_key_values is not None:
+                    assert cache is not None
+                    attn_key_values.extend(cache)
+
+        if last_logits_only:
+            # shape: (batch_size, 1, d_model)
+            x = x[:, -1, :].unsqueeze(1)
+
+        # Apply final layer norm.
+        # shape: (batch_size, seq_len or 1, d_model)
+        x = self.transformer.ln_f(x)  # type: ignore
+        if output_hidden_states:
+            # add final hidden state post-final-layernorm, following HuggingFace's convention
+            all_hidden_states.append(x)
+
+        # Get logits.
+        # shape: (batch_size, seq_len or 1, vocab_size)
+        if self.config.weight_tying:
+            logits = F.linear(x, self.transformer.wte.weight, None)  # type: ignore
+        else:
+            logits = self.transformer.ff_out(x)  # type: ignore
+        if self.config.scale_logits:
+            logits.mul_(1 / math.sqrt(self.config.d_model))
+
+        return LLaDAOutput(
+            logits=logits,
+            attn_key_values=attn_key_values,
+            hidden_states=tuple(all_hidden_states) if output_hidden_states else None,
+        )  # type: ignore[arg-type]
+
+
+def create_model_config_from_pretrained_config(config: LLaDAConfig):
+    """
+    Utility function
+    """
+
+    kwargs = {}
+    for field in fields(ModelConfig):
+        kwargs[field.name] = getattr(config, field.name)
+
+    model_config = ModelConfig(**kwargs)
+    return model_config
+
+
+class LLaDAModelLM(LLaDAGenerationMixin, LLaDAPreTrainedModel):
+    """
+    Extremely barebones HF model wrapper.
+    """
+
+    config_class = LLaDAConfig
+    base_model_prefix = "model"
+    # _no_split_modules = ["LLaDABlock", "LLaDASequentialBlock", "LLaDALlamaBlock"]
+    _no_split_modules = ["LLaDALlamaBlock"]
+    # Required by transformers >= 4.40 get_keys_to_not_convert() for 4-bit/8-bit loading.
+    # LLaDA has no tied weights. transformers 5.x _get_tied_weight_keys() calls
+    # .keys() on this attribute (dict[str, str] | None), so must not be a list.
+    _tied_weights_keys: dict[str, str] = None
+
+    def __init__(
+        self,
+        config: LLaDAConfig,
+        model: Optional[LLaDAModel] = None,
+        init_params: bool = False,
+        **kwargs,
+    ):
+        super().__init__(config, **kwargs)
+
+        if not model:
+            model_config = create_model_config_from_pretrained_config(config)
+            # Initialize model on CPU first; move to GPU after loading weights.
+            model_config.init_device = "cpu"
+            self.model = LLaDAModel(model_config, init_params=init_params)
+        else:
+            self.model = model
+        # Required by transformers >= 4.40: sets self.all_tied_weights_keys used by quantizers.
+        # When init_params=True, LLaDAModel.__init__ also calls post_init() on itself.
+        # This is safe because transformers constructs and registers submodules before the
+        # parent's post_init() runs — by the time LLaDAModelLM.post_init() executes here,
+        # LLaDAModel is already a child of self and its metadata is visible to named_children().
+        # The top-level post_init() then aggregates all_tied_weights_keys from children.
+        # (This is a Transformers design guarantee, not Python MRO behavior.)
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        attention_bias: Optional[torch.Tensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[
+            Cache
+        ] = None,  # This is a hack mitigation of an issue in transformers `4.39.x`
+        **kwargs,  # absorb extra kwargs injected by transformers Trainer (e.g. _prediction_loss_only)
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        if use_cache is None:
+            use_cache = self.config.use_cache
+
+        if output_attentions:
+            raise ValueError("output_attentions is not yet supported in LLaDA")
+
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+        outputs = self.model.forward(
+            input_ids=input_ids,
+            input_embeddings=inputs_embeds,
+            attention_mask=attention_mask,
+            attention_bias=attention_bias,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+        )
+
+        logits = outputs.logits
+        hidden_states = outputs.hidden_states
+
+        loss = None
+        if labels is not None:
+            import warnings
+
+            warnings.warn(
+                "Note that for LLaDA, you cannot calculate the loss here.", UserWarning
+            )
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            logits=logits,
+            past_key_values=outputs.attn_key_values,
+            hidden_states=hidden_states,
+        )
+
+    def can_generate(self) -> bool:
+        return True
+
+    def generate(self, inputs=None, generation_config=None, **kwargs):
+        """Redirect HF autoregressive ``generate()`` to ``diffusion_generate()``.
+
+        LLaDA uses MDLM-style masked diffusion, not autoregressive KV-cache
+        generation.  Calling HF's inherited ``generate()`` would invoke
+        ``prepare_inputs_for_generation()`` (AR protocol) and produce incorrect
+        output.  This override ensures that ``model.generate(...)`` always
+        routes to :meth:`diffusion_generate`.
+
+        The ``generation_config`` positional argument mirrors HF's signature so
+        that callers that pass it positionally work correctly.
+        """
+        return self.diffusion_generate(
+            inputs, generation_config=generation_config, **kwargs
+        )
+
+    # TODO: these are required to make the implementation complete.
+    # def resize_position_embeddings(self, new_num_position_embeddings: int):
+    #     pass
+    #
+    # def get_position_embeddings(self) -> Union[nn.Embedding, Tuple[nn.Embedding]]:
+    #     pass
+    #
+    # def _reorder_cache(self, past_key_values, beam_idx):
+    #     pass
+
+    def get_input_embeddings(self) -> torch.nn.Module:
+        return self.model.transformer.wte
+
+    def set_input_embeddings(self, value: torch.nn.Module):
+        self.model.transformer.wte = value
+
+    def get_output_embeddings(self):
+        if self.config.weight_tying:
+            return self.model.transformer.wte
+        else:
+            return self.model.transformer.ff_out
+
+    def set_output_embeddings(self, value: torch.nn.Module):
+        if self.config.weight_tying:
+            self.model.transformer.wte = value
+        else:
+            self.model.transformer.ff_out = value
+
+    def tie_weights(self, **kwargs):
+        if self.config.weight_tying:
+            self.model.transformer.ff_out = self.model.transformer.wte
+        # Always call super() so transformers 5.x can run its recompute_mapping logic.
+        # This handles missing_keys and recompute_mapping kwargs passed by from_pretrained.
+        super().tie_weights(**kwargs)
+
+
+def _make_llada_fast_rope_forward(original_forward):
+    """Return a patched ``RotaryEmbedding.forward`` that uses Triton on CUDA.
+
+    LLaDA's ``RotaryEmbedding`` caches ``pos_sin/pos_cos`` with shape
+    ``(1, 1, seq_len, head_dim)`` built via ``cat(freqs, freqs)``.
+    ``fast_rope_embedding`` expects cos/sin of shape ``(rows, head_dim//2)``,
+    so we slice the first ``head_dim//2`` elements and use sequential
+    ``arange(seq_len)`` indices (no double-index risk since the cache is
+    sequence-order based, not pre-indexed to ``position_ids``).
+
+    Falls back to the original implementation when query_len != key_len
+    (KV-cache prefix case) because ``Fast_RoPE_Embedding_QK`` requires
+    Q and K to share the same sequence length.
+    """
+
+    def _fast_forward(self, q: torch.Tensor, k: torch.Tensor):
+        query_len, key_len = q.shape[-2], k.shape[-2]
+
+        if not (_HAS_FAST_ROPE and q.device.type == "cuda" and query_len == key_len):
+            return original_forward(self, q, k)
+
+        if self.config.rope_full_precision:
+            q_, k_ = q.float(), k.float()
+        else:
+            q_, k_ = q, k
+
+        pos_sin, pos_cos = self.get_rotary_embedding(key_len, q_.device)
+        pos_sin = pos_sin.type_as(q_)
+        pos_cos = pos_cos.type_as(q_)
+
+        # pos_cos/pos_sin: (1, 1, key_len, head_dim) with cat(freqs,freqs) pattern.
+        # Slice first head_dim//2 elements and drop batch/head dims → (key_len, head_dim//2).
+        half = q_.shape[-1] // 2
+        cos_2d = pos_cos[0, 0, :key_len, :half].contiguous()  # (key_len, head_dim//2)
+        sin_2d = pos_sin[0, 0, :key_len, :half].contiguous()  # (key_len, head_dim//2)
+
+        # rope_embedding_indices grid size = batch * seq_len; tile arange(key_len) over batch.
+        bsz = q_.shape[0]
+        rope_indices = torch.arange(key_len, device=q_.device, dtype=torch.long).repeat(
+            bsz
+        )
+        q_out, k_out = _fast_rope_embedding(
+            q_.clone(), k_.clone(), cos_2d, sin_2d, rope_indices
+        )
+
+        return q_out.type_as(q), k_out.type_as(k)
+
+    return _fast_forward

--- a/unturtle/models/backbones/modernbert/__init__.py
+++ b/unturtle/models/backbones/modernbert/__init__.py
@@ -1,0 +1,48 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ModernBERT diffusion model adapters.
+
+ModernBERT is a native bidirectional encoder (BERT-family), so no
+AR→Diffusion attention surgery is needed. This package adds
+``MaskedDiffusionBlockGenerationMixin`` for dLLM generation utilities and registers a
+distinct ``model_type`` so that fine-tuned checkpoints round-trip via
+AutoModel without colliding with the upstream ``"modernbert"`` type.
+
+Usage::
+
+    from unturtle.models.backbones.modernbert import (
+        DiffusionModernBertConfig,
+        DiffusionModernBertModel,
+        DiffusionModernBertForMaskedLM,
+    )
+"""
+
+from .modeling import (
+    A2DModernBertConfig,
+    A2DModernBertForMaskedLM,
+    A2DModernBertModel,
+    DiffusionModernBertConfig,
+    DiffusionModernBertForMaskedLM,
+    DiffusionModernBertModel,
+)
+
+__all__ = [
+    "A2DModernBertConfig",
+    "A2DModernBertForMaskedLM",
+    "A2DModernBertModel",
+    "DiffusionModernBertConfig",
+    "DiffusionModernBertForMaskedLM",
+    "DiffusionModernBertModel",
+]

--- a/unturtle/models/backbones/modernbert/_fast_forward.py
+++ b/unturtle/models/backbones/modernbert/_fast_forward.py
@@ -1,0 +1,111 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ModernBERT bidirectional fast attention forward.
+
+ModernBERT is a *native* bidirectional diffusion backbone (not an AR→diffusion
+conversion), so its Triton fast-path helpers live with the backbone, not in the
+``conversion`` method packages.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+def ModernBertAttention_fast_forward(
+    self,
+    hidden_states: torch.Tensor,
+    position_embeddings: Optional[tuple] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    **kwargs,
+) -> tuple:
+    """Drop-in replacement for ``ModernBertAttention.forward``.
+
+    Delegates entirely to the upstream implementation for QKV projection, RoPE,
+    Flash/SDPA attention (including sliding_window, dropout, deterministic),
+    and ``out_drop`` — then replaces only the final ``self.Wo(attn_output)``
+    call with ``self.apply_wo(self, attn_output)`` so that the Triton-fused
+    ``apply_lora_o`` kernel is used when patched in by
+    ``_patch_modernbert_peft``.
+
+    Upstream ``ModernBertAttention`` already sets ``self.is_causal = False``, so
+    bidirectionality is preserved without any attention path changes.
+    """
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    from transformers.models.modernbert.modeling_modernbert import (
+        apply_rotary_pos_emb,
+        eager_attention_forward,
+    )
+
+    input_shape = hidden_states.shape[:-1]
+
+    qkv = self.Wqkv(hidden_states)
+    qkv = qkv.view(*input_shape, 3, -1, self.head_dim)
+    query_states, key_states, value_states = qkv.unbind(dim=-3)
+
+    query_states = query_states.transpose(1, 2)
+    key_states = key_states.transpose(1, 2)
+    value_states = value_states.transpose(1, 2)
+
+    if position_embeddings is not None:
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin, unsqueeze_dim=1
+        )
+
+    attention_interface = eager_attention_forward
+    if self.config._attn_implementation != "eager":
+        attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+    attn_output, attn_weights = attention_interface(
+        self,
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        dropout=self.attention_dropout if self.training else 0.0,
+        scaling=self.head_dim**-0.5,
+        sliding_window=self.sliding_window,
+        deterministic=self.deterministic_flash_attn,
+        **kwargs,
+    )
+
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    # Dispatch through apply_wo instead of self.Wo directly —
+    # enables Triton apply_lora_o when patched by _patch_modernbert_peft.
+    attn_output = self.out_drop(self.apply_wo(self, attn_output))
+    return attn_output, attn_weights
+
+
+def _original_apply_wo(self, X: torch.Tensor) -> torch.Tensor:
+    """Default stub: pass through self.Wo (the output projection)."""
+    return self.Wo(X)
+
+
+def _install_modernbert_stubs(model) -> None:
+    """Set apply_wo stub on all ModernBertAttention layers that lack it.
+
+    Required before _patch_modernbert_peft or before using
+    ModernBertAttention_fast_forward without PEFT.
+    """
+    for module in model.modules():
+        if (
+            hasattr(module, "Wqkv")
+            and hasattr(module, "Wo")
+            and not hasattr(module, "apply_wo")
+        ):
+            module.apply_wo = _original_apply_wo

--- a/unturtle/models/backbones/modernbert/configuration.py
+++ b/unturtle/models/backbones/modernbert/configuration.py
@@ -1,0 +1,28 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for ModernBERT diffusion models."""
+
+from transformers import ModernBertConfig
+
+
+class DiffusionModernBertConfig(ModernBertConfig):
+    """ModernBertConfig for diffusive fine-tuning at unturtle.
+
+    Uses a distinct ``model_type`` so that config round-trips via
+    ``AutoConfig.from_pretrained`` resolve to the unturtle subclass
+    instead of colliding with upstream ``"modernbert"``.
+    """
+
+    model_type = "modernbert-diffusion"

--- a/unturtle/models/backbones/modernbert/modeling.py
+++ b/unturtle/models/backbones/modernbert/modeling.py
@@ -1,0 +1,100 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ModernBERT diffusion model.
+
+ModernBERT is already a bidirectional encoder, so no attention mask surgery is
+needed. This module adds ``MaskedDiffusionBlockGenerationMixin`` to enable dLLM generation and
+registers a distinct ``model_type`` so that checkpoints fine-tuned with unturtle
+can be round-tripped via AutoModel without colliding with the upstream
+``"modernbert"`` type.
+
+Usage::
+
+    from unturtle.models.backbones.modernbert import (
+        DiffusionModernBertConfig,
+        DiffusionModernBertForMaskedLM,
+    )
+
+    config = DiffusionModernBertConfig(
+        vocab_size=50368,
+        hidden_size=768,
+        intermediate_size=1152,
+        num_hidden_layers=4,
+        num_attention_heads=12,
+    )
+    model = DiffusionModernBertForMaskedLM(config)
+    # fine-tune with DiffusionTrainer
+"""
+
+import contextlib
+
+import transformers
+from transformers import ModernBertConfig, ModernBertForMaskedLM, ModernBertModel
+
+from ...generation.masked_diffusion_block_mixin import (
+    MaskedDiffusionBlockGenerationMixin,
+)
+from .configuration import DiffusionModernBertConfig
+
+
+class DiffusionModernBertModel(ModernBertModel):
+    """ModernBertModel with diffusion model_type.
+
+    ModernBERT is already bidirectional — no forward override is needed.
+    This subclass exists only to expose the correct ``config_class``.
+    """
+
+    config_class = DiffusionModernBertConfig
+
+
+class DiffusionModernBertForMaskedLM(
+    MaskedDiffusionBlockGenerationMixin, ModernBertForMaskedLM
+):
+    """ModernBERT masked-LM head wrapped for dLLM use.
+
+    Inherits the full ``ModernBertForMaskedLM`` implementation plus
+    ``MaskedDiffusionBlockGenerationMixin`` for MDLM denoising generation.
+    """
+
+    config_class = DiffusionModernBertConfig
+
+    def __init__(self, config: DiffusionModernBertConfig):
+        super().__init__(config)
+        # Replace ModernBertModel with DiffusionModernBertModel so config_class is correct.
+        # tie_weights() must be called after the swap to restore the decoder↔embedding tie
+        # that post_init() established against the original ModernBertModel instance.
+        self.model = DiffusionModernBertModel(config)
+        self.tie_weights()
+
+
+# Backward compat aliases for the old A2D-prefixed names.
+A2DModernBertConfig = DiffusionModernBertConfig
+A2DModernBertModel = DiffusionModernBertModel
+A2DModernBertForMaskedLM = DiffusionModernBertForMaskedLM
+
+
+# Register the diffusion-specific ModernBERT model_type.
+with contextlib.suppress(ValueError):
+    transformers.AutoConfig.register("modernbert-diffusion", DiffusionModernBertConfig)
+
+# Guard AutoModel registrations against re-import.
+with contextlib.suppress(ValueError):
+    transformers.AutoModel.register(
+        DiffusionModernBertConfig, DiffusionModernBertForMaskedLM
+    )
+with contextlib.suppress(ValueError):
+    transformers.AutoModelForMaskedLM.register(
+        DiffusionModernBertConfig, DiffusionModernBertForMaskedLM
+    )

--- a/unturtle/save.py
+++ b/unturtle/save.py
@@ -1,0 +1,153 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Saving utilities for unturtle models.
+
+Adapted from unsloth/save.py — the push_to_hub wrapper is changed to tag
+models with "unturtle" instead of "unsloth".
+"""
+
+from __future__ import annotations
+
+import inspect
+import types
+
+
+def patch_saving_functions(model, vision: bool = False):
+    """Patch ``push_to_hub`` and related methods on a PEFT model.
+
+    Wraps ``push_to_hub`` so that "unturtle" is appended to the model's tags
+    and to the commit message / description when pushing to HuggingFace Hub.
+
+    Also delegates the heavier merged/GGUF/GGML/TorchAO save methods back to
+    the upstream ``unsloth.save`` implementation so that those workflows still
+    work without requiring a full re-port here.
+
+    Args:
+        model:  PEFT-wrapped model returned by ``FastDiffusionModel.get_peft_model``.
+        vision: Unused; kept for API compatibility with the unsloth version.
+    """
+    # Determine the original (un-patched) push_to_hub
+    if (
+        hasattr(model, "push_to_hub")
+        and model.push_to_hub.__name__ == "_unturtle_push_to_hub"
+        and hasattr(model, "original_push_to_hub")
+    ):
+        # Already patched; no-op
+        return model
+
+    # Walk the model chain and patch each push_to_hub
+    original_model = model
+    while True:
+        if (
+            hasattr(original_model, "push_to_hub")
+            and original_model.push_to_hub.__name__ != "_unturtle_push_to_hub"
+        ):
+            original_model.original_push_to_hub = original_model.push_to_hub
+            original_model.push_to_hub = types.MethodType(
+                _unturtle_push_to_hub, original_model
+            )
+            if hasattr(original_model, "add_model_tags"):
+                original_model.add_model_tags(["unturtle"])
+
+        if hasattr(original_model, "model"):
+            original_model = original_model.model
+        else:
+            break
+
+    # Delegate heavier save methods to unsloth.save so they remain functional
+    try:
+        from unsloth.save import patch_saving_functions as _unsloth_patch
+
+        _unsloth_patch(model, vision=vision)
+    except (ImportError, Exception):
+        # If unsloth.save is not available, skip the extra methods silently.
+        pass
+
+    return model
+
+
+def _unturtle_push_to_hub(self, *args, **kwargs):
+    """push_to_hub wrapper that injects the 'unturtle' tag."""
+    # Collect all arguments via the original signature
+    sig = inspect.signature(self.original_push_to_hub)
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+    arguments = dict(bound.arguments)
+
+    # Inject tag
+    if (
+        "tags" in arguments
+        and arguments["tags"] is not None
+        and isinstance(arguments["tags"], (list, tuple))
+        and "unturtle" not in arguments["tags"]
+    ):
+        arguments["tags"] = list(arguments["tags"]) + ["unturtle"]
+    elif "tags" in arguments:
+        arguments["tags"] = ["unturtle"]
+    elif hasattr(self, "add_model_tags"):
+        self.add_model_tags(["unturtle"])
+
+    # Inject commit_message
+    if "commit_message" in arguments:
+        msg = arguments["commit_message"]
+        if msg is not None:
+            if not msg.endswith(" "):
+                msg += " "
+            if "Unturtle" not in msg:
+                msg += "(Trained with Unturtle)"
+        else:
+            msg = "Upload model trained with Unturtle"
+        arguments["commit_message"] = msg
+
+    # Inject commit_description
+    if "commit_description" in arguments:
+        desc = arguments["commit_description"]
+        if desc is not None:
+            if not desc.endswith(" "):
+                desc += " "
+            if "Unturtle" not in desc:
+                desc += "(Trained with Unturtle)"
+        else:
+            desc = "Upload model trained with Unturtle"
+        arguments["commit_description"] = desc
+
+    try:
+        return self.original_push_to_hub(**arguments)
+    except TypeError:
+        # Fallback: drop tags if the original method doesn't accept them
+        arguments.pop("tags", None)
+        return self.original_push_to_hub(**arguments)
+
+
+def prepare_model_for_kbit_training(
+    model,
+    use_gradient_checkpointing=True,
+    use_reentrant: bool = True,
+):
+    """Thin wrapper around ``peft.prepare_model_for_kbit_training``.
+
+    Accepts ``use_reentrant`` (used by the unsloth version) and maps it to
+    PEFT's ``gradient_checkpointing_kwargs``.
+    """
+    from peft import prepare_model_for_kbit_training as _peft_prepare
+
+    return _peft_prepare(
+        model,
+        use_gradient_checkpointing=use_gradient_checkpointing,
+        gradient_checkpointing_kwargs={"use_reentrant": use_reentrant},
+    )
+
+
+__all__ = ["patch_saving_functions", "prepare_model_for_kbit_training"]


### PR DESCRIPTION
Closes #7

## 概要
クリーン移植 Task 4。ネイティブ diffusion バックボーン3種を移植。

- `unturtle/models/backbones/`（llada / dream / modernbert）を legacy から移植（diff -r 検証、相違は非推奨エイリアス参照1箇所の docstring 書き換えのみ）
- `models/__init__.py` に backbones の公開面（LLaDA / Dream / ModernBERT 系）を追加
- **spec 適用: legacy `a2d-modernbert` load-compat を削除**（`DeprecatedA2DModernBertConfig` / `_DeprecatedA2DModel` / AutoConfig・AutoModel register 3件、および `fast_diffusion_model.py` の model_type 受理）。単純エイリアス `A2DModernBert* = DiffusionModernBert*` はテスト契約のため保持
- **計画外の前倒し**: backbone テストが `unturtle.fast_diffusion_model` を直接参照するため、`fast_diffusion_model.py` / `save.py` を先行移植（legacy 比の差分は tiny_a2d 未移植への try/except ガード2行のみ。Task 5 で除去予定、Task 7 はフル検証＋リファクタに再定義）

## テスト
- `pytest tests/ -q` → **98 passed**（utils 14 + models 84、CUDA 上、テスト無修正）
- ruff グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)