### PR TITLE
✨ feat(conversion): port Tiny-A2D without legacy a2d-* load-compat (#9)

### DIFF
--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -1,0 +1,1656 @@
+"""Tests for A2D (AutoRegressive→Diffusion) model adapters.
+
+CPU-only tests covering config instantiation, model instantiation with
+random weights, forward pass shapes, AutoConfig/AutoModel registration,
+and bidirectional attention verification.
+No pretrained checkpoints are downloaded.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# A2D-Llama
+# ---------------------------------------------------------------------------
+
+
+class TestA2DLlama:
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaConfig
+
+        return TinyA2DLlamaConfig(
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+        )
+
+    def test_config_model_type(self, config):
+        assert config.model_type == "tiny-a2d-llama"
+
+    def test_config_inherits_llama_config(self, config):
+        import transformers
+
+        assert isinstance(config, transformers.LlamaConfig)
+
+    def test_model_instantiation(self, config):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+        model = TinyA2DLlamaLMHeadModel(config)
+        assert model is not None
+        assert hasattr(model, "lm_head")
+
+    def test_forward_logits_shape(self, config):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+        model = TinyA2DLlamaLMHeadModel(config)
+        model.eval()
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+
+    def test_autoconfig_registered(self):
+        import transformers
+
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DLlamaConfig,  # ensure registration
+        )
+
+        assert (
+            "tiny-a2d-llama"
+            in transformers.models.auto.configuration_auto.CONFIG_MAPPING
+        )
+
+
+# ---------------------------------------------------------------------------
+# A2D-Qwen2
+# ---------------------------------------------------------------------------
+
+
+class TestA2DQwen2:
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DQwen2Config
+
+        return TinyA2DQwen2Config(
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+            use_sliding_window=False,
+        )
+
+    def test_config_model_type(self, config):
+        assert config.model_type == "tiny-a2d-qwen2"
+
+    def test_config_inherits_qwen2_config(self, config):
+        import transformers
+
+        assert isinstance(config, transformers.Qwen2Config)
+
+    def test_model_instantiation(self, config):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DQwen2LMHeadModel
+
+        model = TinyA2DQwen2LMHeadModel(config)
+        assert model is not None
+
+    def test_forward_logits_shape(self, config):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DQwen2LMHeadModel
+
+        model = TinyA2DQwen2LMHeadModel(config)
+        model.eval()
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+
+    def test_autoconfig_registered(self):
+        import transformers
+
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DQwen2Config,  # ensure registration
+        )
+
+        assert (
+            "tiny-a2d-qwen2"
+            in transformers.models.auto.configuration_auto.CONFIG_MAPPING
+        )
+
+
+# ---------------------------------------------------------------------------
+# A2D-Qwen3
+# ---------------------------------------------------------------------------
+
+
+class TestA2DQwen3:
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DQwen3Config
+
+        return TinyA2DQwen3Config(
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+            use_sliding_window=False,
+        )
+
+    def test_config_model_type(self, config):
+        assert config.model_type == "tiny-a2d-qwen3"
+
+    def test_config_inherits_qwen3_config(self, config):
+        import transformers
+
+        assert isinstance(config, transformers.Qwen3Config)
+
+    def test_model_instantiation(self, config):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DQwen3LMHeadModel
+
+        model = TinyA2DQwen3LMHeadModel(config)
+        assert model is not None
+
+    def test_forward_logits_shape(self, config):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DQwen3LMHeadModel
+
+        model = TinyA2DQwen3LMHeadModel(config)
+        model.eval()
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+
+    def test_autoconfig_registered(self):
+        import transformers
+
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DQwen3Config,  # ensure registration
+        )
+
+        assert (
+            "tiny-a2d-qwen3"
+            in transformers.models.auto.configuration_auto.CONFIG_MAPPING
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bidirectional attention verification (all A2D variants)
+# ---------------------------------------------------------------------------
+
+
+class TestA2DBidirectional:
+    """Verify that A2D models attend to future tokens (non-causal).
+
+    The core property of A2D models is that the causal attention mask has been
+    replaced with a padding-only mask, making attention fully bidirectional.
+    We verify this by checking that the output at position 0 differs when only
+    the last token changes — a causal model would produce identical outputs.
+    """
+
+    @pytest.mark.parametrize(
+        "model_cls,config_cls,model_type",
+        [
+            ("TinyA2DLlamaLMHeadModel", "TinyA2DLlamaConfig", "tiny-a2d-llama"),
+            ("TinyA2DQwen2LMHeadModel", "TinyA2DQwen2Config", "tiny-a2d-qwen2"),
+            ("TinyA2DQwen3LMHeadModel", "TinyA2DQwen3Config", "tiny-a2d-qwen3"),
+        ],
+    )
+    def test_attends_to_future_tokens(self, model_cls, config_cls, model_type):
+        import importlib
+
+        from unturtle.models.conversion.a2d import tiny_a2d as a2d_module
+
+        Config = getattr(a2d_module, config_cls)
+        Model = getattr(a2d_module, model_cls)
+
+        config = Config(
+            vocab_size=512,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=64,
+        )
+        # Qwen3 requires head_dim
+        if model_type == "tiny-a2d-qwen3":
+            config.head_dim = config.hidden_size // config.num_attention_heads
+
+        model = Model(config)
+        model.eval()
+
+        B, L = 1, 8
+        ids_a = torch.randint(0, config.vocab_size, (B, L))
+        ids_b = ids_a.clone()
+        # Change only the last token
+        ids_b[0, -1] = (ids_a[0, -1] + 1) % config.vocab_size
+
+        with torch.no_grad():
+            out_a = model(input_ids=ids_a).logits
+            out_b = model(input_ids=ids_b).logits
+
+        # Position 0 should differ — model attends to position L-1
+        assert not torch.allclose(out_a[:, 0, :], out_b[:, 0, :]), (
+            f"{model_type}: position-0 output is identical after changing position {L - 1}. "
+            "Model appears to be causal — check that TinyA2DModel.forward uses a non-causal mask."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Packed sequence integration
+# ---------------------------------------------------------------------------
+
+
+class TestA2DPackedForward:
+    """Verify that packed_seq_lengths propagates through TinyA2DLlamaLMHeadModel forward."""
+
+    @pytest.fixture
+    def tiny_config(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaConfig
+
+        return TinyA2DLlamaConfig(
+            vocab_size=200,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=64,
+        )
+
+    def test_forward_with_packed_seq_lengths(self, tiny_config):
+        """Model forward must complete without error when packed_seq_lengths is passed."""
+        from unturtle.fast_diffusion_model import _install_apply_stubs
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+        model = TinyA2DLlamaLMHeadModel(tiny_config)
+        _install_apply_stubs(model)
+        model.eval()
+
+        B, L = 2, 16
+        # Simulate two packed rows, each with 2 samples of length 8
+        input_ids = torch.randint(4, tiny_config.vocab_size, (B, L))
+        attention_mask = torch.ones(B, L, dtype=torch.long)
+        position_ids = torch.arange(L).unsqueeze(0).expand(B, -1)
+        # Each row contains 2 samples of length 8
+        packed_seq_lengths = torch.tensor([8, 8, 8, 8], dtype=torch.int32)
+
+        with torch.no_grad():
+            out = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                packed_seq_lengths=packed_seq_lengths,
+            )
+
+        assert out.logits.shape == (B, L, tiny_config.vocab_size), (
+            f"Unexpected logits shape: {out.logits.shape}"
+        )
+
+    def test_get_packed_info_returns_non_none_when_key_present(self, tiny_config):
+        """get_packed_info_from_kwargs must return non-None when packed_seq_lengths is in kwargs."""
+        from unturtle.utils.packing import get_packed_info_from_kwargs
+
+        packed_seq_lengths = torch.tensor([8, 8], dtype=torch.int32)
+        kwargs = {"packed_seq_lengths": packed_seq_lengths}
+
+        result = get_packed_info_from_kwargs(kwargs, device=torch.device("cpu"))
+        assert result is not None, (
+            "get_packed_info_from_kwargs returned None — "
+            "packed_seq_lengths key is present but not recognized"
+        )
+        lengths, cu_seqlens, max_seqlen = result
+        assert lengths.tolist() == [8, 8]
+        assert cu_seqlens.tolist() == [0, 8, 16]
+        assert max_seqlen == 8
+
+
+# ---------------------------------------------------------------------------
+# Flash varlen compaction helper
+# ---------------------------------------------------------------------------
+
+
+class TestFlashVarlenCompaction:
+    """Tests for _flash_varlen_packed: compaction and scatter logic."""
+
+    def test_compaction_token_count_and_values(self):
+        """Compact slices have correct total count and preserve token values."""
+        B, n_heads, L, head_dim = 2, 4, 16, 8
+        # row0: 2 samples × 6 tokens = 12 real; row1: 1 sample × 10 tokens = 10 real
+        _seq_lengths_list = [
+            torch.tensor([6, 6], dtype=torch.int32),
+            torch.tensor([10], dtype=torch.int32),
+        ]
+        real_counts = [12, 10]
+        total_tokens = 22
+
+        Q_t = torch.randn(B, L, n_heads, head_dim)
+        compact = torch.cat([Q_t[b, : real_counts[b]] for b in range(B)], dim=0)
+
+        assert compact.shape[0] == total_tokens
+        assert torch.allclose(compact[:12], Q_t[0, :12])
+        assert torch.allclose(compact[12:], Q_t[1, :10])
+
+    def test_scatter_is_inverse_of_compact(self):
+        """Scatter back into padded buffer is lossless; padding positions remain zero."""
+        B, n_heads, L, head_dim = 2, 4, 16, 8
+        real_counts = [12, 10]
+        total_tokens = 22
+
+        fake_out = torch.randn(total_tokens, n_heads, head_dim)
+        out_full = torch.zeros(B, L, n_heads * head_dim)
+
+        offset = 0
+        for b in range(B):
+            rc = real_counts[b]
+            out_full[b, :rc] = fake_out[offset : offset + rc].reshape(
+                rc, n_heads * head_dim
+            )
+            offset += rc
+
+        assert torch.all(out_full[0, 12:] == 0), "Row 0 padding must be zero"
+        assert torch.all(out_full[1, 10:] == 0), "Row 1 padding must be zero"
+
+        offset = 0
+        for b in range(B):
+            rc = real_counts[b]
+            expected = fake_out[offset : offset + rc].reshape(rc, n_heads * head_dim)
+            assert torch.allclose(out_full[b, :rc], expected), (
+                f"Row {b} values mismatch"
+            )
+            offset += rc
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="CUDA required for Flash Attention"
+    )
+    def test_flash_varlen_packed_gpu_shape_and_bidirectionality(self):
+        """Flash varlen output has correct shape; bidirectionality is preserved."""
+        try:
+            from flash_attn import flash_attn_varlen_func  # noqa: F401
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            _flash_varlen_packed,
+        )
+
+        B, n_heads, L, head_dim = 2, 4, 16, 8
+        n_kv_heads = n_heads
+        device = "cuda"
+
+        seq_lengths_list = [
+            torch.tensor([6, 6], dtype=torch.int32),  # row0: 12 real, 4 padding
+            torch.tensor([10], dtype=torch.int32),  # row1: 10 real, 6 padding
+        ]
+
+        torch.manual_seed(42)
+        Q = torch.randn(B, n_heads, L, head_dim, device=device, dtype=torch.bfloat16)
+        K = torch.randn(B, n_kv_heads, L, head_dim, device=device, dtype=torch.bfloat16)
+        V = torch.randn(B, n_kv_heads, L, head_dim, device=device, dtype=torch.bfloat16)
+
+        out = _flash_varlen_packed(
+            Q,
+            K,
+            V,
+            seq_lengths_list=seq_lengths_list,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+        )
+
+        assert out.shape == (B, L, n_heads * head_dim)
+        assert torch.all(out[0, 12:] == 0), "Row 0 padding must be zero"
+        assert torch.all(out[1, 10:] == 0), "Row 1 padding must be zero"
+
+        # Bidirectionality test: change V at position 5 (last token of sample0, positions 0-5).
+        # Since causal=False, position 0 (same sample) attends to position 5 — output should change.
+        # Position 6 (start of sample1, positions 6-11) must NOT change — cross-sample blocked.
+        V_fwd = V.clone()
+        V_fwd[0, :, 5, :] = torch.randn(
+            n_kv_heads, head_dim, device=device, dtype=torch.bfloat16
+        )
+        out_fwd = _flash_varlen_packed(
+            Q,
+            K,
+            V_fwd,
+            seq_lengths_list=seq_lengths_list,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+        )
+        # Position 0 (sample0) attends to position 5 (same sample) → output changes
+        assert not torch.allclose(
+            out[0, 0].float(), out_fwd[0, 0].float(), atol=1e-3
+        ), (
+            "Position 0 should change when V at position 5 (same sample) changes — "
+            "bidirectional attention not working"
+        )
+        # Position 6 (sample1) does NOT attend to position 5 (sample0) → output unchanged
+        assert torch.allclose(out[0, 6].float(), out_fwd[0, 6].float(), atol=1e-3), (
+            "Position 6 (sample1) should NOT change when V at position 5 (sample0) changes — "
+            "cross-sample attention should be blocked by cu_seqlens"
+        )
+
+
+# ---------------------------------------------------------------------------
+# A2D generation (diffusion_generate)
+# ---------------------------------------------------------------------------
+
+
+class TestA2DGeneration:
+    """Tests for TinyA2DGenerationMixin.diffusion_generate on tiny CPU models."""
+
+    MASK_TOKEN_ID = 999
+
+    @pytest.fixture
+    def llama_config(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaConfig
+
+        return TinyA2DLlamaConfig(
+            vocab_size=1000,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=64,
+            mask_token_id=self.MASK_TOKEN_ID,
+        )
+
+    @pytest.fixture
+    def llama_model(self, llama_config):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+        model = TinyA2DLlamaLMHeadModel(llama_config).eval()
+        return model
+
+    def test_has_diffusion_generate(self, llama_model):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DGenerationMixin
+
+        assert isinstance(llama_model, TinyA2DGenerationMixin)
+        assert callable(llama_model.diffusion_generate)
+
+    def test_output_shape(self, llama_model, llama_config):
+        """Output shape should be [B, max_length].
+
+        In dLLM generation the caller pre-fills completion slots with
+        mask_token_id and passes the full sequence.  max_length must be
+        > input length so we pass max_length explicitly.
+        """
+        B, L_prompt, L_new = 2, 4, 8
+        L_total = L_prompt + L_new
+        prompt_ids = torch.randint(0, 100, (B, L_prompt))
+        mask_fill = torch.full((B, L_new), self.MASK_TOKEN_ID, dtype=torch.long)
+        input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
+        with torch.no_grad():
+            out = llama_model.diffusion_generate(
+                input_ids_full,
+                steps=3,
+                mask_token_id=self.MASK_TOKEN_ID,
+                max_length=L_total + 1,  # must be > input_length
+            )
+        assert out.shape == (B, L_total + 1)
+
+    def test_prompt_tokens_preserved(self, llama_model, llama_config):
+        """Prompt tokens (non-mask) must not be changed by generation."""
+        B, L_prompt, L_new = 1, 4, 6
+        L_total = L_prompt + L_new
+        prompt_ids = torch.tensor([[1, 2, 3, 4]])
+        mask_fill = torch.full((B, L_new), self.MASK_TOKEN_ID, dtype=torch.long)
+        input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
+        with torch.no_grad():
+            out = llama_model.diffusion_generate(
+                input_ids_full,
+                steps=3,
+                mask_token_id=self.MASK_TOKEN_ID,
+                max_length=L_total + 1,
+            )
+        # Original prompt positions were NOT mask tokens → should be preserved
+        assert (out[0, :L_prompt] == prompt_ids[0]).all(), (
+            "Prompt tokens should not be overwritten by diffusion_generate"
+        )
+
+    def test_deterministic_with_seed(self, llama_model, llama_config):
+        """Same random seed + same input → identical output (regardless of alg)."""
+        B, L = 1, 8
+        input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
+        with torch.no_grad():
+            torch.manual_seed(42)
+            out1 = llama_model.diffusion_generate(
+                input_ids.clone(),
+                steps=2,
+                mask_token_id=self.MASK_TOKEN_ID,
+                temperature=0.0,
+                max_length=L + 1,
+            )
+            torch.manual_seed(42)
+            out2 = llama_model.diffusion_generate(
+                input_ids.clone(),
+                steps=2,
+                mask_token_id=self.MASK_TOKEN_ID,
+                temperature=0.0,
+                max_length=L + 1,
+            )
+        assert (out1 == out2).all(), "Same seed must produce identical output"
+
+    def test_num_steps_one(self, llama_model):
+        """steps=1 should complete in a single forward pass."""
+        B, L = 1, 6
+        input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
+        with torch.no_grad():
+            out = llama_model.diffusion_generate(
+                input_ids,
+                steps=1,
+                mask_token_id=self.MASK_TOKEN_ID,
+                max_length=L + 1,
+            )
+        assert out.shape == (B, L + 1)
+
+    def test_return_dict(self, llama_model):
+        """return_dict=True should return MaskedDiffusionModelOutput."""
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionModelOutput,
+        )
+
+        B, L = 1, 4
+        input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
+        with torch.no_grad():
+            out = llama_model.diffusion_generate(
+                input_ids,
+                steps=2,
+                mask_token_id=self.MASK_TOKEN_ID,
+                max_length=L + 1,
+                return_dict=True,
+            )
+        assert isinstance(out, MaskedDiffusionModelOutput)
+        assert out.sequences.shape == (B, L + 1)
+
+    def test_maskgit_plus_alg(self, llama_model):
+        """maskgit_plus algorithm should run without error."""
+        B, L = 1, 6
+        input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
+        with torch.no_grad():
+            out = llama_model.diffusion_generate(
+                input_ids,
+                steps=3,
+                mask_token_id=self.MASK_TOKEN_ID,
+                alg="maskgit_plus",
+                max_length=L + 1,
+            )
+        assert out.shape == (B, L + 1)
+
+    def test_num_return_sequences(self, llama_model):
+        """num_return_sequences=2 should double the batch dimension."""
+        B, L = 1, 6
+        input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
+        with torch.no_grad():
+            out = llama_model.diffusion_generate(
+                input_ids,
+                steps=2,
+                mask_token_id=self.MASK_TOKEN_ID,
+                max_length=L + 1,
+                num_return_sequences=2,
+            )
+        assert out.shape == (B * 2, L + 1)
+
+    def test_attention_mask(self, llama_model):
+        """Padded attention_mask should be handled without error."""
+        B, L = 2, 8
+        input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
+        attention_mask = torch.ones((B, L), dtype=torch.long)
+        attention_mask[1, -2:] = 0  # simulate padding in second sample
+        with torch.no_grad():
+            out = llama_model.diffusion_generate(
+                input_ids,
+                attention_mask=attention_mask,
+                steps=2,
+                mask_token_id=self.MASK_TOKEN_ID,
+                max_length=L + 1,
+            )
+        assert out.shape == (B, L + 1)
+
+
+# ---------------------------------------------------------------------------
+# RoPE unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_cos_sin(
+    B: int,
+    L: int,
+    head_dim: int,
+    dtype: torch.dtype = torch.float32,
+    device: str = "cpu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build sequential cos/sin of shape (B, L, head_dim)."""
+    position_ids = torch.arange(L, dtype=torch.long).unsqueeze(0).expand(B, -1)
+    return _make_cos_sin_from_position_ids(
+        position_ids=position_ids,
+        head_dim=head_dim,
+        dtype=dtype,
+        device=device,
+    )
+
+
+def _make_cos_sin_from_position_ids(
+    position_ids: torch.Tensor,
+    head_dim: int,
+    dtype: torch.dtype = torch.float32,
+    device: str = "cpu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build cos/sin of shape (B, L, head_dim) for arbitrary position_ids."""
+    theta = 1.0 / (
+        10000 ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
+    )
+    freqs = position_ids[..., None].to(torch.float32) * theta.view(1, 1, -1)
+    emb = torch.cat([freqs, freqs], dim=-1)
+    cos = emb.cos().to(dtype=dtype).to(device)
+    sin = emb.sin().to(dtype=dtype).to(device)
+    return cos, sin
+
+
+class TestA2DRoPE:
+    """Unit tests for ``_rotate_half_rope`` (CPU RoPE fallback in A2D fast forward)."""
+
+    def test_l2_norm_preserved_no_position_ids(self):
+        """RoPE rotation must be an isometry: per-vector L2 norm is preserved."""
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            _rotate_half_rope,
+        )
+
+        B, n_heads, L, head_dim = 2, 4, 8, 16
+        torch.manual_seed(0)
+        Q = torch.randn(B, n_heads, L, head_dim)
+        K = torch.randn(B, n_heads, L, head_dim)
+        cos, sin = _make_cos_sin(B, L, head_dim)
+
+        Q_out, K_out = _rotate_half_rope(Q, K, cos, sin, position_ids=None)
+
+        assert Q_out.shape == Q.shape
+        assert K_out.shape == K.shape
+        torch.testing.assert_close(
+            Q_out.norm(dim=-1),
+            Q.norm(dim=-1),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+        torch.testing.assert_close(
+            K_out.norm(dim=-1),
+            K.norm(dim=-1),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    def test_l2_norm_preserved_with_position_ids(self):
+        """RoPE norm preservation must hold for packed-style repeated position_ids."""
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            _rotate_half_rope,
+        )
+
+        B, n_heads, L, head_dim = 2, 4, 8, 16
+        torch.manual_seed(1)
+        Q = torch.randn(B, n_heads, L, head_dim)
+        K = torch.randn(B, n_heads, L, head_dim)
+        position_ids: torch.LongTensor = torch.tensor(
+            [[0, 1, 2, 3, 0, 1, 2, 3], [0, 0, 1, 1, 2, 2, 3, 3]],
+            dtype=torch.long,
+        )
+        cos, sin = _make_cos_sin_from_position_ids(position_ids, head_dim)
+
+        Q_out, K_out = _rotate_half_rope(Q, K, cos, sin, position_ids=position_ids)
+
+        torch.testing.assert_close(
+            Q_out.norm(dim=-1),
+            Q.norm(dim=-1),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+        torch.testing.assert_close(
+            K_out.norm(dim=-1),
+            K.norm(dim=-1),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_cpu_matches_cuda_no_position_ids(self):
+        """CPU _rotate_half_rope must match CUDA fast_rope_embedding (no position_ids)."""
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            _rotate_half_rope,
+        )
+
+        try:
+            from unturtle.kernels import fast_rope_embedding
+        except ImportError:
+            pytest.skip("fast_rope_embedding not available")
+
+        B, n_heads, L, head_dim = 1, 4, 8, 32
+        torch.manual_seed(2)
+        Q_cpu = torch.randn(B, n_heads, L, head_dim)
+        K_cpu = torch.randn(B, n_heads, L, head_dim)
+        cos_cpu, sin_cpu = _make_cos_sin(B, L, head_dim)
+
+        Q_out_cpu, K_out_cpu = _rotate_half_rope(Q_cpu, K_cpu, cos_cpu, sin_cpu)
+
+        # fast_rope_embedding expects cos/sin as (1, L, head_dim) or (L, head_dim);
+        # it calls .squeeze() internally so (1, L, head_dim) → (L, head_dim).
+        Q_cuda = Q_cpu.cuda().to(torch.bfloat16)
+        K_cuda = K_cpu.cuda().to(torch.bfloat16)
+        cos_cuda = cos_cpu.cuda().to(torch.bfloat16)  # (1, L, head_dim)
+        sin_cuda = sin_cpu.cuda().to(torch.bfloat16)
+
+        Q_out_cuda, K_out_cuda = fast_rope_embedding(Q_cuda, K_cuda, cos_cuda, sin_cuda)
+
+        # Tolerance is relaxed to 1e-2 because CUDA path runs in bfloat16
+        torch.testing.assert_close(
+            Q_out_cuda.float().cpu(),
+            Q_out_cpu,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            K_out_cuda.float().cpu(),
+            K_out_cpu,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_cpu_matches_cuda_with_position_ids(self):
+        """CPU fallback must match CUDA RoPE for packed-style position_ids."""
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            _rotate_half_rope,
+        )
+
+        try:
+            from unturtle.kernels import fast_rope_embedding
+        except ImportError:
+            pytest.skip("fast_rope_embedding not available")
+
+        B, n_heads, L, head_dim = 1, 4, 8, 32
+        torch.manual_seed(3)
+        Q_cpu = torch.randn(B, n_heads, L, head_dim)
+        K_cpu = torch.randn(B, n_heads, L, head_dim)
+        position_ids: torch.LongTensor = torch.tensor(
+            [[0, 1, 0, 1, 2, 3, 4, 5]], dtype=torch.long
+        )
+        cos_cpu, sin_cpu = _make_cos_sin_from_position_ids(position_ids, head_dim)
+
+        Q_out_cpu, K_out_cpu = _rotate_half_rope(
+            Q_cpu, K_cpu, cos_cpu, sin_cpu, position_ids=position_ids
+        )
+
+        Q_cuda = Q_cpu.cuda().to(torch.bfloat16)
+        K_cuda = K_cpu.cuda().to(torch.bfloat16)
+        cos_cuda = cos_cpu.cuda().to(torch.bfloat16)
+        sin_cuda = sin_cpu.cuda().to(torch.bfloat16)
+
+        Q_out_cuda, K_out_cuda = fast_rope_embedding(
+            Q_cuda,
+            K_cuda,
+            cos_cuda,
+            sin_cuda,
+        )
+
+        torch.testing.assert_close(
+            Q_out_cuda.float().cpu(),
+            Q_out_cpu,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            K_out_cuda.float().cpu(),
+            K_out_cpu,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_flattened_preindexed_cuda_path_matches_cpu(self):
+        """Flattened pre-indexed cos/sin with flat row indices must match CPU fallback."""
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            _rotate_half_rope,
+        )
+
+        try:
+            from unturtle.kernels import fast_rope_embedding
+        except ImportError:
+            pytest.skip("fast_rope_embedding not available")
+
+        B, n_heads, L, head_dim = 2, 4, 8, 32
+        torch.manual_seed(4)
+        Q_cpu = torch.randn(B, n_heads, L, head_dim)
+        K_cpu = torch.randn(B, n_heads, L, head_dim)
+        position_ids: torch.LongTensor = torch.tensor(
+            [[0, 1, 2, 3, 0, 1, 2, 3], [0, 0, 1, 1, 2, 2, 3, 3]],
+            dtype=torch.long,
+        )
+        cos_cpu, sin_cpu = _make_cos_sin_from_position_ids(position_ids, head_dim)
+
+        Q_expected, K_expected = _rotate_half_rope(
+            Q_cpu, K_cpu, cos_cpu, sin_cpu, position_ids=position_ids
+        )
+
+        flat_indices = torch.arange(B * L, dtype=torch.long, device="cuda")
+        Q_out_cuda, K_out_cuda = fast_rope_embedding(
+            Q_cpu.cuda().to(torch.bfloat16),
+            K_cpu.cuda().to(torch.bfloat16),
+            cos_cpu.reshape(B * L, head_dim).cuda().to(torch.bfloat16),
+            sin_cpu.reshape(B * L, head_dim).cuda().to(torch.bfloat16),
+            rope_embedding_indices=flat_indices,
+        )
+
+        torch.testing.assert_close(
+            Q_out_cuda.float().cpu(),
+            Q_expected,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            K_out_cuda.float().cpu(),
+            K_expected,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_broadcasted_cos_sin_cuda_path_matches_cpu(self):
+        """Broadcasted (1, L, D) cos/sin must stay on the non-indexed CUDA path."""
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            _rotate_half_rope,
+        )
+
+        try:
+            from unturtle.kernels import fast_rope_embedding
+        except ImportError:
+            pytest.skip("fast_rope_embedding not available")
+
+        B, n_heads, L, head_dim = 2, 4, 8, 32
+        torch.manual_seed(5)
+        Q_cpu = torch.randn(B, n_heads, L, head_dim)
+        K_cpu = torch.randn(B, n_heads, L, head_dim)
+        cos_cpu, sin_cpu = _make_cos_sin(1, L, head_dim)
+
+        Q_expected, K_expected = _rotate_half_rope(Q_cpu, K_cpu, cos_cpu, sin_cpu)
+        Q_out_cuda, K_out_cuda = fast_rope_embedding(
+            Q_cpu.cuda().to(torch.bfloat16),
+            K_cpu.cuda().to(torch.bfloat16),
+            cos_cpu.cuda().to(torch.bfloat16),
+            sin_cpu.cuda().to(torch.bfloat16),
+        )
+
+        torch.testing.assert_close(
+            Q_out_cuda.float().cpu(),
+            Q_expected,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            K_out_cuda.float().cpu(),
+            K_expected,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# A2D-ModernBERT
+# ---------------------------------------------------------------------------
+
+
+def _tiny_modernbert_config():
+    """Return a minimal A2DModernBertConfig suitable for CPU tests.
+
+    ModernBertConfig defaults include token IDs (e.g. pad_token_id=50283) that
+    exceed our tiny vocab_size=1000, so we override them explicitly.
+    """
+    from unturtle.models.backbones.modernbert import A2DModernBertConfig
+
+    return A2DModernBertConfig(
+        vocab_size=1000,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        max_position_embeddings=128,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        cls_token_id=1,
+        sep_token_id=2,
+    )
+
+
+class TestA2DModernBert:
+    @pytest.fixture
+    def config(self):
+        return _tiny_modernbert_config()
+
+    def test_config_model_type(self, config):
+        assert config.model_type == "modernbert-diffusion"
+
+    def test_config_inherits_modernbert_config(self, config):
+        from transformers import ModernBertConfig
+
+        assert isinstance(config, ModernBertConfig)
+
+    def test_model_instantiation(self, config):
+        from unturtle.models.backbones.modernbert import (
+            A2DModernBertForMaskedLM,
+            A2DModernBertModel,
+        )
+
+        model = A2DModernBertForMaskedLM(config)
+        assert model is not None
+        assert isinstance(model.model, A2DModernBertModel)
+        assert hasattr(model, "decoder")
+
+    def test_decoder_weight_tied_to_embeddings(self, config):
+        """decoder.weight must be tied to tok_embeddings.weight after model swap."""
+        from unturtle.models.backbones.modernbert import A2DModernBertForMaskedLM
+
+        model = A2DModernBertForMaskedLM(config)
+        assert model.decoder.weight is model.model.embeddings.tok_embeddings.weight, (
+            "decoder.weight and tok_embeddings.weight are not the same tensor — "
+            "tie_weights() was not called after self.model replacement."
+        )
+
+    def test_forward_logits_shape(self, config):
+        from unturtle.models.backbones.modernbert import A2DModernBertForMaskedLM
+
+        model = A2DModernBertForMaskedLM(config)
+        model.eval()
+        B, L = 2, 16
+        input_ids = torch.randint(3, config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+
+    def test_autoconfig_registered(self):
+        import transformers
+
+        from unturtle.models.backbones.modernbert import (
+            A2DModernBertConfig,  # ensure import still works
+        )
+
+        assert (
+            "modernbert-diffusion"
+            in transformers.models.auto.configuration_auto.CONFIG_MAPPING
+        )
+
+    def test_bidirectional_attention(self, config):
+        """ModernBERT is already bidirectional — position-0 output changes when last token changes."""
+        from unturtle.models.backbones.modernbert import A2DModernBertForMaskedLM
+
+        model = A2DModernBertForMaskedLM(config)
+        model.eval()
+
+        B, L = 1, 8
+        ids_a = torch.randint(3, config.vocab_size, (B, L))
+        ids_b = ids_a.clone()
+        ids_b[0, -1] = (ids_a[0, -1] + 1) % config.vocab_size
+
+        with torch.no_grad():
+            out_a = model(input_ids=ids_a).logits
+            out_b = model(input_ids=ids_b).logits
+
+        assert not torch.allclose(out_a[:, 0, :], out_b[:, 0, :]), (
+            "a2d-modernbert: position-0 output is identical after changing position L-1. "
+            "Bidirectional attention is not working."
+        )
+
+
+class TestA2DBlockDecode:
+    """Test block-decode KV cache functionality (Phase M)."""
+
+    @pytest.fixture
+    def tiny_config(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaConfig
+
+        return TinyA2DLlamaConfig(
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            intermediate_size=128,
+            max_position_embeddings=128,
+        )
+
+    @pytest.fixture
+    def tiny_model(self, tiny_config):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+        model = TinyA2DLlamaLMHeadModel(tiny_config)
+        model.eval()
+        return model
+
+    def test_block_decode_baseline(self, tiny_model, tiny_config):
+        """Phase M.1: Block-decode with tuple cache trimming runs without error."""
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        # Generate short sequence with block-decode
+        input_ids = torch.randint(3, tiny_config.vocab_size, (1, 4))
+        mask_token_id = 1
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=8,
+            steps=2,
+            alg="origin",
+            use_cache=True,
+            block_length=4,
+            mask_token_id=mask_token_id,
+        )
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=input_ids, generation_config=gen_config
+            )
+
+        # Basic shape check
+        assert output.shape[0] == 1
+        assert output.shape[1] == 4 + 8  # prompt + generated
+
+    def test_block_decode_correctness(self, tiny_model, tiny_config):
+        """Phase M.1: Block-decode generates valid (non-mask) tokens in the generated region.
+
+        Block-decode uses a trimmed KV-cache so attended context differs from the full
+        no-cache forward pass in a bidirectional model — exact value equivalence with the
+        no-cache baseline is not guaranteed.  We verify output correctness instead:
+        correct shape, prompt preserved, no remaining mask tokens.
+        """
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        torch.manual_seed(42)
+        input_ids = torch.randint(3, tiny_config.vocab_size, (1, 4))
+        mask_token_id = 1
+        prompt_len = input_ids.shape[1]
+        max_new = 8
+
+        gen_config_block = MaskedDiffusionGenerationConfig(
+            max_new_tokens=max_new,
+            steps=4,
+            alg="origin",
+            use_cache=True,
+            block_length=4,
+            mask_token_id=mask_token_id,
+            temperature=0.0,
+        )
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=input_ids, generation_config=gen_config_block
+            )
+
+        assert output.shape == (1, prompt_len + max_new)
+        assert torch.equal(output[:, :prompt_len], input_ids)
+        assert not torch.any(output[:, prompt_len:] == mask_token_id), (
+            "Block-decode should produce no remaining mask tokens in generated region"
+        )
+
+    def test_block_decode_disables_replace_cache_for_a2d(
+        self, tiny_model, tiny_config, monkeypatch
+    ):
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        input_ids = torch.randint(3, tiny_config.vocab_size, (1, 4))
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=8,
+            steps=2,
+            alg="origin",
+            use_cache=True,
+            block_length=4,
+            mask_token_id=1,
+            use_replace_cache=True,
+        )
+        captured = {}
+
+        def fake_block_decode_loop(*, input_ids, attention_mask, generation_config):
+            captured["use_replace_cache"] = generation_config.use_replace_cache
+            return torch.cat(
+                [
+                    input_ids,
+                    torch.full(
+                        (input_ids.shape[0], 8),
+                        7,
+                        dtype=input_ids.dtype,
+                        device=input_ids.device,
+                    ),
+                ],
+                dim=1,
+            )
+
+        monkeypatch.setattr(tiny_model, "_block_decode_loop", fake_block_decode_loop)
+
+        output = tiny_model.diffusion_generate(
+            inputs=input_ids, generation_config=gen_config
+        )
+
+        assert captured == {"use_replace_cache": False}
+        assert output.shape == (1, 12)
+
+
+# ---------------------------------------------------------------------------
+# BD3LM generation config fields
+# ---------------------------------------------------------------------------
+
+
+class TestBD3LMGenerationConfig:
+    """Tests for BD3LM-related config fields."""
+
+    def test_new_fields_have_correct_defaults(self):
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        cfg = MaskedDiffusionGenerationConfig()
+        assert cfg.use_block_diffusion is False
+        assert cfg.bd3lm_block_size == 32
+        assert cfg.cfg_scale == 0.0
+
+    def test_fields_settable_via_kwargs(self):
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        cfg = MaskedDiffusionGenerationConfig(
+            use_block_diffusion=True,
+            bd3lm_block_size=16,
+            cfg_scale=1.5,
+        )
+        assert cfg.use_block_diffusion is True
+        assert cfg.bd3lm_block_size == 16
+        assert cfg.cfg_scale == 1.5
+
+    def test_use_block_diffusion_and_use_cache_raises(self):
+        import pytest
+
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            MaskedDiffusionGenerationConfig(
+                use_block_diffusion=True,
+                use_cache=True,
+            )
+
+    def test_use_block_diffusion_and_return_dict_raises(self):
+        import pytest
+
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        with pytest.raises(ValueError, match="return_dict"):
+            MaskedDiffusionGenerationConfig(
+                use_block_diffusion=True,
+                return_dict=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# BD3LM block-diffusion generation
+# ---------------------------------------------------------------------------
+
+
+class TestA2DBlockDiffusionGeneration:
+    """Tests for A2D BD3LM generation via use_block_diffusion=True."""
+
+    MASK_ID = 100
+    PAD_ID = 0
+
+    @pytest.fixture
+    def tiny_model(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DLlamaConfig,
+            TinyA2DLlamaLMHeadModel,
+        )
+
+        config = TinyA2DLlamaConfig(
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            max_position_embeddings=256,
+            mask_token_id=self.MASK_ID,
+            pad_token_id=self.PAD_ID,
+        )
+        model = TinyA2DLlamaLMHeadModel(config)
+        model.eval()
+        return model
+
+    def test_use_block_diffusion_runs(self, tiny_model):
+        """BD3LM generation completes and returns correct shape."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        block_size = 4
+        max_new_tokens = 8
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=block_size,
+                max_new_tokens=max_new_tokens,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+            )
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (1, prompt.shape[1] + max_new_tokens)
+
+    def test_no_mask_tokens_in_generated_region(self, tiny_model):
+        """Generated region contains no remaining mask tokens."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        padded_prompt_len = 4  # 4 is multiple of block_size=4
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=4,
+                max_new_tokens=8,
+                steps=4,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+            )
+        generated = out[:, padded_prompt_len:]
+        assert not (generated == self.MASK_ID).any(), (
+            "Generated region must have no remaining mask tokens"
+        )
+
+    def test_cfg_scale_accepted(self, tiny_model):
+        """cfg_scale > 0 runs and produces correct shape with no mask tokens."""
+        import math
+
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        block_size = 4
+        max_new_tokens = 4
+        padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=block_size,
+                max_new_tokens=max_new_tokens,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                cfg_scale=1.0,
+                temperature=0.0,
+            )
+        assert out.shape == (1, padded_prompt_len + max_new_tokens)
+        assert not (out[:, padded_prompt_len:] == self.MASK_ID).any()
+
+    def test_right_shift_logits_accepted(self, tiny_model):
+        """right_shift_logits=True runs and produces correct shape with no mask tokens."""
+        import math
+
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        block_size = 4
+        max_new_tokens = 4
+        padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=block_size,
+                max_new_tokens=max_new_tokens,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                right_shift_logits=True,
+                temperature=0.0,
+            )
+        assert out.shape == (1, padded_prompt_len + max_new_tokens)
+        assert not (out[:, padded_prompt_len:] == self.MASK_ID).any()
+
+    def test_non_aligned_prompt_length_does_not_leak_left_padding(self, tiny_model):
+        prompt = torch.tensor([[7, 8, 9]])
+
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=4,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+            )
+
+        assert out.shape == (1, prompt.shape[1] + 4)
+        assert torch.equal(out[:, : prompt.shape[1]], prompt)
+        assert not (out[:, prompt.shape[1] :] == self.PAD_ID).any()
+
+    def test_block_diffusion_accepts_max_length_without_max_new_tokens(
+        self, tiny_model
+    ):
+        prompt = torch.tensor([[7, 8, 9, 10]])
+
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=4,
+                max_length=8,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+            )
+
+        assert out.shape == (1, 8)
+        assert torch.equal(out[:, : prompt.shape[1]], prompt)
+
+    def test_block_diffusion_kv_cache_is_reused_from_prefix_only(
+        self, tiny_model, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from unturtle.models.generation import (
+            masked_diffusion_block_mixin as generation_utils_module,
+        )
+
+        class FakeCache:
+            def __init__(self, counter=0):
+                self.counter = counter
+
+        def fake_snapshot_prefix_cache(past_key_values):
+            return ("prefix", past_key_values.counter)
+
+        def fake_rewrap_prefix_cache(past_key_values, device):
+            _, counter = past_key_values
+            return FakeCache(counter=counter)
+
+        def fake_forward(
+            input_ids,
+            attention_mask=None,
+            position_ids=None,
+            use_cache=False,
+            past_key_values=None,
+            **kwargs,
+        ):
+            vocab = tiny_model.config.vocab_size
+            batch, seq_len = input_ids.shape
+            logits = torch.zeros(batch, seq_len, vocab)
+
+            if use_cache:
+                logits[..., 11] = 1.0
+                return SimpleNamespace(logits=logits, past_key_values=FakeCache())
+
+            if past_key_values is not None:
+                token_id = 11 + past_key_values.counter
+                logits[..., token_id] = 1.0
+                past_key_values.counter += 1
+                return SimpleNamespace(logits=logits)
+
+            logits[..., 99] = 1.0
+            return SimpleNamespace(logits=logits)
+
+        monkeypatch.setattr(
+            generation_utils_module,
+            "_snapshot_prefix_cache",
+            fake_snapshot_prefix_cache,
+        )
+        monkeypatch.setattr(
+            generation_utils_module, "_rewrap_prefix_cache", fake_rewrap_prefix_cache
+        )
+        monkeypatch.setattr(tiny_model, "forward", fake_forward)
+
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=2,
+                max_new_tokens=2,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+            )
+
+        assert torch.equal(out[:, : prompt.shape[1]], prompt)
+        assert torch.equal(out[:, prompt.shape[1] :], torch.tensor([[11, 11]]))
+
+    def test_block_diffusion_rewraps_prefix_cache_without_deepcopy(
+        self, tiny_model, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        class FakeCache:
+            def __deepcopy__(self, memo):
+                raise AssertionError(
+                    "deepcopy should not be used for prefix cache reuse"
+                )
+
+        def fake_forward(
+            input_ids,
+            attention_mask=None,
+            position_ids=None,
+            use_cache=False,
+            past_key_values=None,
+            **kwargs,
+        ):
+            vocab = tiny_model.config.vocab_size
+            batch, seq_len = input_ids.shape
+            logits = torch.zeros(batch, seq_len, vocab)
+            logits[..., 11] = 1.0
+            if use_cache:
+                return SimpleNamespace(logits=logits, past_key_values=FakeCache())
+            return SimpleNamespace(logits=logits)
+
+        monkeypatch.setattr(tiny_model, "forward", fake_forward)
+
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=torch.tensor([[1, 2, 3, 4]]),
+                use_block_diffusion=True,
+                bd3lm_block_size=2,
+                max_new_tokens=2,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+            )
+
+        assert out.shape == (1, 6)
+
+    def test_eos_stops_finished_rows_in_batch(self, tiny_model, monkeypatch):
+        from types import SimpleNamespace
+
+        eos_id = 4
+
+        def fake_forward(
+            input_ids,
+            attention_mask=None,
+            position_ids=None,
+            use_cache=False,
+            past_key_values=None,
+            **kwargs,
+        ):
+            vocab = tiny_model.config.vocab_size
+            batch, seq_len = input_ids.shape
+            logits = torch.zeros(batch, seq_len, vocab)
+            logits[:, -1, 9] = 1.0
+            logits[0, -1, eos_id] = 10.0
+            if use_cache:
+                return SimpleNamespace(logits=logits, past_key_values=object())
+            return SimpleNamespace(logits=logits)
+
+        monkeypatch.setattr(tiny_model, "forward", fake_forward)
+
+        prompt = torch.tensor([[1, 2, 3, 10], [5, 6, 7, 8]])
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=2,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                eos_token_id=eos_id,
+                temperature=0.0,
+            )
+
+        assert out.shape == (2, 8)
+        assert (out[0, 4:6] == eos_id).any()
+        first_eos = (out[0] == eos_id).nonzero(as_tuple=True)[0][0].item()
+        assert torch.equal(
+            out[0, first_eos + 1 :],
+            torch.tensor([self.PAD_ID] * (out.shape[1] - first_eos - 1)),
+        )
+        assert not (out[1, 4:] == eos_id).any()
+        assert (out[1, 4:] != self.PAD_ID).any()
+
+    def test_stream_callback_called_each_inner_step(self, tiny_model):
+        """stream_callback fires once per inner denoising step across all blocks."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        block_size = 4
+        max_new_tokens = 8
+        steps = 4
+        import math
+
+        num_blocks = math.ceil(max_new_tokens / block_size)
+        steps_per_block = max(1, math.ceil(steps / num_blocks))
+        expected_calls = num_blocks * steps_per_block
+
+        stream_calls = []
+
+        def stream_cb(step, total, x):
+            stream_calls.append((step, total, x.shape))
+
+        with torch.no_grad():
+            tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=block_size,
+                max_new_tokens=max_new_tokens,
+                steps=steps,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+                stream_callback=stream_cb,
+            )
+
+        assert len(stream_calls) == expected_calls
+        steps_seen = [s for s, _, _ in stream_calls]
+        assert steps_seen == list(range(1, expected_calls + 1))
+        totals_seen = {t for _, t, _ in stream_calls}
+        assert totals_seen == {expected_calls}
+
+    def test_step_callback_called_each_inner_step(self, tiny_model):
+        """step_callback fires once per inner denoising step across all blocks."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        block_size = 4
+        max_new_tokens = 4
+        steps = 2
+        import math
+
+        num_blocks = math.ceil(max_new_tokens / block_size)
+        steps_per_block = max(1, math.ceil(steps / num_blocks))
+        expected_calls = num_blocks * steps_per_block
+
+        step_calls = []
+
+        def step_cb(step, total):
+            step_calls.append((step, total))
+
+        with torch.no_grad():
+            tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=block_size,
+                max_new_tokens=max_new_tokens,
+                steps=steps,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+                step_callback=step_cb,
+            )
+
+        assert len(step_calls) == expected_calls
+        steps_seen = [s for s, _ in step_calls]
+        assert steps_seen == list(range(1, expected_calls + 1))
+
+    def test_stream_callback_excludes_left_padding_for_non_aligned_prompt(
+        self, tiny_model
+    ):
+        prompt = torch.tensor([[1, 2, 3]])
+        stream_shapes = []
+
+        def stream_cb(step, total, x):
+            stream_shapes.append(tuple(x.shape))
+            assert x.shape[1] >= prompt.shape[1]
+            assert torch.equal(x[0, : prompt.shape[1]], prompt[0])
+
+        with torch.no_grad():
+            tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=4,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+                stream_callback=stream_cb,
+            )
+
+        assert stream_shapes
+
+    def test_callback_errors_do_not_abort_block_diffusion(self, tiny_model):
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        stream_calls = 0
+        step_calls = 0
+        expected_calls = 2
+
+        def stream_cb(step, total, x):
+            nonlocal stream_calls
+            stream_calls += 1
+            raise RuntimeError("stream callback boom")
+
+        def step_cb(step, total):
+            nonlocal step_calls
+            step_calls += 1
+            raise RuntimeError("step callback boom")
+
+        with torch.no_grad():
+            out = tiny_model.diffusion_generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=4,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=self.MASK_ID,
+                pad_token_id=self.PAD_ID,
+                temperature=0.0,
+                stream_callback=stream_cb,
+                step_callback=step_cb,
+            )
+
+        assert out.shape == (1, 8)
+        assert stream_calls == expected_calls
+        assert step_calls == expected_calls

--- a/tests/models/test_block_decode.py
+++ b/tests/models/test_block_decode.py
@@ -1,0 +1,248 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for block-decode generation with KV-cache."""
+
+import pytest
+import torch
+
+from unturtle.models.conversion.a2d.tiny_a2d import (
+    TinyA2DLlamaConfig,
+    TinyA2DLlamaLMHeadModel,
+)
+
+MASK_TOKEN_ID = 100
+
+
+class TestA2DBlockDecode:
+    """Test A2D block-decode generation with cache."""
+
+    @pytest.fixture
+    def tiny_model(self):
+        """Create a tiny A2D LLaMA model for testing."""
+        config = TinyA2DLlamaConfig(
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            max_position_embeddings=128,
+            mask_token_id=MASK_TOKEN_ID,
+        )
+        model = TinyA2DLlamaLMHeadModel(config)
+        model.eval()
+        return model
+
+    def test_cache_generation_runs(self, tiny_model):
+        """Cache-based generation runs without errors and produces correct shape."""
+        prompt = torch.tensor([[1, 2, 3, 4, 5]])
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=16,
+                steps=4,
+                use_cache=True,
+                block_length=8,
+                mask_token_id=MASK_TOKEN_ID,
+            )
+
+        assert output.shape == (1, 21)  # 5 + 16 = 21
+        # Generated region must have no remaining mask tokens
+        assert not torch.any(output[:, 5:] == MASK_TOKEN_ID)
+
+    def test_cache_vs_no_cache_shape_equivalence(self, tiny_model):
+        """Cache and no-cache outputs have the same shape."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        max_new = 12
+        # block_length=4 → num_blocks=3; steps must be divisible by num_blocks
+        steps = 3
+
+        with torch.no_grad():
+            output_no_cache = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=max_new,
+                steps=steps,
+                use_cache=False,
+                mask_token_id=MASK_TOKEN_ID,
+            )
+            output_with_cache = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=max_new,
+                steps=steps,
+                use_cache=True,
+                block_length=4,  # must divide max_new (12); num_blocks=3
+                mask_token_id=MASK_TOKEN_ID,
+            )
+
+        assert output_no_cache.shape == output_with_cache.shape
+        # Generated region must have no remaining mask tokens
+        assert not torch.any(output_with_cache[:, 4:] == MASK_TOKEN_ID)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_cache_generation_cuda(self, tiny_model):
+        """Cache-based generation on CUDA produces correct shape with no mask tokens."""
+        tiny_model = tiny_model.cuda()
+        prompt = torch.tensor([[1, 2, 3, 4, 5]]).cuda()
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=16,
+                steps=4,
+                use_cache=True,
+                block_length=8,
+                mask_token_id=MASK_TOKEN_ID,
+            )
+
+        assert output.device.type == "cuda"
+        assert output.shape == (1, 21)
+        assert not torch.any(output[:, 5:] == MASK_TOKEN_ID)
+
+
+class TestA2DBlockDecodeEquivalence:
+    """Test correctness of block-decode generation."""
+
+    @pytest.fixture
+    def tiny_model(self):
+        """Create a tiny A2D model with fixed seed for reproducibility."""
+        torch.manual_seed(42)
+        config = TinyA2DLlamaConfig(
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            max_position_embeddings=128,
+            mask_token_id=MASK_TOKEN_ID,
+        )
+        model = TinyA2DLlamaLMHeadModel(config)
+        model.eval()
+        return model
+
+    def test_deterministic_output_with_seed(self, tiny_model):
+        """Setting the same seed produces deterministic uncached output."""
+        prompt = torch.tensor([[1, 2, 3]])
+
+        torch.manual_seed(123)
+        with torch.no_grad():
+            output1 = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=8,
+                steps=4,
+                use_cache=False,
+                mask_token_id=MASK_TOKEN_ID,
+                temperature=0.0,
+            )
+
+        torch.manual_seed(123)
+        with torch.no_grad():
+            output2 = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=8,
+                steps=4,
+                use_cache=False,
+                mask_token_id=MASK_TOKEN_ID,
+                temperature=0.0,
+            )
+
+        assert torch.equal(output1, output2), (
+            "Seeded generation should be deterministic"
+        )
+
+    def test_cache_generates_valid_tokens(self, tiny_model):
+        """Block-decode with cache produces valid (non-mask) tokens in generated region.
+
+        Note: Block-decode is an approximation of uncached generation for bidirectional
+        models — it uses a trimmed KV-cache so attended context differs from the full
+        no-cache forward pass.  We verify output correctness (no mask tokens remain,
+        shape is right), not exact value matching against the uncached baseline.
+        """
+        prompt = torch.tensor([[1, 2, 3, 4, 5]])
+        prompt_len = prompt.shape[1]
+        max_new = 12
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=max_new,
+                steps=6,  # num_blocks=3; steps must be divisible by num_blocks
+                use_cache=True,
+                block_length=4,  # must divide max_new (12)
+                mask_token_id=MASK_TOKEN_ID,
+                temperature=0.0,
+            )
+
+        assert output.shape == (1, prompt_len + max_new)
+        # Prompt tokens must be preserved
+        assert torch.equal(output[:, :prompt_len], prompt)
+        # Generated region must have no remaining mask tokens
+        assert not torch.any(output[:, prompt_len:] == MASK_TOKEN_ID)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_cache_generates_valid_tokens_cuda(self, tiny_model):
+        """Block-decode on CUDA produces valid tokens in generated region."""
+        tiny_model = tiny_model.cuda()
+        prompt = torch.tensor([[1, 2, 3, 4]]).cuda()
+        prompt_len = prompt.shape[1]
+        max_new = 8
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=max_new,
+                steps=4,
+                use_cache=True,
+                block_length=4,  # must divide max_new (8)
+                mask_token_id=MASK_TOKEN_ID,
+                temperature=0.0,
+            )
+
+        assert output.device.type == "cuda"
+        assert output.shape == (1, prompt_len + max_new)
+        assert torch.equal(output[:, :prompt_len], prompt)
+        assert not torch.any(output[:, prompt_len:] == MASK_TOKEN_ID)
+
+
+class TestA2DUsesBlockDecodeMixin:
+    """Verify TinyA2DGenerationMixin delegates use_cache=True to BlockDecodeMixin."""
+
+    def test_a2d_inherits_block_decode_mixin(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DGenerationMixin
+        from unturtle.models.generation.block_decode_mixin import BlockDecodeMixin
+
+        assert issubclass(TinyA2DGenerationMixin, BlockDecodeMixin)
+
+    def test_a2d_has_model_forward_with_cache(self):
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DGenerationMixin
+
+        assert hasattr(TinyA2DGenerationMixin, "_model_forward_with_cache")
+        # Must not be the abstract base — concrete implementation
+        import inspect
+
+        src = inspect.getsource(TinyA2DGenerationMixin._model_forward_with_cache)
+        assert "NotImplementedError" not in src
+
+    def test_a2d_use_cache_routes_through_block_decode_loop(self):
+        """use_cache=True must route through _block_decode_loop, not _sample_with_cache."""
+        import inspect
+
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DGenerationMixin
+
+        src = inspect.getsource(TinyA2DGenerationMixin._sample_with_cache)
+        assert "_block_decode_loop" in src, (
+            "TinyA2DGenerationMixin._sample_with_cache must delegate to _block_decode_loop"
+        )

--- a/tests/models/test_block_decode_benchmark.py
+++ b/tests/models/test_block_decode_benchmark.py
@@ -1,0 +1,139 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke benchmark for block-decode KV-cache speedup."""
+
+import time
+
+import pytest
+import torch
+
+from unturtle.models.conversion.a2d.tiny_a2d import (
+    TinyA2DLlamaConfig,
+    TinyA2DLlamaLMHeadModel,
+)
+
+
+@pytest.mark.benchmark
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for meaningful benchmark"
+)
+class TestBlockDecodeBenchmark:
+    """Smoke benchmark to verify KV-cache speedup."""
+
+    @pytest.fixture
+    def benchmark_model(self):
+        """Create a slightly larger model for benchmarking."""
+        torch.manual_seed(42)
+        config = TinyA2DLlamaConfig(
+            vocab_size=512,
+            hidden_size=256,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=512,
+            max_position_embeddings=256,
+            mask_token_id=500,
+        )
+        model = TinyA2DLlamaLMHeadModel(config).cuda()
+        model.eval()
+        return model
+
+    def test_cache_speedup_smoke(self, benchmark_model):
+        """Smoke test to measure cache overhead (Phase L baseline).
+
+        Phase L implements basic cache infrastructure but does not yet include
+        block-wise decoding optimizations. This test confirms the cache path
+        works without adding significant overhead.
+
+        **Expected**: ~1.0x (no speedup yet, cache resets each step)
+        **Phase M target**: ≥2.0x (with block-decode + parallel sampling)
+
+        Full benchmarks will be in benchmarks/ after Phase M.
+        """
+        prompt = torch.tensor([[1, 2, 3, 4, 5]]).cuda()
+        warmup_runs = 2
+        test_runs = 5
+
+        # Warmup
+        for _ in range(warmup_runs):
+            with torch.no_grad():
+                benchmark_model.diffusion_generate(
+                    inputs=prompt,
+                    max_new_tokens=32,
+                    steps=16,
+                    use_cache=False,
+                    mask_token_id=500,
+                )
+
+        # Benchmark no-cache
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        for _ in range(test_runs):
+            with torch.no_grad():
+                benchmark_model.diffusion_generate(
+                    inputs=prompt,
+                    max_new_tokens=32,
+                    steps=16,
+                    use_cache=False,
+                    mask_token_id=500,
+                )
+        torch.cuda.synchronize()
+        no_cache_time = (time.perf_counter() - start) / test_runs
+
+        # Warmup cache
+        for _ in range(warmup_runs):
+            with torch.no_grad():
+                benchmark_model.diffusion_generate(
+                    inputs=prompt,
+                    max_new_tokens=32,
+                    steps=16,
+                    use_cache=True,
+                    block_length=16,
+                    mask_token_id=500,
+                )
+
+        # Benchmark with-cache
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+        for _ in range(test_runs):
+            with torch.no_grad():
+                benchmark_model.diffusion_generate(
+                    inputs=prompt,
+                    max_new_tokens=32,
+                    steps=16,
+                    use_cache=True,
+                    block_length=16,
+                    mask_token_id=500,
+                )
+        torch.cuda.synchronize()
+        with_cache_time = (time.perf_counter() - start) / test_runs
+
+        speedup = no_cache_time / with_cache_time
+
+        print("\n=== Block-decode KV-cache Smoke Benchmark (Phase L) ===")
+        print(f"No-cache:       {no_cache_time * 1000:.2f} ms")
+        print(f"With-cache:     {with_cache_time * 1000:.2f} ms")
+        print(f"Speedup:        {speedup:.2f}x")
+        print("Phase L status: Infrastructure complete (no optimization yet)")
+        print("Phase M target: ≥2.0x (block-decode + parallel sampling)")
+
+        # Phase L: Both paths must run; timing is a loose smoke check only.
+        # Some GPUs/drivers show the cache path slower here (extra bookkeeping, small
+        # tensors); tight bands caused flaky CI. Phase M targets real speedup (≥2x).
+        assert 0.15 <= speedup <= 5.0, (
+            f"Cache speedup {speedup:.2f}x is outside sanity range (0.15x-5.0x). "
+            "Expect extreme values only if a path errors or hangs."
+        )

--- a/tests/models/test_parallel_decode.py
+++ b/tests/models/test_parallel_decode.py
@@ -1,0 +1,258 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Phase M confidence-aware parallel decoding."""
+
+import pytest
+import torch
+
+from unturtle.models.conversion.a2d.tiny_a2d import (
+    TinyA2DLlamaConfig,
+    TinyA2DLlamaLMHeadModel,
+)
+
+
+class TestConfidenceParallelDecode:
+    """Test confidence-aware parallel decoding (Phase M MVP)."""
+
+    @pytest.fixture
+    def tiny_model(self):
+        """Create a tiny A2D LLaMA model for testing."""
+        torch.manual_seed(42)
+        config = TinyA2DLlamaConfig(
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            max_position_embeddings=128,
+            mask_token_id=100,
+        )
+        model = TinyA2DLlamaLMHeadModel(config)
+        model.eval()
+        return model
+
+    def test_parallel_decode_runs(self, tiny_model):
+        """Test that parallel_decode=True runs without errors."""
+        prompt = torch.tensor([[1, 2, 3, 4, 5]])
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=16,
+                steps=4,
+                use_cache=True,
+                parallel_decode=True,
+                confidence_threshold=0.8,
+                alg="maskgit_plus",
+                mask_token_id=100,
+            )
+
+        assert output is not None
+        assert output.shape == (1, 21)  # 5 + 16 = 21
+
+    def test_parallel_decode_shape_equivalence(self, tiny_model):
+        """Test that parallel_decode and non-parallel have same output shape."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        max_new = 12
+        steps = 4
+
+        with torch.no_grad():
+            output_non_parallel = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=max_new,
+                steps=steps,
+                use_cache=True,
+                parallel_decode=False,
+                alg="maskgit_plus",
+                mask_token_id=100,
+            )
+            output_parallel = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=max_new,
+                steps=steps,
+                use_cache=True,
+                parallel_decode=True,
+                confidence_threshold=0.9,
+                alg="maskgit_plus",
+                mask_token_id=100,
+            )
+
+        assert output_non_parallel.shape == output_parallel.shape
+
+    def test_parallel_decode_threshold_affects_output(self, tiny_model):
+        """Test that different thresholds produce different outputs."""
+        prompt = torch.tensor([[1, 2, 3, 4, 5]])
+
+        # Use realistic confidence thresholds for random/untrained models
+        # (confidence values are typically 0.01-0.2 for vocab=128)
+        torch.manual_seed(123)
+        with torch.no_grad():
+            output_low = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=12,
+                steps=8,  # More steps for convergence
+                use_cache=True,
+                parallel_decode=True,
+                confidence_threshold=0.05,  # Low threshold → more tokens unmasked
+                alg="maskgit_plus",
+                mask_token_id=100,
+                temperature=0.0,
+            )
+
+        torch.manual_seed(123)
+        with torch.no_grad():
+            output_high = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=12,
+                steps=8,
+                use_cache=True,
+                parallel_decode=True,
+                confidence_threshold=0.15,  # High threshold → fewer tokens unmasked
+                alg="maskgit_plus",
+                mask_token_id=100,
+                temperature=0.0,
+            )
+
+        # Low threshold should unmask more tokens than high threshold
+        num_unmasked_low = (output_low != 100).sum().item()
+        num_unmasked_high = (output_high != 100).sum().item()
+
+        # Both should unmask prompt (5 tokens) + at least some completion
+        assert num_unmasked_low >= 5, (
+            f"Low threshold unmasked only {num_unmasked_low} (expected >= 5)"
+        )
+        assert num_unmasked_high >= 5, (
+            f"High threshold unmasked only {num_unmasked_high} (expected >= 5)"
+        )
+
+        # Low threshold should unmask more or equal tokens than high threshold
+        assert num_unmasked_low >= num_unmasked_high, (
+            f"Low threshold ({num_unmasked_low}) should unmask >= high threshold ({num_unmasked_high})"
+        )
+
+    def test_parallel_decode_completes_block_when_steps_per_block_is_small(
+        self, tiny_model, monkeypatch
+    ):
+        """Threshold mode keeps denoising until a block finishes, not just steps_per_block."""
+        import unturtle.models.generation.diffusion_generation_utils as gen_utils
+
+        def select_single_token(masked_confidence, mask_index_block, threshold):
+            transfer_mask = torch.zeros_like(mask_index_block, dtype=torch.bool)
+            for row_idx in range(mask_index_block.shape[0]):
+                masked_positions = mask_index_block[row_idx].nonzero(as_tuple=True)[0]
+                if masked_positions.numel() > 0:
+                    transfer_mask[row_idx, masked_positions[0]] = True
+            return transfer_mask
+
+        monkeypatch.setattr(
+            gen_utils, "select_threshold_transfer_mask", select_single_token
+        )
+
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=8,
+                steps=2,
+                use_cache=True,
+                parallel_decode=True,
+                confidence_threshold=0.99,
+                alg="maskgit_plus",
+                block_length=4,
+                mask_token_id=100,
+                temperature=0.0,
+            )
+
+        assert output.shape == (1, 12)
+        assert not torch.any(output[:, 4:] == 100)
+
+    def test_parallel_decode_with_algorithms(self, tiny_model):
+        """Test parallel_decode with different confidence algorithms."""
+        prompt = torch.tensor([[1, 2, 3]])
+
+        algorithms = ["maskgit_plus", "topk_margin", "entropy"]
+        for alg in algorithms:
+            with torch.no_grad():
+                output = tiny_model.diffusion_generate(
+                    inputs=prompt,
+                    max_new_tokens=8,
+                    steps=4,
+                    use_cache=True,
+                    parallel_decode=True,
+                    confidence_threshold=0.8,
+                    alg=alg,
+                    mask_token_id=100,
+                )
+            assert output.shape == (1, 11), f"Algorithm {alg} failed"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_parallel_decode_cuda(self, tiny_model):
+        """Test parallel_decode on CUDA."""
+        tiny_model = tiny_model.cuda()
+        prompt = torch.tensor([[1, 2, 3, 4, 5]]).cuda()
+
+        with torch.no_grad():
+            output = tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=16,
+                steps=4,
+                use_cache=True,
+                parallel_decode=True,
+                confidence_threshold=0.9,
+                alg="maskgit_plus",
+                mask_token_id=100,
+            )
+
+        assert output.device.type == "cuda"
+        assert output.shape == (1, 21)
+
+    def test_parallel_decode_requires_cache(self, tiny_model):
+        """Test that parallel_decode without use_cache raises error."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+
+        # parallel_decode with use_cache=False should raise ValueError
+        with pytest.raises(
+            ValueError, match="parallel_decode=True.*requires.*use_cache=True"
+        ):
+            tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=8,
+                steps=4,
+                use_cache=False,
+                parallel_decode=True,
+                confidence_threshold=0.9,
+                alg="maskgit_plus",
+                mask_token_id=100,
+            )
+
+    def test_parallel_decode_incompatible_with_origin(self, tiny_model):
+        """Test that parallel_decode with alg='origin' raises error."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+
+        with (
+            pytest.raises(ValueError, match="does not support `alg='origin'`"),
+            torch.no_grad(),
+        ):
+            tiny_model.diffusion_generate(
+                inputs=prompt,
+                max_new_tokens=8,
+                steps=4,
+                use_cache=True,
+                parallel_decode=True,
+                confidence_threshold=0.9,
+                alg="origin",
+                mask_token_id=100,
+            )

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -81,13 +81,9 @@ from unturtle.models.backbones.modernbert._fast_forward import (
     ModernBertAttention_fast_forward,
     _install_modernbert_stubs,
 )
-
-try:
-    from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
-        TinyA2DAttention_fast_forward,
-    )
-except ImportError:
-    TinyA2DAttention_fast_forward = None  # type: ignore[assignment]  # Task 5 not yet ported
+from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+    TinyA2DAttention_fast_forward,
+)
 from unturtle.models.generation.sampler import (
     algorithm_to_flags,
     resolve_algorithm,
@@ -171,7 +167,7 @@ def _patch_a2d_peft(
 
     for layer in layers:
         # --- fast attention (bidirectional) — GPU only ---
-        if on_cuda and TinyA2DAttention_fast_forward is not None:
+        if on_cuda:
             layer.self_attn.forward = types.MethodType(
                 TinyA2DAttention_fast_forward, layer.self_attn
             )

--- a/unturtle/models/__init__.py
+++ b/unturtle/models/__init__.py
@@ -14,29 +14,15 @@
 
 """unturtle.models — Diffusion Language Model architectures.
 
-Public API (generation infrastructure + backbones — available now)::
-
-    from unturtle.models.generation.cache import BlockKVCache
-    from unturtle.models.generation.diffusion_generation_utils import (
-        MaskedDiffusionGenerationConfig,
-        MaskedDiffusionGenerationMixin,
-        MaskedDiffusionModelOutput,
-        prepare_for_sampling,
-    )
-    from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
-    from unturtle.models.backbones.dream import DreamConfig, DreamModel
-    from unturtle.models.backbones.modernbert import (
-        DiffusionModernBertConfig,
-        DiffusionModernBertForMaskedLM,
-    )
-
-Conversion methods will be exported here once Task 5 lands:
+Public API::
 
     from unturtle.models.conversion.a2d import (
         TinyA2DLlamaConfig, TinyA2DLlamaLMHeadModel,
         TinyA2DQwen2Config, TinyA2DQwen2LMHeadModel,
         TinyA2DQwen3Config, TinyA2DQwen3LMHeadModel,
     )
+    from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
+    from unturtle.models.backbones.dream import DreamConfig, DreamModel
 """
 
 from .backbones.dream import (
@@ -61,6 +47,19 @@ from .backbones.modernbert import (
     DiffusionModernBertForMaskedLM,
     DiffusionModernBertModel,
 )
+from .conversion.a2d import (
+    TinyA2DGenerationConfig,
+    TinyA2DGenerationMixin,
+    TinyA2DLlamaConfig,
+    TinyA2DLlamaLMHeadModel,
+    TinyA2DLlamaModel,
+    TinyA2DQwen2Config,
+    TinyA2DQwen2LMHeadModel,
+    TinyA2DQwen2Model,
+    TinyA2DQwen3Config,
+    TinyA2DQwen3LMHeadModel,
+    TinyA2DQwen3Model,
+)
 from .generation.cache import BlockKVCache
 from .generation.diffusion_generation_utils import (
     MaskedDiffusionGenerationConfig,
@@ -76,6 +75,18 @@ __all__ = [
     "MaskedDiffusionGenerationMixin",
     "MaskedDiffusionModelOutput",
     "prepare_for_sampling",
+    # Tiny-A2D conversion method
+    "TinyA2DGenerationConfig",
+    "TinyA2DGenerationMixin",
+    "TinyA2DLlamaConfig",
+    "TinyA2DLlamaModel",
+    "TinyA2DLlamaLMHeadModel",
+    "TinyA2DQwen2Config",
+    "TinyA2DQwen2Model",
+    "TinyA2DQwen2LMHeadModel",
+    "TinyA2DQwen3Config",
+    "TinyA2DQwen3Model",
+    "TinyA2DQwen3LMHeadModel",
     # LLaDA backbone
     "LLaDAConfig",
     "LLaDAGenerationConfig",
@@ -95,5 +106,4 @@ __all__ = [
     "A2DModernBertConfig",
     "A2DModernBertModel",
     "A2DModernBertForMaskedLM",
-    # Conversion (Task 5) exports will be added here.
 ]

--- a/unturtle/models/conversion/__init__.py
+++ b/unturtle/models/conversion/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle.models.conversion — the *method* axis of a dLLM.
+
+Conversion methods turn a non-diffusion backbone into a dLLM. Currently:
+  - a2d: AutoRegressive→Diffusion family; the implemented recipe is Tiny-A2D
+    (see unturtle.models.conversion.a2d.tiny_a2d)
+"""
+
+from .a2d import TINY_A2D_CONFIG_CLASSES, TINY_A2D_MODEL_CLASSES
+
+__all__ = ["TINY_A2D_MODEL_CLASSES", "TINY_A2D_CONFIG_CLASSES"]

--- a/unturtle/models/conversion/a2d/__init__.py
+++ b/unturtle/models/conversion/a2d/__init__.py
@@ -1,0 +1,65 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle.models.conversion.a2d — the AR→diffusion conversion method family.
+
+``a2d`` is the *family* (AutoRegressive→Diffusion conversion). The current implementation
+is the **Tiny-A2D** recipe (dLLM paper section 4.2.2: the small Qwen3-0.6B mask-replacement
+variant), under ``tiny_a2d``. Future recipes (DiffuLLaMA, RND1) would be sibling
+subpackages here. These are thin adapters over ``transformers`` backbones — the backbone
+(Qwen/Llama) lives upstream; this code is the *method*.
+"""
+
+from .tiny_a2d import (
+    TinyA2DGenerationConfig,
+    TinyA2DGenerationMixin,
+    TinyA2DLlamaConfig,
+    TinyA2DLlamaLMHeadModel,
+    TinyA2DLlamaModel,
+    TinyA2DQwen2Config,
+    TinyA2DQwen2LMHeadModel,
+    TinyA2DQwen2Model,
+    TinyA2DQwen3Config,
+    TinyA2DQwen3LMHeadModel,
+    TinyA2DQwen3Model,
+)
+
+#: Supported AR backbones for the Tiny-A2D recipe -> their LM-head classes.
+TINY_A2D_MODEL_CLASSES = {
+    "llama": TinyA2DLlamaLMHeadModel,
+    "qwen2": TinyA2DQwen2LMHeadModel,
+    "qwen3": TinyA2DQwen3LMHeadModel,
+}
+
+TINY_A2D_CONFIG_CLASSES = {
+    "llama": TinyA2DLlamaConfig,
+    "qwen2": TinyA2DQwen2Config,
+    "qwen3": TinyA2DQwen3Config,
+}
+
+__all__ = [
+    "TINY_A2D_MODEL_CLASSES",
+    "TINY_A2D_CONFIG_CLASSES",
+    "TinyA2DGenerationConfig",
+    "TinyA2DGenerationMixin",
+    "TinyA2DLlamaConfig",
+    "TinyA2DLlamaModel",
+    "TinyA2DLlamaLMHeadModel",
+    "TinyA2DQwen2Config",
+    "TinyA2DQwen2Model",
+    "TinyA2DQwen2LMHeadModel",
+    "TinyA2DQwen3Config",
+    "TinyA2DQwen3Model",
+    "TinyA2DQwen3LMHeadModel",
+]

--- a/unturtle/models/conversion/a2d/tiny_a2d/__init__.py
+++ b/unturtle/models/conversion/a2d/tiny_a2d/__init__.py
@@ -1,0 +1,65 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tiny-A2D (AutoRegressive→Diffusion) model adapters.
+
+Lightweight adapters that convert causal LLMs to bidirectional masked
+diffusion LMs by removing causal attention masking. All pretrained weights
+are preserved without modification. This is the **Tiny-A2D** recipe of the
+``a2d`` conversion family (dLLM paper section 4.2.2).
+
+Supported base architectures:
+  - LLaMA (Meta-Llama-3, Meta-Llama-3.1, …)
+  - Qwen2 (Qwen/Qwen2.5-*)
+  - Qwen3 (Qwen/Qwen3-*)
+
+Usage::
+
+    from unturtle.models.conversion.a2d.tiny_a2d import (
+        TinyA2DLlamaConfig, TinyA2DLlamaLMHeadModel,
+        TinyA2DQwen2Config, TinyA2DQwen2LMHeadModel,
+        TinyA2DQwen3Config, TinyA2DQwen3LMHeadModel,
+    )
+"""
+
+from .generation_utils import TinyA2DGenerationConfig, TinyA2DGenerationMixin
+from .modeling_llama import (
+    TinyA2DLlamaConfig,
+    TinyA2DLlamaLMHeadModel,
+    TinyA2DLlamaModel,
+)
+from .modeling_qwen2 import (
+    TinyA2DQwen2Config,
+    TinyA2DQwen2LMHeadModel,
+    TinyA2DQwen2Model,
+)
+from .modeling_qwen3 import (
+    TinyA2DQwen3Config,
+    TinyA2DQwen3LMHeadModel,
+    TinyA2DQwen3Model,
+)
+
+__all__ = [
+    "TinyA2DGenerationConfig",
+    "TinyA2DGenerationMixin",
+    "TinyA2DLlamaConfig",
+    "TinyA2DLlamaModel",
+    "TinyA2DLlamaLMHeadModel",
+    "TinyA2DQwen2Config",
+    "TinyA2DQwen2Model",
+    "TinyA2DQwen2LMHeadModel",
+    "TinyA2DQwen3Config",
+    "TinyA2DQwen3Model",
+    "TinyA2DQwen3LMHeadModel",
+]

--- a/unturtle/models/conversion/a2d/tiny_a2d/_fast_forward.py
+++ b/unturtle/models/conversion/a2d/tiny_a2d/_fast_forward.py
@@ -1,0 +1,295 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Non-causal (bidirectional) fast attention forward for Tiny-A2D models.
+
+Replaces the standard ``LlamaAttention.forward`` with a version that:
+1. Dispatches through ``self.apply_qkv`` / ``self.apply_o`` so unsloth's
+   Triton-fused LoRA kernels are invoked when patched in by
+   ``FastDiffusionModel.patch_peft_model``.
+2. Passes ``causal=False`` to Flash Attention and ``is_causal=False`` to SDPA,
+   preventing any causal masking.
+
+Signature follows the **transformers 5.x** ``LlamaAttention.forward`` API:
+- ``position_embeddings`` is passed from the model level (no ``self.rotary_emb``)
+- Returns a 2-tuple ``(attn_output, attn_weights)``
+
+dLLMs require bidirectional attention because they condition on all visible
+tokens (not just past tokens) to predict masked positions.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+from transformers.cache_utils import Cache
+from unsloth.kernels.rope_embedding import fast_rope_embedding
+
+from unturtle.utils.attention_dispatch import (
+    HAS_FLASH_ATTENTION,
+    SDPA,
+    AttentionConfig,
+    AttentionContext,
+    run_attention,
+    select_attention_backend,
+)
+from unturtle.utils.packing import get_packed_info_from_kwargs
+
+if HAS_FLASH_ATTENTION:
+    from flash_attn import flash_attn_varlen_func
+
+
+def _rotate_half_rope(
+    Q: torch.Tensor,
+    K: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: Optional[torch.LongTensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """CPU-safe rotate-half RoPE.  cos/sin shape: (B, L, head_dim)."""
+
+    def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+        x1 = x[..., : x.shape[-1] // 2]
+        x2 = x[..., x.shape[-1] // 2 :]
+        return torch.cat([-x2, x1], dim=-1)
+
+    # cos/sin: (B, L, head_dim) → unsqueeze head axis → (B, 1, L, head_dim)
+    cos = cos.unsqueeze(1).to(dtype=Q.dtype)
+    sin = sin.unsqueeze(1).to(dtype=Q.dtype)
+    Q_out = Q * cos + _rotate_half(Q) * sin
+    K_out = K * cos + _rotate_half(K) * sin
+    return Q_out, K_out
+
+
+def _flash_varlen_packed(
+    Q: torch.Tensor,  # [B, n_heads, L, head_dim]
+    K: torch.Tensor,  # [B, n_kv_heads, L, head_dim]
+    V: torch.Tensor,  # [B, n_kv_heads, L, head_dim]
+    seq_lengths_list: list,  # list[Tensor] — seq_lengths_list[b] = int32 lengths for row b
+    n_heads: int,
+    n_kv_heads: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Compact Q/K/V to padding-free buffers, run flash_attn_varlen_func, scatter back.
+
+    Each row b in the batch has ``sum(seq_lengths_list[b])`` real tokens followed by
+    padding.  This function:
+      1. Strips padding from each row and concatenates into a flat compacted buffer.
+      2. Calls ``flash_attn_varlen_func`` with ``causal=False`` (bidirectional dLLM).
+      3. Scatters the output back into a zero-padded ``[B, L, n_heads * head_dim]`` tensor.
+
+    flash_attn handles GQA natively: Q has ``n_heads`` heads, K/V have ``n_kv_heads``.
+
+    Returns:
+        Tensor of shape ``[B, L, n_heads * head_dim]`` with zeros at padding positions.
+    """
+    bsz = Q.shape[0]
+    q_len = Q.shape[2]
+
+    # Compute real token count per row (tiny CPU ops — seq_lengths are small)
+    real_counts = [int(sl.sum().item()) for sl in seq_lengths_list]
+
+    # Build per-sample cu_seqlens for flash_attn_varlen_func.
+    # Concatenate all per-row length tensors → flat [total_samples] vector.
+    # cu_seqlens indexes into the compacted buffer (sample-level boundaries).
+    flat_lengths = torch.cat(
+        [sl.to(device=Q.device, dtype=torch.int32) for sl in seq_lengths_list]
+    )  # [total_samples_across_all_rows]
+    cu_seqlens = torch.zeros(
+        flat_lengths.numel() + 1, dtype=torch.int32, device=Q.device
+    )
+    torch.cumsum(flat_lengths, dim=0, out=cu_seqlens[1:])
+    max_seqlen = int(flat_lengths.max().item())
+
+    # Compact: remove padding, concatenate real tokens from all rows.
+    # Q: [B, n_heads, L, head_dim] → transpose → [B, L, n_heads, head_dim] → slice + cat
+    Q_t = Q.transpose(1, 2)  # [B, L, n_heads, head_dim]
+    K_t = K.transpose(1, 2)  # [B, L, n_kv_heads, head_dim]
+    V_t = V.transpose(1, 2)  # [B, L, n_kv_heads, head_dim]
+
+    Q_compact = torch.cat([Q_t[b, : real_counts[b]] for b in range(bsz)], dim=0)
+    K_compact = torch.cat([K_t[b, : real_counts[b]] for b in range(bsz)], dim=0)
+    V_compact = torch.cat([V_t[b, : real_counts[b]] for b in range(bsz)], dim=0)
+    # shapes: [total_tokens, n_heads/n_kv_heads, head_dim]
+
+    # Flash varlen — bidirectional (causal=False), no dropout during fine-tuning.
+    attn_out = flash_attn_varlen_func(
+        Q_compact,
+        K_compact,
+        V_compact,
+        cu_seqlens,
+        cu_seqlens,
+        max_seqlen,
+        max_seqlen,
+        dropout_p=0.0,
+        causal=False,
+    )  # [total_tokens, n_heads, head_dim]
+
+    # Scatter back into zero-padded [B, L, n_heads * head_dim].
+    # new_zeros preserves dtype and device from Q.
+    out_full = Q.new_zeros(bsz, q_len, n_heads * head_dim)
+    offset = 0
+    for b in range(bsz):
+        rc = real_counts[b]
+        out_full[b, :rc] = attn_out[offset : offset + rc].reshape(
+            rc, n_heads * head_dim
+        )
+        offset += rc
+
+    return out_full
+
+
+def TinyA2DAttention_fast_forward(
+    self,
+    hidden_states: torch.Tensor,
+    position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    past_key_values: Optional[Cache] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Bidirectional (non-causal) fast forward for Tiny-A2D attention layers.
+
+    Dispatches through ``self.apply_qkv`` / ``self.apply_o`` hooks, enabling
+    unsloth's Triton-fused LoRA kernels when they are patched in.
+    Attention is fully bidirectional (``causal=False``).
+    """
+    # Extract position_ids and cache_position from kwargs.
+    # transformers 5.x LlamaDecoderLayer passes them as named keyword args to
+    # self.self_attn(), which lands in **kwargs here since LlamaAttention.forward
+    # no longer declares them as explicit parameters.
+    position_ids: Optional[torch.LongTensor] = kwargs.get("position_ids")
+    cache_position: Optional[torch.LongTensor] = kwargs.get("cache_position")
+    bsz, q_len, _ = hidden_states.size()
+
+    n_heads = self.config.num_attention_heads
+    n_groups = self.num_key_value_groups
+    n_kv_heads = self.config.num_key_value_heads
+    head_dim = self.head_dim
+    assert n_kv_heads * n_groups == n_heads
+
+    # Dispatch through apply_qkv — uses Triton fused kernel when patched
+    Q, K, V = self.apply_qkv(self, hidden_states)
+    Q = Q.view(bsz, q_len, n_heads, head_dim).transpose(1, 2)
+    K = K.view(bsz, q_len, n_kv_heads, head_dim).transpose(1, 2)
+    V = V.view(bsz, q_len, n_kv_heads, head_dim).transpose(1, 2)
+    seq_info = get_packed_info_from_kwargs(kwargs, Q.device)
+
+    kv_seq_len = K.shape[-2]
+    if past_key_values is not None:
+        kv_seq_len += past_key_values.get_seq_length(self.layer_idx)
+
+    # Apply rotary embeddings
+    if position_embeddings is not None:
+        cos, sin = position_embeddings
+        if Q.device.type == "cuda":
+            if position_ids is not None and cos.ndim == 3 and cos.shape[0] == bsz:
+                cos = cos.reshape(-1, cos.shape[-1])
+                sin = sin.reshape(-1, sin.shape[-1])
+                rope_indices = torch.arange(
+                    bsz * q_len, device=Q.device, dtype=torch.long
+                )
+                Q, K = fast_rope_embedding(Q, K, cos, sin, rope_indices)
+            else:
+                Q, K = fast_rope_embedding(Q, K, cos, sin)
+        else:
+            # CPU fallback: plain rotate_half RoPE on pre-indexed cos/sin
+            Q, K = _rotate_half_rope(Q, K, cos, sin, position_ids)
+    # If position_embeddings is None, skip RoPE (shouldn't happen for Tiny-A2D models
+    # since TinyA2DLlamaModel.forward always computes and passes them)
+
+    if past_key_values is not None:
+        cache_kwargs = {"cache_position": cache_position}
+        K, V = past_key_values.update(K, V, self.layer_idx, cache_kwargs)
+
+    # Determine attention backend.
+    #
+    # Packed sequence handling (seq_info present, no KV cache):
+    #   The 4D attention_mask from TinyA2DLlamaModel.forward is an all-ones padding mask for
+    #   packed inputs — it is semantically irrelevant and must not be passed to the kernel.
+    #
+    #   Flash varlen requires padding-free compacted Q/K/V (total_tokens, heads, dim).
+    #   The current batched tensors are [B, L] with padding, so feeding them to flash
+    #   varlen would produce metadata mismatches when any row is not fully packed.
+    #   Flash varlen support with proper compaction is deferred to a follow-up PR.
+    #
+    #   SDPA packed path: use block_attention_mask from the collator ([B, 1, L, L] bool).
+    #   Do NOT fall back to build_sdpa_packed_attention_mask() — that upstream helper
+    #   builds causal (upper-triangular) blocks, which is incorrect for bidirectional dLLM.
+    #   If block_attention_mask is absent (non-packed forward), use the standard mask path.
+    use_varlen = seq_info is not None and past_key_values is None
+
+    if use_varlen:
+        seq_lengths_list = kwargs.get("seq_lengths")
+        if (
+            HAS_FLASH_ATTENTION
+            and Q.device.type == "cuda"
+            and seq_lengths_list is not None
+        ):
+            # Flash varlen path: compact padding tokens out, call flash_attn_varlen_func
+            # directly (bypasses run_attention which does uncompacted reshape).
+            A = _flash_varlen_packed(
+                Q,
+                K,
+                V,
+                seq_lengths_list=seq_lengths_list,
+                n_heads=n_heads,
+                n_kv_heads=n_kv_heads,
+                head_dim=head_dim,
+            )
+            # _flash_varlen_packed returns [B, L, n_heads * head_dim] already
+            attn_output = self.apply_o(self, A)
+            return attn_output, None
+
+        # SDPA fallback: flash not available or seq_lengths absent.
+        # Use block_attention_mask (bidirectional block-diagonal) from collator when present.
+        # Do NOT fall back to build_sdpa_packed_attention_mask() — it builds causal blocks.
+        effective_mask = kwargs.get("block_attention_mask")
+        backend = SDPA
+    else:
+        effective_mask = attention_mask
+        backend = (
+            SDPA
+            if attention_mask is not None
+            else select_attention_backend(False, device_type=Q.device.type)
+        )
+
+    # Key difference from LlamaAttention: causal=False everywhere.
+    # sdpa_kwargs prevents SDPA from auto-inferring causal when q_len == k_len.
+    config = AttentionConfig(
+        backend=backend,
+        n_kv_heads=n_kv_heads,
+        n_groups=n_groups,
+        flash_dense_kwargs={"causal": False},
+        flash_varlen_kwargs={"dropout_p": 0.0, "causal": False},
+        sdpa_kwargs={"is_causal": False},
+    )
+    context = AttentionContext(
+        bsz=bsz,
+        q_len=q_len,
+        kv_seq_len=K.shape[-2],
+        n_heads=n_heads,
+        head_dim=head_dim,
+        requires_grad=hidden_states.requires_grad,
+        seq_info=seq_info,
+        attention_mask=effective_mask,
+        causal_mask=None,
+    )
+
+    A = run_attention(config=config, context=context, Q=Q, K=K, V=V)
+    attn_output = A.reshape(bsz, q_len, n_heads * head_dim)
+    # Dispatch through apply_o — uses Triton fused kernel when patched
+    attn_output = self.apply_o(self, attn_output)
+    return attn_output, None

--- a/unturtle/models/conversion/a2d/tiny_a2d/generation_utils.py
+++ b/unturtle/models/conversion/a2d/tiny_a2d/generation_utils.py
@@ -1,0 +1,54 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generation mixin for Tiny-A2D (AutoRegressive→Diffusion) models.
+
+The actual generation logic (block-decode + MDLM + BD3LM) is generic masked-diffusion
+behavior shared with native diffusion backbones (e.g. ModernBERT), so it lives in
+``unturtle.models.generation.masked_diffusion_block_mixin``. These thin subclasses give
+the Tiny-A2D models their own named generation mixin/config.
+"""
+
+from unturtle.models.generation.diffusion_generation_utils import (
+    MaskedDiffusionModelOutput,
+)
+from unturtle.models.generation.masked_diffusion_block_mixin import (
+    MaskedDiffusionBlockGenerationConfig,
+    MaskedDiffusionBlockGenerationMixin,
+)
+
+
+class TinyA2DGenerationConfig(MaskedDiffusionBlockGenerationConfig):
+    """Generation config for Tiny-A2D models (currently identical to the shared config)."""
+
+    pass
+
+
+class TinyA2DGenerationMixin(MaskedDiffusionBlockGenerationMixin):
+    """Generation mixin for Tiny-A2D models.
+
+    All behavior is inherited from
+    :class:`~unturtle.models.generation.masked_diffusion_block_mixin.MaskedDiffusionBlockGenerationMixin`
+    (block-decode KV-cache, MDLM no-cache loop, and BD3LM block-diffusion). This subclass
+    exists so Tiny-A2D models have a recipe-named mixin.
+    """
+
+    pass
+
+
+__all__ = [
+    "TinyA2DGenerationConfig",
+    "TinyA2DGenerationMixin",
+    "MaskedDiffusionModelOutput",
+]

--- a/unturtle/models/conversion/a2d/tiny_a2d/modeling_llama.py
+++ b/unturtle/models/conversion/a2d/tiny_a2d/modeling_llama.py
@@ -1,0 +1,159 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Ported from zhziszz/dllm (dllm/pipelines/a2d/models/llama/modeling_llama.py).
+# Removed __main__ block (dllm.utils dependency). Model code is unchanged.
+
+"""Tiny-A2D (AutoRegressive→Diffusion) adapter for LLaMA models.
+
+Converts a causal LLaMA model to a bidirectional masked diffusion LM by
+replacing the causal attention mask with a padding-only attention mask.
+All pretrained weights are reused without modification.
+
+Usage::
+
+    from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaConfig, TinyA2DLlamaLMHeadModel
+
+    config = TinyA2DLlamaConfig.from_pretrained("meta-llama/Meta-Llama-3-8B")
+    model = TinyA2DLlamaLMHeadModel(config)
+    # fine-tune with DiffusionTrainer
+"""
+
+from typing import Optional
+
+import torch
+import transformers
+from torch import nn
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from .generation_utils import TinyA2DGenerationMixin
+
+if transformers.utils.is_torch_flex_attn_available():
+    from torch.nn.attention.flex_attention import BlockMask
+else:
+    BlockMask = torch.Tensor
+
+
+class TinyA2DLlamaConfig(transformers.LlamaConfig):
+    model_type = "tiny-a2d-llama"
+
+
+class TinyA2DLlamaModel(transformers.LlamaModel):
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds"
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        past_seen_tokens = (
+            past_key_values.get_seq_length() if past_key_values is not None else 0
+        )
+        if cache_position is None:
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        # Bidirectional (padding-only) mask — replaces the upstream causal mask.
+        # With cache, the key/value length includes both cached prefix and current tokens.
+        key_value_length = past_seen_tokens + inputs_embeds.shape[1]
+        if attention_mask is None:
+            attention_mask = torch.ones(
+                (inputs_embeds.shape[0], key_value_length),
+                device=inputs_embeds.device,
+                dtype=torch.long,
+            )
+        elif (
+            isinstance(attention_mask, torch.Tensor)
+            and attention_mask.ndim == 2
+            and attention_mask.shape[1] == inputs_embeds.shape[1]
+            and past_seen_tokens > 0
+        ):
+            prefix_mask = torch.ones(
+                (attention_mask.shape[0], past_seen_tokens),
+                device=attention_mask.device,
+                dtype=attention_mask.dtype,
+            )
+            attention_mask = torch.cat([prefix_mask, attention_mask], dim=1)
+
+        # 2) Convert 2-D padding mask to 4-D additive attention bias.
+        if not (
+            isinstance(attention_mask, BlockMask)
+            or (isinstance(attention_mask, torch.Tensor) and attention_mask.ndim == 4)
+        ):
+            attention_mask = _prepare_4d_attention_mask(
+                attention_mask,
+                self.dtype,
+                tgt_len=inputs_embeds.shape[1],
+            )
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+        )
+
+
+class TinyA2DLlamaLMHeadModel(TinyA2DGenerationMixin, transformers.LlamaForCausalLM):
+    config: TinyA2DLlamaConfig
+
+    def __init__(self, config):
+        transformers.LlamaPreTrainedModel.__init__(self, config)
+        self.model = TinyA2DLlamaModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+
+transformers.AutoConfig.register("tiny-a2d-llama", TinyA2DLlamaConfig)
+transformers.AutoModel.register(TinyA2DLlamaConfig, TinyA2DLlamaLMHeadModel)
+transformers.AutoModelForMaskedLM.register(TinyA2DLlamaConfig, TinyA2DLlamaLMHeadModel)

--- a/unturtle/models/conversion/a2d/tiny_a2d/modeling_qwen2.py
+++ b/unturtle/models/conversion/a2d/tiny_a2d/modeling_qwen2.py
@@ -1,0 +1,167 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Ported from zhziszz/dllm (dllm/pipelines/a2d/models/qwen2/modeling_qwen2.py).
+# Removed __main__ block (dllm.utils dependency). Model code is unchanged.
+
+"""Tiny-A2D (AutoRegressive→Diffusion) adapter for Qwen2 models.
+
+Converts a causal Qwen2 model to a bidirectional masked diffusion LM by
+replacing the causal attention mask (including sliding-window layers) with
+a padding-only attention mask. All pretrained weights are reused as-is.
+
+Usage::
+
+    from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DQwen2Config, TinyA2DQwen2LMHeadModel
+
+    config = TinyA2DQwen2Config.from_pretrained("Qwen/Qwen2.5-0.5B")
+    model = TinyA2DQwen2LMHeadModel(config)
+"""
+
+from typing import Optional
+
+import torch
+import transformers
+from torch import nn
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from .generation_utils import TinyA2DGenerationMixin
+
+if transformers.utils.is_torch_flex_attn_available():
+    from torch.nn.attention.flex_attention import BlockMask
+else:
+    BlockMask = torch.Tensor
+
+
+class TinyA2DQwen2Config(transformers.Qwen2Config):
+    model_type = "tiny-a2d-qwen2"
+
+
+class TinyA2DQwen2Model(transformers.Qwen2Model):
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds"
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        past_seen_tokens = (
+            past_key_values.get_seq_length() if past_key_values is not None else 0
+        )
+        if cache_position is None:
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        # Bidirectional (padding-only) mask — replaces the upstream causal mask.
+        if not isinstance(causal_mask_mapping := attention_mask, dict):
+            key_value_length = past_seen_tokens + inputs_embeds.shape[1]
+            if attention_mask is None:
+                attention_mask = torch.ones(
+                    (inputs_embeds.shape[0], key_value_length),
+                    device=inputs_embeds.device,
+                    dtype=torch.long,
+                )
+            elif (
+                isinstance(attention_mask, torch.Tensor)
+                and attention_mask.ndim == 2
+                and attention_mask.shape[1] == inputs_embeds.shape[1]
+                and past_seen_tokens > 0
+            ):
+                prefix_mask = torch.ones(
+                    (attention_mask.shape[0], past_seen_tokens),
+                    device=attention_mask.device,
+                    dtype=attention_mask.dtype,
+                )
+                attention_mask = torch.cat([prefix_mask, attention_mask], dim=1)
+
+            if not (
+                isinstance(attention_mask, BlockMask)
+                or (
+                    isinstance(attention_mask, torch.Tensor)
+                    and attention_mask.ndim == 4
+                )
+            ):
+                attention_mask = _prepare_4d_attention_mask(
+                    attention_mask,
+                    self.dtype,
+                    tgt_len=inputs_embeds.shape[1],
+                )
+
+            causal_mask_mapping = {"full_attention": attention_mask}
+            if self.has_sliding_layers:
+                causal_mask_mapping["sliding_attention"] = attention_mask
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        # Transformers >=4.57 selects mask variant via `config.layer_types[i]`, not
+        # `decoder_layer.attention_type` (removed from Qwen2DecoderLayer).
+        for i, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask_mapping[self.config.layer_types[i]],
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values if use_cache else None,
+        )
+
+
+class TinyA2DQwen2LMHeadModel(TinyA2DGenerationMixin, transformers.Qwen2ForCausalLM):
+    config: TinyA2DQwen2Config
+
+    def __init__(self, config):
+        transformers.Qwen2PreTrainedModel.__init__(self, config)
+        self.model = TinyA2DQwen2Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+
+transformers.AutoConfig.register("tiny-a2d-qwen2", TinyA2DQwen2Config)
+transformers.AutoModel.register(TinyA2DQwen2Config, TinyA2DQwen2LMHeadModel)
+transformers.AutoModelForMaskedLM.register(TinyA2DQwen2Config, TinyA2DQwen2LMHeadModel)

--- a/unturtle/models/conversion/a2d/tiny_a2d/modeling_qwen3.py
+++ b/unturtle/models/conversion/a2d/tiny_a2d/modeling_qwen3.py
@@ -1,0 +1,167 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Ported from zhziszz/dllm (dllm/pipelines/a2d/models/qwen3/modeling_qwen3.py).
+# Removed __main__ block (dllm.utils dependency). Model code is unchanged.
+
+"""Tiny-A2D (AutoRegressive→Diffusion) adapter for Qwen3 models.
+
+Converts a causal Qwen3 model to a bidirectional masked diffusion LM by
+replacing the causal attention mask (including sliding-window layers) with
+a padding-only attention mask. All pretrained weights are reused as-is.
+
+Usage::
+
+    from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DQwen3Config, TinyA2DQwen3LMHeadModel
+
+    config = TinyA2DQwen3Config.from_pretrained("Qwen/Qwen3-0.6B-Base")
+    model = TinyA2DQwen3LMHeadModel(config)
+"""
+
+from typing import Optional
+
+import torch
+import transformers
+from torch import nn
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask
+from transformers.modeling_outputs import BaseModelOutputWithPast
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from .generation_utils import TinyA2DGenerationMixin
+
+if transformers.utils.is_torch_flex_attn_available():
+    from torch.nn.attention.flex_attention import BlockMask
+else:
+    BlockMask = torch.Tensor
+
+
+class TinyA2DQwen3Config(transformers.Qwen3Config):
+    model_type = "tiny-a2d-qwen3"
+
+
+class TinyA2DQwen3Model(transformers.Qwen3Model):
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds"
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        past_seen_tokens = (
+            past_key_values.get_seq_length() if past_key_values is not None else 0
+        )
+        if cache_position is None:
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        # Bidirectional (padding-only) mask — replaces the upstream causal mask.
+        if not isinstance(causal_mask_mapping := attention_mask, dict):
+            key_value_length = past_seen_tokens + inputs_embeds.shape[1]
+            if attention_mask is None:
+                attention_mask = torch.ones(
+                    (inputs_embeds.shape[0], key_value_length),
+                    device=inputs_embeds.device,
+                    dtype=torch.long,
+                )
+            elif (
+                isinstance(attention_mask, torch.Tensor)
+                and attention_mask.ndim == 2
+                and attention_mask.shape[1] == inputs_embeds.shape[1]
+                and past_seen_tokens > 0
+            ):
+                prefix_mask = torch.ones(
+                    (attention_mask.shape[0], past_seen_tokens),
+                    device=attention_mask.device,
+                    dtype=attention_mask.dtype,
+                )
+                attention_mask = torch.cat([prefix_mask, attention_mask], dim=1)
+
+            if not (
+                isinstance(attention_mask, BlockMask)
+                or (
+                    isinstance(attention_mask, torch.Tensor)
+                    and attention_mask.ndim == 4
+                )
+            ):
+                attention_mask = _prepare_4d_attention_mask(
+                    attention_mask,
+                    self.dtype,
+                    tgt_len=inputs_embeds.shape[1],
+                )
+
+            causal_mask_mapping = {"full_attention": attention_mask}
+            if self.has_sliding_layers:
+                causal_mask_mapping["sliding_attention"] = attention_mask
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        # Transformers >=4.57 selects mask variant via `config.layer_types[i]`, not
+        # `decoder_layer.attention_type` (removed from Qwen3DecoderLayer).
+        for i, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask_mapping[self.config.layer_types[i]],
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values if use_cache else None,
+        )
+
+
+class TinyA2DQwen3LMHeadModel(TinyA2DGenerationMixin, transformers.Qwen3ForCausalLM):
+    config: TinyA2DQwen3Config
+
+    def __init__(self, config):
+        transformers.Qwen3PreTrainedModel.__init__(self, config)
+        self.model = TinyA2DQwen3Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+
+transformers.AutoConfig.register("tiny-a2d-qwen3", TinyA2DQwen3Config)
+transformers.AutoModel.register(TinyA2DQwen3Config, TinyA2DQwen3LMHeadModel)
+transformers.AutoModelForMaskedLM.register(TinyA2DQwen3Config, TinyA2DQwen3LMHeadModel)


### PR DESCRIPTION
Closes #9

## 概要
クリーン移植 Task 5。AR→Diffusion 変換メソッド Tiny-A2D を移植。

- `unturtle/models/conversion/a2d/tiny_a2d/`（llama / qwen2 / qwen3 アダプタ + fast_forward + generation mixin）を移植
- **legacy `a2d-*` load-compat を全削除**: `_LegacyA2D{Llama,Qwen2,Qwen3}Config` と `AutoConfig/AutoModel/AutoModelForMaskedLM.register(a2d-*)` 計9 register（diff -r で除去がこれのみであることを検証済み）
- Task 4 の暫定 try/except ガードを除去し `fast_diffusion_model.py` を legacy 形に復元（残差分は a2d-modernbert frozenset の1行のみ）
- `models/__init__.py` に TinyA2D 系 11 シンボルを export

## テスト
- not slow: models 165 passed / 1 skipped
- **全量回帰: 180 passed, 1 skipped**（テスト無修正、本体の transformers 5.5 起因修正もゼロ）
- ruff グリーン

## 残課題（Task 7 スコープ）
`fast_diffusion_model.py` 内の `_TINY_A2D_MODEL_TYPES` / `_UNTURTLE_MODEL_CLASSES` に legacy `a2d-*` エントリと dllm-hub repo id 分岐が残存（#301 コメント付き）。Task 7 のリファクタで除去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)