### PR TITLE
✨ feat(models): FastDiffusionModel tests + exports; 🔥 compat removal; ♻️ loader split (#14)

### DIFF
--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -1,0 +1,240 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fast (CPU, no downloads) end-to-end integration tests for FastDiffusionModel + DiffusionTrainer.
+
+Uses a tiny random-weight model to verify the full
+``get_peft_model → DiffusionTrainer`` pipeline runs and loss is finite.
+Always runs in CI — no GPU or HF download required.
+
+For slow E2E tests with real HuggingFace checkpoints, see::
+
+    tests/test_e2e_real_checkpoint.py  (run with ``pytest -m slow``)
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Shared tiny A2D config
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tiny_a2d_config():
+    from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaConfig
+
+    return TinyA2DLlamaConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=64,
+    )
+
+
+@pytest.fixture(scope="module")
+def tiny_a2d_model(tiny_a2d_config):
+    from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+    model = TinyA2DLlamaLMHeadModel(tiny_a2d_config)
+    model.train()
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Fast E2E: FastDiffusionModel.get_peft_model → DiffusionTrainer (CPU)
+# ---------------------------------------------------------------------------
+
+
+class TestE2EFastDiffusionTrainer:
+    """Full pipeline: base model → LoRA → DiffusionTrainer → loss decreasing.
+
+    Uses a tiny random-weight A2D-Llama model so no GPU or HF download
+    is needed.  Verifies that the Trainer integrates with FastDiffusionModel.
+    """
+
+    def test_pipeline_loss_decreases(self, tiny_a2d_model, tmp_path):
+        """After 3 gradient steps the training loss should decrease."""
+        from tokenizers import Tokenizer, models, normalizers, pre_tokenizers
+        from transformers import PreTrainedTokenizerFast
+
+        from unturtle.diffusion import (
+            DiffusionTrainer,
+            DiffusionTrainingArguments,
+            MaskedDiffusionDataCollator,
+        )
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        cfg = tiny_a2d_model.config
+
+        # Build a minimal BPE tokenizer with a mask token
+        raw_tok = Tokenizer(models.BPE(unk_token="[UNK]"))
+        raw_tok.normalizer = normalizers.Lowercase()
+        raw_tok.pre_tokenizer = pre_tokenizers.Whitespace()
+        tokenizer = PreTrainedTokenizerFast(
+            tokenizer_object=raw_tok,
+            unk_token="[UNK]",
+            mask_token="[MASK]",
+            pad_token="[PAD]",
+        )
+        tokenizer.add_special_tokens(
+            {"unk_token": "[UNK]", "mask_token": "[MASK]", "pad_token": "[PAD]"}
+        )
+        # Give the tokenizer a non-empty name so the Trainer doesn't try to
+        # fetch processor_config.json from the HuggingFace hub.
+        tokenizer.name_or_path = "local"
+
+        # Use fixed token ids that fall within vocab_size=256
+        mask_token_id = tokenizer.mask_token_id or 1
+        assert mask_token_id < cfg.vocab_size, (
+            f"mask_token_id={mask_token_id} exceeds vocab_size={cfg.vocab_size}"
+        )
+
+        # Build PEFT model (CPU-only; Triton kernels are automatically skipped
+        # on CPU via the cuda_available guard in FastDiffusionModel).
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_a2d_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+
+        # Tiny dataset: 8 sequences of length 16
+        L = 16
+        dataset = [
+            {
+                "input_ids": torch.randint(2, cfg.vocab_size, (L,)).tolist(),
+                "labels": torch.randint(2, cfg.vocab_size, (L,)).tolist(),
+                "attention_mask": [1] * L,
+            }
+            for _ in range(8)
+        ]
+
+        collator = MaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            mask_token_id=mask_token_id,
+            completion_only=False,
+        )
+
+        training_args = DiffusionTrainingArguments(
+            output_dir=str(tmp_path / "checkpoints"),
+            num_train_epochs=1,
+            max_steps=3,
+            per_device_train_batch_size=2,
+            logging_steps=1,
+            save_steps=100,
+            use_cpu=True,  # CPU-only
+            bf16=False,
+            fp16=False,
+            dataloader_drop_last=True,
+            remove_unused_columns=False,
+            report_to="none",
+        )
+
+        # Capture per-step losses to verify the pipeline actually learns
+        losses: list[float] = []
+        original_log = DiffusionTrainer.log
+
+        def capturing_log(self_inner, logs, start_time=None, **kw):
+            if "loss" in logs:
+                losses.append(float(logs["loss"]))
+            original_log(self_inner, logs, start_time=start_time, **kw)
+
+        DiffusionTrainer.log = capturing_log
+        try:
+            trainer = DiffusionTrainer(
+                model=peft_model,
+                args=training_args,
+                train_dataset=dataset,
+                data_collator=collator,
+                processing_class=tokenizer,
+            )
+            result = trainer.train()
+        finally:
+            DiffusionTrainer.log = original_log
+
+        # Loss must be finite and the training loop must have logged at least once
+        assert result.training_loss is not None
+        assert torch.isfinite(torch.tensor(result.training_loss)), (
+            f"Training loss is not finite: {result.training_loss}"
+        )
+        # Verify the loss logging path was exercised (gradient steps are running)
+        assert len(losses) >= 1, (
+            "No loss values were logged — training loop may not have run"
+        )
+        # All logged losses must be finite (no NaN/Inf explosion)
+        for step_loss in losses:
+            assert torch.isfinite(torch.tensor(step_loss)), (
+                f"Step loss is not finite: {step_loss} in {losses}"
+            )
+
+    def test_adapter_save_reload_forward_matches(self, tiny_a2d_config, tmp_path):
+        """Save LoRA adapter, reload, and verify forward output matches."""
+        from peft import PeftModel
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+        cfg = tiny_a2d_config
+        # Use a fresh model — the shared tiny_a2d_model may already be PEFT-wrapped
+        base_model = TinyA2DLlamaLMHeadModel(cfg)
+        base_model.train()
+        # Snapshot base weights before PEFT wrapping so we can restore them on
+        # a new model instance (for the reload verification later).
+        base_state_dict = {k: v.clone() for k, v in base_model.state_dict().items()}
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            base_model,
+            r=4,
+            target_modules=["q_proj", "v_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        peft_model.eval()
+
+        B, L = 2, 8
+        input_ids = torch.randint(2, tiny_a2d_config.vocab_size, (B, L))
+
+        with torch.no_grad():
+            logits_before = peft_model(input_ids).logits
+
+        # Save adapter
+        adapter_dir = tmp_path / "adapter"
+        peft_model.save_pretrained(str(adapter_dir))
+
+        # Reload onto a fresh base model with the same weights as the original.
+        fresh_base = TinyA2DLlamaLMHeadModel(cfg)
+        fresh_base.load_state_dict(base_state_dict)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            reloaded = PeftModel.from_pretrained(fresh_base, str(adapter_dir))
+        reloaded.eval()
+
+        with torch.no_grad():
+            logits_after = reloaded(input_ids).logits
+
+        assert logits_before.shape == logits_after.shape
+        assert torch.allclose(logits_before, logits_after, atol=1e-5), (
+            "Forward outputs diverged after save/reload of LoRA adapter."
+        )

--- a/tests/test_e2e_real_checkpoint.py
+++ b/tests/test_e2e_real_checkpoint.py
@@ -1,0 +1,292 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Slow E2E tests with real HuggingFace checkpoints.
+
+These tests download a real dLLM checkpoint from HuggingFace and exercise the
+full ``FastDiffusionModel.from_pretrained → get_peft_model → DiffusionTrainer``
+pipeline on GPU.
+
+**Skipped by default.**  To run::
+
+    pytest tests/test_e2e_real_checkpoint.py -m slow -v
+
+Override the default checkpoint (GSAI-ML/LLaDA-8B-Instruct) with::
+
+    UNTURTLE_TEST_CHECKPOINT=your/model pytest tests/test_e2e_real_checkpoint.py -m slow
+
+Requirements:
+- CUDA GPU
+- ``HF_TOKEN`` env var if the model is gated
+- Sufficient disk space (~16 GB for LLaDA-8B in 4-bit)
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Default checkpoint — override with env var to use a smaller model
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CHECKPOINT = os.environ.get(
+    "UNTURTLE_TEST_CHECKPOINT", "GSAI-ML/LLaDA-8B-Instruct"
+)
+
+
+@pytest.mark.slow
+@pytest.mark.gpu
+class TestFromPretrainedLoads:
+    """FastDiffusionModel.from_pretrained works with a real checkpoint."""
+
+    @pytest.fixture(autouse=True)
+    def require_cuda(self):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA GPU required for slow E2E test")
+
+    def test_model_and_tokenizer_returned(self):
+        """from_pretrained returns (model, tokenizer), model has max_seq_length."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        model, tokenizer = FastDiffusionModel.from_pretrained(
+            _DEFAULT_CHECKPOINT,
+            max_seq_length=512,
+            load_in_4bit=True,
+            trust_remote_code=True,
+        )
+        assert model is not None, "model is None"
+        assert tokenizer is not None, "tokenizer is None"
+        assert model.max_seq_length == 512
+
+    def test_forward_produces_logits(self):
+        """Model forward pass produces logits of the correct shape."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        model, tokenizer = FastDiffusionModel.from_pretrained(
+            _DEFAULT_CHECKPOINT,
+            max_seq_length=64,
+            load_in_4bit=True,
+            trust_remote_code=True,
+        )
+        model.eval()
+
+        text = "The quick brown fox"
+        inputs = tokenizer(text, return_tensors="pt").to("cuda")
+        B, L = inputs["input_ids"].shape
+
+        with torch.no_grad():
+            out = model(**inputs)
+
+        assert out.logits.shape == (B, L, model.config.vocab_size), (
+            f"Unexpected logits shape: {out.logits.shape}"
+        )
+        assert torch.isfinite(out.logits).all(), "Logits contain inf/nan"
+
+
+@pytest.mark.slow
+@pytest.mark.gpu
+class TestPeftAndTraining:
+    """LoRA patching + DiffusionTrainer with a real checkpoint."""
+
+    @pytest.fixture(autouse=True)
+    def require_cuda(self):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA GPU required for slow E2E test")
+
+    def test_loss_decreases_after_training_steps(self, tmp_path):
+        """3 gradient steps with a real model: loss must be finite and decrease."""
+        from unturtle.diffusion import (
+            DiffusionTrainer,
+            DiffusionTrainingArguments,
+            MaskedDiffusionDataCollator,
+        )
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        model, tokenizer = FastDiffusionModel.from_pretrained(
+            _DEFAULT_CHECKPOINT,
+            max_seq_length=256,
+            load_in_4bit=True,
+            trust_remote_code=True,
+        )
+        assert tokenizer is not None, "Tokenizer required for real checkpoint test"
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            model,
+            r=8,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+                "gate_proj",
+                "up_proj",
+                "down_proj",
+            ],
+            lora_alpha=16,
+            lora_dropout=0,
+            use_gradient_checkpointing="unsloth",
+        )
+
+        mask_token_id = tokenizer.mask_token_id or getattr(
+            model.config, "mask_token_id", None
+        )
+        assert mask_token_id is not None, (
+            "Real-checkpoint E2E requires a mask token id. "
+            "Pass mask_token_id explicitly or use a checkpoint whose tokenizer/config defines one."
+        )
+
+        # Tiny 10-sample dataset: prompt + completion.
+        # Use add_special_tokens=False consistently for prompt/full tokenization so
+        # the prompt/completion boundary stays exact even with override checkpoints.
+        prompts = ["The capital of France is"] * 10
+        completions = [" Paris."] * 10
+        dataset = []
+        for prompt, completion in zip(prompts, completions, strict=False):
+            prompt_ids = tokenizer(prompt, add_special_tokens=False)["input_ids"]
+            completion_ids = tokenizer(completion, add_special_tokens=False)[
+                "input_ids"
+            ]
+            input_ids = (prompt_ids + completion_ids)[:64]
+            attention_mask = [1] * len(input_ids)
+            labels = [-100] * min(len(prompt_ids), len(input_ids)) + input_ids[
+                len(prompt_ids) :
+            ]
+            labels = labels[: len(input_ids)]
+            dataset.append(
+                {
+                    "input_ids": input_ids,
+                    "labels": labels,
+                    "attention_mask": attention_mask,
+                }
+            )
+
+        collator = MaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            mask_token_id=mask_token_id,
+            completion_only=True,
+        )
+        training_args = DiffusionTrainingArguments(
+            output_dir=str(tmp_path / "checkpoints"),
+            num_train_epochs=1,
+            max_steps=3,
+            per_device_train_batch_size=2,
+            logging_steps=1,
+            save_steps=100,
+            bf16=True,
+            dataloader_drop_last=True,
+            remove_unused_columns=False,
+            report_to="none",
+        )
+
+        losses: list[float] = []
+        original_log = DiffusionTrainer.log
+
+        def _capturing_log(self_inner, logs, *args, **kw):
+            if "loss" in logs:
+                losses.append(float(logs["loss"]))
+            original_log(self_inner, logs, *args, **kw)
+
+        DiffusionTrainer.log = _capturing_log
+        try:
+            trainer = DiffusionTrainer(
+                model=peft_model,
+                args=training_args,
+                train_dataset=dataset,
+                data_collator=collator,
+                processing_class=tokenizer,
+            )
+            trainer.train()
+        finally:
+            DiffusionTrainer.log = original_log
+
+        assert len(losses) >= 2, (
+            f"Need >= 2 logged steps to compare loss, got: {losses}"
+        )
+        for step_loss in losses:
+            assert torch.isfinite(torch.tensor(step_loss)), (
+                f"Non-finite loss at step: {step_loss}"
+            )
+        # Allow small tolerance: loss may fluctuate over only 3 steps
+        assert losses[-1] < losses[0] or abs(losses[-1] - losses[0]) < 0.5, (
+            f"Loss did not decrease: {losses}"
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.gpu
+class TestAdapterSaveReload:
+    """LoRA adapter save + reload reproduces identical forward outputs."""
+
+    @pytest.fixture(autouse=True)
+    def require_cuda(self):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA GPU required for slow E2E test")
+
+    def test_save_reload_forward_matches(self, tmp_path):
+        """Save LoRA adapter and reload onto a fresh base; logits must match."""
+        from peft import PeftModel
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        model, tokenizer = FastDiffusionModel.from_pretrained(
+            _DEFAULT_CHECKPOINT,
+            max_seq_length=64,
+            load_in_4bit=True,
+            trust_remote_code=True,
+        )
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            model,
+            r=4,
+            target_modules=["q_proj", "v_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        peft_model.eval()
+
+        text = "The quick brown fox"
+        inputs = tokenizer(text, return_tensors="pt").to("cuda")
+
+        with torch.no_grad():
+            logits_before = peft_model(**inputs).logits
+
+        # Save adapter
+        adapter_dir = tmp_path / "adapter"
+        peft_model.save_pretrained(str(adapter_dir))
+
+        # Reload: fresh from_pretrained + load adapter
+        base_model2, _ = FastDiffusionModel.from_pretrained(
+            _DEFAULT_CHECKPOINT,
+            max_seq_length=64,
+            load_in_4bit=True,
+            trust_remote_code=True,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            reloaded = PeftModel.from_pretrained(base_model2, str(adapter_dir))
+        reloaded.eval()
+
+        with torch.no_grad():
+            logits_after = reloaded(**inputs).logits
+
+        assert logits_before.shape == logits_after.shape
+        assert torch.allclose(logits_before.float(), logits_after.float(), atol=1e-3), (
+            "Forward outputs diverged after save/reload of LoRA adapter. "
+            f"Max diff: {(logits_before.float() - logits_after.float()).abs().max().item():.4f}"
+        )

--- a/tests/test_fast_diffusion_generate.py
+++ b/tests/test_fast_diffusion_generate.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from unturtle.fast_diffusion_model import FastDiffusionModel
+
+
+class _RecordingModel:
+    """Stub dLLM model: records the kwargs diffusion_generate receives."""
+
+    def __init__(self, *, cache_capable: bool = True) -> None:
+        self.calls: list[dict] = []
+        self._cache_capable = cache_capable
+
+    def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
+    def diffusion_generate(self, inputs=None, **kwargs):  # noqa: ANN001, ANN003
+        self.calls.append({"inputs": inputs, **kwargs})
+        return "GENERATED"
+
+
+class _NoCacheModel:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def diffusion_generate(self, inputs=None, **kwargs):  # noqa: ANN001, ANN003
+        self.calls.append({"inputs": inputs, **kwargs})
+        return "GENERATED"
+
+
+def test_generate_auto_selects_block_decode_for_cache_capable() -> None:
+    model = _RecordingModel(cache_capable=True)
+    out = FastDiffusionModel.generate(model, inputs="X", steps=8)
+    assert out == "GENERATED"
+    call = model.calls[-1]
+    assert call["use_cache"] is True
+    assert call["use_block_diffusion"] is False
+    assert call["steps"] == 8
+    assert call["inputs"] == "X"
+
+
+def test_generate_auto_falls_back_to_mdlm_without_cache() -> None:
+    model = _NoCacheModel()
+    FastDiffusionModel.generate(model, inputs="X")
+    call = model.calls[-1]
+    assert call["use_cache"] is False
+    assert call["use_block_diffusion"] is False
+
+
+def test_generate_explicit_mdlm_overrides_auto() -> None:
+    model = _RecordingModel(cache_capable=True)
+    FastDiffusionModel.generate(model, inputs="X", algorithm="mdlm")
+    call = model.calls[-1]
+    assert call["use_cache"] is False
+    assert call["use_block_diffusion"] is False
+
+
+def test_generate_explicit_bd3lm() -> None:
+    model = _RecordingModel(cache_capable=True)
+    FastDiffusionModel.generate(model, inputs="X", algorithm="bd3lm")
+    call = model.calls[-1]
+    assert call["use_block_diffusion"] is True
+    assert call["use_cache"] is False
+
+
+def test_generate_auto_with_use_block_diffusion_kwarg_picks_bd3lm() -> None:
+    model = _RecordingModel(cache_capable=True)
+    FastDiffusionModel.generate(model, inputs="X", use_block_diffusion=True)
+    call = model.calls[-1]
+    assert call["use_block_diffusion"] is True
+    assert call["use_cache"] is False
+
+
+def test_generate_unknown_algorithm_raises() -> None:
+    model = _RecordingModel()
+    with pytest.raises(ValueError):
+        FastDiffusionModel.generate(model, inputs="X", algorithm="continuous_ddpm")
+
+
+def test_generate_requires_diffusion_generate() -> None:
+    class _NotADLLM:
+        pass
+
+    with pytest.raises(TypeError):
+        FastDiffusionModel.generate(_NotADLLM(), inputs="X")
+
+
+def test_generate_passes_through_gen_kwargs() -> None:
+    model = _RecordingModel()
+    FastDiffusionModel.generate(
+        model, inputs="X", algorithm="block_decode", temperature=0.7, max_new_tokens=32
+    )
+    call = model.calls[-1]
+    assert call["temperature"] == 0.7
+    assert call["max_new_tokens"] == 32
+
+
+def _tiny_a2d_model():
+    from unturtle.models.conversion.a2d.tiny_a2d import (
+        TinyA2DLlamaConfig,
+        TinyA2DLlamaLMHeadModel,
+    )
+
+    config = TinyA2DLlamaConfig(
+        vocab_size=1000,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=128,
+        mask_token_id=999,
+    )
+    model = TinyA2DLlamaLMHeadModel(config)
+    model.eval()
+    return model
+
+
+@pytest.mark.parametrize(
+    "algorithm,flags",
+    [
+        ("mdlm", {"use_cache": False, "use_block_diffusion": False}),
+        ("block_decode", {"use_cache": True, "use_block_diffusion": False}),
+    ],
+)
+def test_generate_parity_with_diffusion_generate(algorithm, flags) -> None:
+    model = _tiny_a2d_model()
+    prompt = torch.tensor([[1, 2, 3, 4]])
+    gen_kwargs = dict(
+        steps=4, max_new_tokens=4, temperature=0.0, mask_token_id=999, block_length=4
+    )
+
+    torch.manual_seed(0)
+    out_direct = model.diffusion_generate(inputs=prompt, **flags, **gen_kwargs)
+
+    torch.manual_seed(0)
+    out_generate = FastDiffusionModel.generate(
+        model, inputs=prompt, algorithm=algorithm, **gen_kwargs
+    )
+
+    seq_direct = (
+        out_direct.sequences if hasattr(out_direct, "sequences") else out_direct
+    )
+    seq_generate = (
+        out_generate.sequences if hasattr(out_generate, "sequences") else out_generate
+    )
+    assert torch.equal(seq_direct, seq_generate)

--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -1,0 +1,1541 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for FastDiffusionModel — CPU-only, no pretrained checkpoints downloaded.
+
+Tests cover:
+- apply_qkv / apply_o stub installation
+- Forward pass through TinyA2DAttention_fast_forward (CPU / SDPA path)
+- LoRA application and Triton kernel patching (CPU, lora_dropout=0)
+- Bidirectionality: model attends to future tokens (non-causal property)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Shared tiny A2D-Llama config fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tiny_config():
+    from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaConfig
+
+    return TinyA2DLlamaConfig(
+        vocab_size=512,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=64,
+    )
+
+
+@pytest.fixture
+def tiny_model(tiny_config):
+    from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+
+    model = TinyA2DLlamaLMHeadModel(tiny_config)
+    model.eval()
+    return model
+
+
+# ---------------------------------------------------------------------------
+# _install_apply_stubs
+# ---------------------------------------------------------------------------
+
+
+class TestInstallApplyStubs:
+    def test_stubs_installed_on_all_layers(self, tiny_model):
+        from unturtle.fast_diffusion_model import _install_apply_stubs
+
+        _install_apply_stubs(tiny_model)
+        for layer in tiny_model.model.layers:
+            attn = layer.self_attn
+            assert hasattr(attn, "apply_qkv"), "apply_qkv stub missing"
+            assert hasattr(attn, "apply_o"), "apply_o stub missing"
+
+    def test_stub_output_shape(self, tiny_model):
+        from unturtle.fast_diffusion_model import _install_apply_stubs
+
+        _install_apply_stubs(tiny_model)
+        attn = tiny_model.model.layers[0].self_attn
+        B, L = 1, 8
+        hidden = torch.randn(B, L, tiny_model.config.hidden_size)
+        Q, K, V = attn.apply_qkv(attn, hidden)
+        expected = (B, L, tiny_model.config.num_attention_heads * attn.head_dim)
+        assert Q.shape == expected
+
+
+# ---------------------------------------------------------------------------
+# TinyA2DAttention_fast_forward (CPU / SDPA path)
+# ---------------------------------------------------------------------------
+
+
+class TestA2DAttentionFastForward:
+    def test_forward_returns_correct_shapes(self, tiny_model):
+        import types
+
+        from unturtle.fast_diffusion_model import _install_apply_stubs
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            TinyA2DAttention_fast_forward,
+        )
+
+        _install_apply_stubs(tiny_model)
+        attn = tiny_model.model.layers[0].self_attn
+        attn.forward = types.MethodType(TinyA2DAttention_fast_forward, attn)
+
+        B, L = 2, 8
+        hidden = torch.randn(B, L, tiny_model.config.hidden_size)
+        out, weights = attn(hidden)
+
+        assert out.shape == (B, L, tiny_model.config.hidden_size)
+        assert weights is None
+
+    def test_passes_cpu_device_type_to_backend_selection(self, tiny_model, monkeypatch):
+        import types
+
+        from unturtle.fast_diffusion_model import _install_apply_stubs
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            _fast_forward as fast_forward_module,
+        )
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            TinyA2DAttention_fast_forward,
+        )
+        from unturtle.utils import attention_dispatch
+
+        captured = {}
+
+        def _capture_backend(use_varlen=False, *, device_type):
+            captured["use_varlen"] = use_varlen
+            captured["device_type"] = device_type
+            return attention_dispatch.SDPA
+
+        monkeypatch.setattr(
+            fast_forward_module, "select_attention_backend", _capture_backend
+        )
+
+        _install_apply_stubs(tiny_model)
+        attn = tiny_model.model.layers[0].self_attn
+        attn.forward = types.MethodType(TinyA2DAttention_fast_forward, attn)
+
+        hidden = torch.randn(1, 4, tiny_model.config.hidden_size)
+        out, weights = attn(hidden)
+
+        assert out.shape == (1, 4, tiny_model.config.hidden_size)
+        assert weights is None
+        assert captured == {"use_varlen": False, "device_type": "cpu"}
+
+    def test_bidirectional_attends_to_future_tokens(self, tiny_config):
+        """A bidirectional model's output at position 0 should depend on
+        tokens at positions 1+.  We verify this by comparing outputs with
+        two sequences that differ only at position L-1: a truly causal model
+        would produce identical output at position 0, a bidirectional model
+        would produce different output.
+        """
+        import types
+
+        from unturtle.fast_diffusion_model import _install_apply_stubs
+        from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DLlamaLMHeadModel
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            TinyA2DAttention_fast_forward,
+        )
+
+        model = TinyA2DLlamaLMHeadModel(tiny_config)
+        model.eval()
+        _install_apply_stubs(model)
+
+        # Patch all attention layers
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                TinyA2DAttention_fast_forward, layer.self_attn
+            )
+
+        B, L = 1, 8
+        # Two sequences identical everywhere except position L-1
+        ids_a = torch.randint(0, tiny_config.vocab_size, (B, L))
+        ids_b = ids_a.clone()
+        ids_b[0, -1] = (ids_a[0, -1] + 1) % tiny_config.vocab_size
+
+        with torch.no_grad():
+            out_a = model(ids_a).logits
+            out_b = model(ids_b).logits
+
+        # Position 0 output should differ because model sees future token
+        assert not torch.allclose(out_a[:, 0, :], out_b[:, 0, :]), (
+            "Position 0 outputs are identical — attention appears to be causal!"
+        )
+
+
+# ---------------------------------------------------------------------------
+# FastDiffusionModel.get_peft_model (CPU, no GPU kernel execution)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPeftModel:
+    def test_peft_model_wraps_base(self, tiny_model):
+        """get_peft_model returns a PEFT-wrapped model."""
+        from peft import PeftModel
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+                "gate_proj",
+                "up_proj",
+                "down_proj",
+            ],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        assert isinstance(peft_model, PeftModel)
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton kernels require CUDA"
+    )
+    def test_apply_qkv_patched_to_lora(self, tiny_model):
+        """After get_peft_model, apply_qkv on attention layers should be
+        apply_lora_qkv (the Triton kernel) when lora_dropout=0 and bias='none'.
+        """
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.kernels.fast_lora import apply_lora_qkv
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_model.cuda(),
+            r=4,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+                "gate_proj",
+                "up_proj",
+                "down_proj",
+            ],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        for layer in peft_model.base_model.model.model.layers:
+            assert layer.self_attn.apply_qkv is apply_lora_qkv, (
+                f"apply_qkv not patched to apply_lora_qkv: {layer.self_attn.apply_qkv}"
+            )
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton kernels require CUDA"
+    )
+    def test_apply_o_patched_to_lora(self, tiny_model):
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.kernels.fast_lora import apply_lora_o
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_model.cuda(),
+            r=4,
+            target_modules=[
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+                "gate_proj",
+                "up_proj",
+                "down_proj",
+            ],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        for layer in peft_model.base_model.model.model.layers:
+            assert layer.self_attn.apply_o is apply_lora_o, (
+                f"apply_o not patched to apply_lora_o: {layer.self_attn.apply_o}"
+            )
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton kernels require CUDA"
+    )
+    def test_fast_attn_forward_injected(self, tiny_model):
+        """Attention forward should be replaced with TinyA2DAttention_fast_forward."""
+        import types
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
+            TinyA2DAttention_fast_forward,
+        )
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_model.cuda(),
+            r=4,
+            target_modules=["q_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        for layer in peft_model.base_model.model.model.layers:
+            forward_fn = layer.self_attn.forward
+            # types.MethodType wraps the function — extract __func__
+            if isinstance(forward_fn, types.MethodType):
+                forward_fn = forward_fn.__func__
+            assert forward_fn is TinyA2DAttention_fast_forward
+
+    def test_peft_model_forward_runs(self, tiny_model):
+        """Forward pass through a PEFT-wrapped dLLM should not raise."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        peft_model.eval()
+
+        B, L = 2, 8
+        input_ids = torch.randint(0, tiny_model.config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = peft_model(input_ids)
+        assert out.logits.shape == (B, L, tiny_model.config.vocab_size)
+
+    def test_peft_model_with_gc_keeps_grad_flow(self, tiny_model):
+        """Non-quantized LoRA + gradient checkpointing should preserve backward."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=True,
+        )
+        peft_model.train()
+
+        B, L = 2, 8
+        input_ids = torch.randint(0, tiny_model.config.vocab_size, (B, L))
+        logits = peft_model(input_ids).logits
+
+        assert logits.requires_grad
+
+        loss = logits.sum()
+        loss.backward()
+
+        lora_params = [
+            param for name, param in peft_model.named_parameters() if "lora_" in name
+        ]
+        assert lora_params
+        assert any(param.grad is not None for param in lora_params)
+
+    def test_peft_save_load_roundtrip(self, tiny_model, tmp_path):
+        """LoRA adapter weights can be saved and reloaded."""
+        from peft import PeftModel
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=["q_proj", "v_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        save_dir = tmp_path / "adapter"
+        peft_model.save_pretrained(str(save_dir))
+
+        # Reload onto fresh base model
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DLlamaConfig,
+            TinyA2DLlamaLMHeadModel,
+        )
+
+        base = TinyA2DLlamaLMHeadModel(tiny_model.config)
+        loaded = PeftModel.from_pretrained(base, str(save_dir))
+        assert loaded is not None
+
+        # Shape of reloaded LoRA A should match original
+        orig_lora_A = (
+            peft_model.base_model.model.model.layers[0]
+            .self_attn.q_proj.lora_A["default"]
+            .weight
+        )
+        loaded_lora_A = (
+            loaded.base_model.model.model.layers[0]
+            .self_attn.q_proj.lora_A["default"]
+            .weight
+        )
+        assert orig_lora_A.shape == loaded_lora_A.shape
+        assert torch.allclose(orig_lora_A, loaded_lora_A)
+
+
+# ---------------------------------------------------------------------------
+# Dream model patching
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tiny_dream_config():
+    from unturtle.models.backbones.dream.configuration_dream import DreamConfig
+
+    return DreamConfig(
+        vocab_size=512,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=64,
+        mask_token_id=1,
+        pad_token_id=0,
+    )
+
+
+@pytest.fixture
+def tiny_dream_model(tiny_dream_config):
+    from unturtle.models.backbones.dream.modeling_dream import DreamModel
+
+    model = DreamModel(tiny_dream_config)
+    model.eval()
+    return model
+
+
+# ---------------------------------------------------------------------------
+# LoRA_QKV_Bias kernel unit tests
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# FastDiffusionModel.from_pretrained improvements
+# ---------------------------------------------------------------------------
+
+
+class TestFromPretrained:
+    """Tests for the improved from_pretrained helper functions."""
+
+    def test_dtype_cpu_fallback(self):
+        """On CPU (no CUDA), dtype should default to float32."""
+        import unittest.mock as mock
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DLlamaConfig,
+            TinyA2DLlamaLMHeadModel,
+        )
+
+        config = TinyA2DLlamaConfig(
+            vocab_size=512,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            max_position_embeddings=32,
+        )
+        base_model = TinyA2DLlamaLMHeadModel(config)
+
+        # Patch from_pretrained to return our tiny model
+        with (
+            mock.patch.object(
+                TinyA2DLlamaLMHeadModel, "from_pretrained", return_value=base_model
+            ),
+            mock.patch("torch.cuda.is_available", return_value=False),
+        ):
+            model, _ = FastDiffusionModel.from_pretrained(
+                "dummy-path",
+                model_class=TinyA2DLlamaLMHeadModel,
+                load_in_4bit=False,
+            )
+        # Float32 default on CPU
+        assert model is base_model
+
+    def test_max_seq_length_set(self):
+        """from_pretrained sets max_seq_length on model and nested modules."""
+        import unittest.mock as mock
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DLlamaConfig,
+            TinyA2DLlamaLMHeadModel,
+        )
+
+        config = TinyA2DLlamaConfig(
+            vocab_size=512,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            max_position_embeddings=32,
+        )
+        base_model = TinyA2DLlamaLMHeadModel(config)
+
+        with (
+            mock.patch.object(
+                TinyA2DLlamaLMHeadModel, "from_pretrained", return_value=base_model
+            ),
+            mock.patch("torch.cuda.is_available", return_value=False),
+        ):
+            model, _ = FastDiffusionModel.from_pretrained(
+                "dummy-path",
+                max_seq_length=128,
+                model_class=TinyA2DLlamaLMHeadModel,
+                load_in_4bit=False,
+            )
+        assert model.max_seq_length == 128
+
+    def test_apply_stubs_installed(self):
+        """from_pretrained installs apply_qkv / apply_o stubs."""
+        import unittest.mock as mock
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DLlamaConfig,
+            TinyA2DLlamaLMHeadModel,
+        )
+
+        config = TinyA2DLlamaConfig(
+            vocab_size=512,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            max_position_embeddings=32,
+        )
+        base_model = TinyA2DLlamaLMHeadModel(config)
+
+        with (
+            mock.patch.object(
+                TinyA2DLlamaLMHeadModel, "from_pretrained", return_value=base_model
+            ),
+            mock.patch("torch.cuda.is_available", return_value=False),
+        ):
+            model, _ = FastDiffusionModel.from_pretrained(
+                "dummy-path",
+                model_class=TinyA2DLlamaLMHeadModel,
+                load_in_4bit=False,
+            )
+        for layer in model.model.layers:
+            assert hasattr(layer.self_attn, "apply_qkv")
+            assert hasattr(layer.self_attn, "apply_o")
+
+    def test_tokenizer_warning_on_missing(self):
+        """Missing tokenizer emits a UserWarning instead of silently returning None."""
+        import unittest.mock as mock
+        import warnings
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DLlamaConfig,
+            TinyA2DLlamaLMHeadModel,
+        )
+
+        config = TinyA2DLlamaConfig(
+            vocab_size=512,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            max_position_embeddings=32,
+        )
+        base_model = TinyA2DLlamaLMHeadModel(config)
+
+        with (
+            mock.patch.object(
+                TinyA2DLlamaLMHeadModel, "from_pretrained", return_value=base_model
+            ),
+            mock.patch("torch.cuda.is_available", return_value=False),
+            mock.patch(
+                "unturtle.fast_diffusion_model.AutoTokenizer.from_pretrained",
+                side_effect=OSError("no tokenizer files"),
+            ),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            model, tokenizer = FastDiffusionModel.from_pretrained(
+                "dummy-path",
+                model_class=TinyA2DLlamaLMHeadModel,
+                load_in_4bit=False,
+            )
+        assert tokenizer is None
+        assert any("tokenizer" in str(warning.message).lower() for warning in w)
+
+
+class TestLoRAQKVBias:
+    """Unit tests for the LoRA_QKV_Bias autograd function."""
+
+    def test_output_shapes(self):
+        """LoRA_QKV_Bias.apply returns three tensors with correct shapes."""
+        from unturtle.kernels.fast_lora import LoRA_QKV_Bias
+
+        B, L, D, R = 2, 8, 32, 4
+        X = torch.randn(B, L, D, requires_grad=True)
+        # Simulate (W, W_quant=None, A, B, S, bias) for Q, K, V
+        QW = torch.randn(D, D)
+        KW = torch.randn(D, D)
+        VW = torch.randn(D, D)
+        QA = torch.randn(R, D)
+        QB = torch.randn(D, R)
+        KA = torch.randn(R, D)
+        KB = torch.randn(D, R)
+        VA = torch.randn(R, D)
+        VB = torch.randn(D, R)
+        QBias = torch.randn(D)
+        KBias = torch.randn(D)
+        VBias = torch.randn(D)
+        scale = 1.0
+
+        Q, K, V = LoRA_QKV_Bias.apply(
+            X,
+            QW,
+            None,
+            QA,
+            QB,
+            scale,
+            QBias,
+            KW,
+            None,
+            KA,
+            KB,
+            scale,
+            KBias,
+            VW,
+            None,
+            VA,
+            VB,
+            scale,
+            VBias,
+            False,
+        )
+        assert Q.shape == (B, L, D)
+        assert K.shape == (B, L, D)
+        assert V.shape == (B, L, D)
+
+    def test_bias_is_applied(self):
+        """Setting bias to a constant vector shifts all outputs by that vector."""
+        from unturtle.kernels.fast_lora import LoRA_QKV_Bias
+
+        B, L, D, R = 1, 4, 16, 2
+        X = torch.zeros(B, L, D)  # zero input → W*0 = 0
+        W = torch.eye(D)
+        A = torch.zeros(R, D)
+        Bmat = torch.zeros(D, R)
+        bias = torch.ones(D) * 5.0
+        scale = 1.0
+
+        Q, K, V = LoRA_QKV_Bias.apply(
+            X,
+            W,
+            None,
+            A,
+            Bmat,
+            scale,
+            bias,
+            W,
+            None,
+            A,
+            Bmat,
+            scale,
+            bias,
+            W,
+            None,
+            A,
+            Bmat,
+            scale,
+            bias,
+            False,
+        )
+        # With zero input and eye weight: W@X=0, LoRA=0, so output = bias
+        assert torch.allclose(Q, torch.ones(B, L, D) * 5.0)
+        assert torch.allclose(K, torch.ones(B, L, D) * 5.0)
+        assert torch.allclose(V, torch.ones(B, L, D) * 5.0)
+
+    def test_backward_runs(self):
+        """Backward pass through LoRA_QKV_Bias should not raise."""
+        from unturtle.kernels.fast_lora import LoRA_QKV_Bias
+
+        B, L, D, R = 2, 4, 16, 2
+        X = torch.randn(B, L, D, requires_grad=True)
+        QW = torch.randn(D, D, requires_grad=False)
+        QA = torch.randn(R, D, requires_grad=True)
+        QB = torch.randn(D, R, requires_grad=True)
+        QBias = torch.randn(D, requires_grad=True)
+        scale = 1.0
+
+        Q, K, V = LoRA_QKV_Bias.apply(
+            X,
+            QW,
+            None,
+            QA,
+            QB,
+            scale,
+            QBias,
+            QW,
+            None,
+            QA,
+            QB,
+            scale,
+            QBias,
+            QW,
+            None,
+            QA,
+            QB,
+            scale,
+            QBias,
+            False,
+        )
+        loss = (Q + K + V).sum()
+        loss.backward()
+
+        assert X.grad is not None
+        assert QA.grad is not None
+        assert QB.grad is not None
+        assert QBias.grad is not None
+
+
+class TestDreamPatching:
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton kernels require CUDA"
+    )
+    def test_dream_peft_o_proj_patched(self, tiny_dream_model):
+        """After get_peft_model, o_proj layers should have apply_o=apply_lora_o."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.kernels.fast_lora import apply_lora_o
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_dream_model.cuda(),
+            r=4,
+            target_modules=["o_proj", "gate_proj", "up_proj", "down_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        for layer in peft_model.base_model.model.model.layers:
+            assert layer.self_attn.apply_o is apply_lora_o, (
+                f"apply_o not patched: {layer.self_attn.apply_o}"
+            )
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton kernels require CUDA"
+    )
+    def test_dream_peft_qkv_uses_bias_kernel(self, tiny_dream_model):
+        """Dream q/k/v_proj (bias=True) should use apply_lora_qkv_with_bias."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.kernels.fast_lora import apply_lora_qkv_with_bias
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_dream_model.cuda(),
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        for layer in peft_model.base_model.model.model.layers:
+            assert layer.self_attn.apply_qkv is apply_lora_qkv_with_bias, (
+                f"apply_qkv not set to apply_lora_qkv_with_bias: {layer.self_attn.apply_qkv}"
+            )
+
+    def test_dream_peft_forward_runs(self, tiny_dream_model):
+        """Forward pass through a PEFT-wrapped Dream model should not raise."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_dream_model,
+            r=4,
+            target_modules=["o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        peft_model.eval()
+
+        B, L = 2, 8
+        input_ids = torch.randint(0, tiny_dream_model.config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = peft_model(input_ids=input_ids)
+        # DreamModel returns MaskedLMOutput with logits
+        assert out.logits.shape == (B, L, tiny_dream_model.config.vocab_size)
+
+
+# ---------------------------------------------------------------------------
+# LLaDA model patching
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tiny_llada_config():
+    from unturtle.models.backbones.llada.configuration_llada import LLaDAConfig
+
+    return LLaDAConfig(
+        d_model=64,
+        n_heads=4,
+        n_layers=2,
+        mlp_hidden_size=128,
+        vocab_size=512,
+        embedding_size=512,
+        max_sequence_length=64,
+        block_type="llama",
+        activation_type="silu",  # LLaDALlamaBlock does gate*up with silu (not swiglu split)
+        rope=True,
+        include_bias=False,
+        include_qkv_bias=False,
+        weight_tying=False,
+    )
+
+
+@pytest.fixture
+def tiny_llada_model(tiny_llada_config):
+    from unturtle.models.backbones.llada.modeling_llada import LLaDAModelLM
+
+    model = LLaDAModelLM(tiny_llada_config)
+    model.eval()
+    return model
+
+
+class TestLLaDAPatching:
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton kernels require CUDA"
+    )
+    def test_llada_peft_attn_out_patched(self, tiny_llada_model):
+        """After get_peft_model, attn_out in LLaDALlamaBlocks should have apply_o=apply_lora_o."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.kernels.fast_lora import apply_lora_o
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_llada_model.cuda(),
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "attn_out"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        from unturtle.models.backbones.llada.modeling_llada import LLaDALlamaBlock
+
+        # LLaDAModelLM wraps LLaDAModel in self.model
+        blocks = peft_model.base_model.model.model.transformer.blocks
+        for block in blocks:
+            if isinstance(block, LLaDALlamaBlock):
+                assert block.apply_o is apply_lora_o, (
+                    f"apply_o not patched on LLaDALlamaBlock: {block.apply_o}"
+                )
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Triton kernels require CUDA"
+    )
+    def test_llada_peft_qkv_patched(self, tiny_llada_model):
+        """LLaDALlamaBlock q/k/v_proj without bias should get apply_qkv=apply_lora_qkv."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.kernels.fast_lora import apply_lora_qkv
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_llada_model.cuda(),
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "attn_out"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        from unturtle.models.backbones.llada.modeling_llada import LLaDALlamaBlock
+
+        # LLaDAModelLM wraps LLaDAModel in self.model
+        blocks = peft_model.base_model.model.model.transformer.blocks
+        for block in blocks:
+            if isinstance(block, LLaDALlamaBlock):
+                assert block.apply_qkv is apply_lora_qkv, (
+                    f"apply_qkv not patched on LLaDALlamaBlock: {block.apply_qkv}"
+                )
+
+    def test_llada_peft_forward_runs(self, tiny_llada_model):
+        """Forward pass through a PEFT-wrapped LLaDA model should not raise."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_llada_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "attn_out"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        peft_model.eval()
+
+        B, L = 2, 8
+        input_ids = torch.randint(0, tiny_llada_model.config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = peft_model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, tiny_llada_model.config.vocab_size)
+
+
+# ---------------------------------------------------------------------------
+# TestInferenceTrainingMethods — for_inference / for_training / inference_context
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceTrainingMethods:
+    """Tests for FastDiffusionModel.for_inference, for_training, inference_context."""
+
+    def test_for_inference_sets_eval(self, tiny_model):
+        """for_inference puts model in eval mode."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.train()
+        assert tiny_model.training
+        FastDiffusionModel.for_inference(tiny_model)
+        assert not tiny_model.training
+
+    def test_for_inference_returns_model(self, tiny_model):
+        """for_inference returns the same model object."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        returned = FastDiffusionModel.for_inference(tiny_model)
+        assert returned is tiny_model
+
+    def test_for_training_sets_train(self, tiny_model):
+        """for_training puts model in training mode."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.eval()
+        assert not tiny_model.training
+        FastDiffusionModel.for_training(tiny_model, use_gradient_checkpointing=False)
+        assert tiny_model.training
+
+    def test_for_training_returns_model(self, tiny_model):
+        """for_training returns the same model object."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        returned = FastDiffusionModel.for_training(
+            tiny_model, use_gradient_checkpointing=False
+        )
+        assert returned is tiny_model
+
+    def test_inference_context_restores_train_mode(self, tiny_model):
+        """inference_context restores training mode on exit."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.train()
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert not tiny_model.training  # eval inside context
+        assert tiny_model.training  # restored after exit
+
+    def test_inference_context_stays_eval_if_was_eval(self, tiny_model):
+        """inference_context does not flip to train if model was already in eval."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.eval()
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert not tiny_model.training
+        assert not tiny_model.training  # stays eval
+
+    def test_inference_context_no_grad(self, tiny_model):
+        """Inside inference_context, gradients are disabled."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.eval()
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert not torch.is_grad_enabled()
+
+    def test_inference_context_restores_gc_mode_false(self, tiny_model):
+        """inference_context should restore False GC mode exactly."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model._unturtle_gradient_checkpointing_mode = False
+        tiny_model.train()
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert _all_gc_flags_false(tiny_model)
+        assert tiny_model.training
+        assert tiny_model._unturtle_gradient_checkpointing_mode is False
+        assert _all_gc_flags_false(tiny_model)
+
+    def test_inference_context_restores_gc_mode_unsloth(self, tiny_model):
+        """inference_context should preserve the symbolic 'unsloth' mode."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.for_training(
+            tiny_model, use_gradient_checkpointing="unsloth"
+        )
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert _all_gc_flags_false(tiny_model)
+        assert tiny_model._unturtle_gradient_checkpointing_mode == "unsloth"
+        assert _all_gc_flags_true(tiny_model)
+
+    def test_inference_context_restores_state_on_exception(self, tiny_model):
+        """inference_context should restore mode/state even if body raises."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.for_training(tiny_model, use_gradient_checkpointing=False)
+        with (
+            pytest.raises(RuntimeError, match="boom"),
+            FastDiffusionModel.inference_context(tiny_model),
+        ):
+            raise RuntimeError("boom")
+        assert tiny_model.training
+        assert tiny_model._unturtle_gradient_checkpointing_mode is False
+        assert _all_gc_flags_false(tiny_model)
+
+    def test_for_training_preserves_requested_unsloth_mode(self, tiny_model):
+        """for_training should remember symbolic unsloth mode for later restore."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.for_training(
+            tiny_model, use_gradient_checkpointing="unsloth"
+        )
+        assert tiny_model._unturtle_gradient_checkpointing_mode == "unsloth"
+        assert _all_gc_flags_true(tiny_model)
+
+
+# ---------------------------------------------------------------------------
+# TestSavePretrainedMerged — save_pretrained_merged
+# ---------------------------------------------------------------------------
+
+
+class TestSavePretrainedMerged:
+    """Tests for FastDiffusionModel.save_pretrained_merged."""
+
+    @pytest.fixture
+    def peft_model(self, tiny_model):
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        return FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+
+    def test_save_creates_directory(self, peft_model, tmp_path):
+        """save_pretrained_merged writes files to the given directory."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        save_dir = tmp_path / "merged"
+        FastDiffusionModel.save_pretrained_merged(peft_model, str(save_dir))
+        # Should contain at least a config and a weight file
+        assert save_dir.exists()
+        assert (save_dir / "config.json").exists()
+        files = list(save_dir.iterdir())
+        assert len(files) >= 2
+
+    def test_save_does_not_modify_original(self, peft_model, tmp_path):
+        """save_pretrained_merged leaves adapter weights on the original model intact."""
+        from peft import PeftModel
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        adapter_weights_before = {
+            name: param.detach().clone()
+            for name, param in peft_model.named_parameters()
+            if "lora_" in name
+        }
+
+        save_dir = tmp_path / "merged2"
+        FastDiffusionModel.save_pretrained_merged(peft_model, str(save_dir))
+
+        assert isinstance(peft_model, PeftModel)
+        adapter_weights_after = {
+            name: param.detach().clone()
+            for name, param in peft_model.named_parameters()
+            if "lora_" in name
+        }
+        assert adapter_weights_before.keys() == adapter_weights_after.keys()
+        for name in adapter_weights_before:
+            assert torch.equal(
+                adapter_weights_before[name], adapter_weights_after[name]
+            )
+
+    def test_save_with_tokenizer(self, peft_model, tmp_path):
+        """save_pretrained_merged saves tokenizer when provided."""
+        from unittest.mock import MagicMock
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        mock_tokenizer = MagicMock()
+        save_dir = tmp_path / "merged3"
+        FastDiffusionModel.save_pretrained_merged(
+            peft_model, str(save_dir), tokenizer=mock_tokenizer
+        )
+        mock_tokenizer.save_pretrained.assert_called_once_with(str(save_dir))
+
+
+class TestPushToHubMerged:
+    """Tests for FastDiffusionModel.push_to_hub_merged."""
+
+    @pytest.fixture
+    def peft_model(self, tiny_model):
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        return FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+
+    def test_push_forwards_kwargs_to_model_and_tokenizer(self, peft_model, monkeypatch):
+        """push_to_hub_merged should forward the same Hub kwargs to tokenizer."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        pushed = {}
+
+        def fake_deepcopy(obj):
+            merged = MagicMock()
+            merged_base = MagicMock()
+            merged.merge_and_unload.return_value = merged_base
+            pushed["merged_base"] = merged_base
+            return merged
+
+        monkeypatch.setattr("copy.deepcopy", fake_deepcopy)
+
+        tokenizer = MagicMock()
+        FastDiffusionModel.push_to_hub_merged(
+            peft_model,
+            "user/repo",
+            tokenizer=tokenizer,
+            token="hf_xxx",
+            revision="main",
+            private=True,
+            create_pr=True,
+            commit_message="test commit",
+        )
+
+        pushed["merged_base"].push_to_hub.assert_called_once_with(
+            "user/repo",
+            safe_serialization=True,
+            token="hf_xxx",
+            revision="main",
+            private=True,
+            create_pr=True,
+            commit_message="test commit",
+        )
+        tokenizer.push_to_hub.assert_called_once_with(
+            "user/repo",
+            safe_serialization=True,
+            token="hf_xxx",
+            revision="main",
+            private=True,
+            create_pr=True,
+            commit_message="test commit",
+        )
+
+
+def _all_gc_flags_false(model):
+    flags = [
+        m.gradient_checkpointing
+        for m in model.modules()
+        if hasattr(m, "gradient_checkpointing")
+    ]
+    return all(flag is False for flag in flags)
+
+
+def _all_gc_flags_true(model):
+    flags = [
+        m.gradient_checkpointing
+        for m in model.modules()
+        if hasattr(m, "gradient_checkpointing")
+    ]
+    return all(flag is True for flag in flags)
+
+
+# ---------------------------------------------------------------------------
+# ModernBERT PEFT patching tests
+# ---------------------------------------------------------------------------
+
+
+def _tiny_modernbert_config():
+    from unturtle.models.backbones.modernbert import A2DModernBertConfig
+
+    return A2DModernBertConfig(
+        vocab_size=1000,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        max_position_embeddings=128,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        cls_token_id=1,
+        sep_token_id=2,
+    )
+
+
+class TestModernBertPeftPatching:
+    """CPU tests for _patch_modernbert_peft and ModernBertAttention_fast_forward."""
+
+    @pytest.fixture
+    def peft_model(self):
+        from peft import LoraConfig, TaskType, get_peft_model
+
+        from unturtle.models.backbones.modernbert import A2DModernBertForMaskedLM
+
+        config = _tiny_modernbert_config()
+        model = A2DModernBertForMaskedLM(config)
+        lora_config = LoraConfig(
+            r=4,
+            target_modules=["Wqkv", "Wo"],
+            task_type=TaskType.FEATURE_EXTRACTION,
+            lora_dropout=0,
+            bias="none",
+        )
+        return get_peft_model(model, lora_config)
+
+    def test_patch_peft_model_does_not_raise_on_cpu(self, peft_model):
+        """patch_peft_model must succeed on CPU (Triton skipped gracefully)."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.patch_peft_model(peft_model, lora_dropout=0, bias="none")
+
+    def test_fast_forward_injected_on_cuda(self, peft_model):
+        """ModernBertAttention_fast_forward must be injected on CUDA."""
+        pytest.importorskip("torch.cuda", reason="CUDA required")
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.backbones.modernbert._fast_forward import (
+            ModernBertAttention_fast_forward,
+        )
+
+        cuda_model = peft_model.cuda()
+        FastDiffusionModel.patch_peft_model(cuda_model, lora_dropout=0, bias="none")
+
+        for layer in cuda_model.base_model.model.model.layers:
+            assert layer.attn.forward.__func__ is ModernBertAttention_fast_forward, (
+                "ModernBertAttention_fast_forward was not injected on CUDA"
+            )
+
+    def test_forward_logits_shape_after_patch_cpu(self, peft_model):
+        """Forward pass shape is correct after CPU patch (fast_forward not injected)."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.patch_peft_model(peft_model, lora_dropout=0, bias="none")
+        peft_model.eval()
+        B, L = 2, 16
+        input_ids = torch.randint(3, 1000, (B, L))
+        with torch.no_grad():
+            out = peft_model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, 1000)
+
+    def test_apply_wo_stub_installed(self, peft_model):
+        """apply_wo stubs must be present after patching."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.backbones.modernbert._fast_forward import (
+            _original_apply_wo,
+        )
+
+        FastDiffusionModel.patch_peft_model(peft_model, lora_dropout=0, bias="none")
+        for layer in peft_model.base_model.model.model.layers:
+            assert hasattr(layer.attn, "apply_wo"), "apply_wo stub missing after patch"
+
+
+# ---------------------------------------------------------------------------
+# Issue #134: FastDiffusionModel.save_pretrained_gguf
+# ---------------------------------------------------------------------------
+
+
+class TestSavePretrainedGguf:
+    """Tests for FastDiffusionModel.save_pretrained_gguf (Issue #134)."""
+
+    def test_applies_patch_and_delegates(self, monkeypatch):
+        """save_pretrained_gguf calls patch_saving_functions then model.save_pretrained_gguf."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        patched = {}
+        # patch_saving_functions is imported inside save_pretrained_gguf via
+        # `from unturtle.save import patch_saving_functions`, so we must patch
+        # the canonical location in unturtle.save.
+        monkeypatch.setattr(
+            "unturtle.save.patch_saving_functions",
+            lambda m: patched.setdefault("model", m),
+        )
+
+        fake_model = MagicMock()
+        fake_model.save_pretrained_gguf = MagicMock()
+
+        FastDiffusionModel.save_pretrained_gguf(
+            fake_model, "/tmp/out", tokenizer="tok", quantization_method="q8_0"
+        )
+
+        assert patched["model"] is fake_model
+        fake_model.save_pretrained_gguf.assert_called_once_with(
+            "/tmp/out", "tok", quantization_method="q8_0"
+        )
+
+    def test_raises_runtime_error_when_patch_unavailable(self, monkeypatch):
+        """Raises RuntimeError when patch_saving_functions does not inject the method."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        # save_pretrained_gguf does `from unturtle.save import patch_saving_functions`
+        # at call time, so we must patch the canonical binding in unturtle.save.
+        monkeypatch.setattr(
+            "unturtle.save.patch_saving_functions",
+            lambda m: None,  # no-op — does NOT add save_pretrained_gguf
+        )
+
+        fake_model = MagicMock(
+            spec=[]
+        )  # spec=[] means no attributes, incl. no gguf method
+        with pytest.raises(RuntimeError, match="save_pretrained_gguf is not available"):
+            FastDiffusionModel.save_pretrained_gguf(
+                fake_model, "/tmp/out", tokenizer=None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Issue #135: FastDiffusionModel.save_lora_adapter
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLORAAdapter:
+    """Tests for FastDiffusionModel.save_lora_adapter (Issue #135)."""
+
+    @pytest.fixture
+    def peft_model(self, tiny_model):
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        return FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+
+    def test_raises_value_error_for_non_peft_model(self, tiny_model, tmp_path):
+        """Passing a non-PEFT model raises ValueError."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        with pytest.raises(ValueError, match="requires a PEFT-wrapped model"):
+            FastDiffusionModel.save_lora_adapter(tiny_model, str(tmp_path / "adapter"))
+
+    def test_saves_adapter_files(self, peft_model, tmp_path):
+        """save_lora_adapter writes adapter_config.json and adapter weights."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        save_dir = tmp_path / "adapter"
+        FastDiffusionModel.save_lora_adapter(peft_model, str(save_dir))
+
+        assert save_dir.exists()
+        assert (save_dir / "adapter_config.json").exists()
+
+    def test_saves_tokenizer_when_provided(self, peft_model, tmp_path):
+        """save_lora_adapter calls tokenizer.save_pretrained when tokenizer is given."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        mock_tokenizer = MagicMock()
+        save_dir = tmp_path / "adapter_tok"
+        FastDiffusionModel.save_lora_adapter(
+            peft_model, str(save_dir), tokenizer=mock_tokenizer
+        )
+        mock_tokenizer.save_pretrained.assert_called_once_with(str(save_dir))
+
+    def test_no_tokenizer_save_when_none(self, peft_model, tmp_path):
+        """save_lora_adapter does not call tokenizer.save_pretrained when tokenizer=None."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        save_dir = tmp_path / "adapter_notok"
+        FastDiffusionModel.save_lora_adapter(peft_model, str(save_dir), tokenizer=None)
+        # tokenizer=None: no tokenizer files (tokenizer.json, tokenizer_config.json, etc.)
+        tokenizer_files = list(save_dir.glob("tokenizer*"))
+        assert tokenizer_files == [], (
+            f"Expected no tokenizer files, got: {tokenizer_files}"
+        )
+        # Adapter files must still be written
+        assert (save_dir / "adapter_config.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Issue #136: FastDiffusionModel.from_pretrained — PEFT adapter detection
+# ---------------------------------------------------------------------------
+
+
+class TestFromPretrainedAdapterDetection:
+    """Tests for PEFT adapter checkpoint detection in from_pretrained (Issue #136).
+
+    The two-stage load path (base model load + PeftModel.from_pretrained) requires
+    network access, so those tests only cover the detection and error logic that
+    runs before any HF Hub call.
+    """
+
+    def test_raises_value_error_when_base_model_missing_from_adapter_config(
+        self, tmp_path
+    ):
+        """Raises ValueError when adapter_config.json has no base_model_name_or_path."""
+        import json
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        adapter_dir = tmp_path / "bad_adapter"
+        adapter_dir.mkdir()
+        (adapter_dir / "adapter_config.json").write_text(
+            json.dumps({}), encoding="utf-8"
+        )
+
+        with pytest.raises(ValueError, match="base_model_name_or_path"):
+            FastDiffusionModel.from_pretrained(str(adapter_dir), load_in_4bit=False)
+
+    def test_skips_adapter_detection_when_full_weights_present(self, tmp_path):
+        """Full model weights alongside adapter_config.json bypasses adapter path."""
+        import json
+        from unittest.mock import patch
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        model_dir = tmp_path / "full_model"
+        model_dir.mkdir()
+        (model_dir / "adapter_config.json").write_text(
+            json.dumps({"base_model_name_or_path": "hf/base"}), encoding="utf-8"
+        )
+        # Presence of model.safetensors marks this as a full-weight directory
+        (model_dir / "model.safetensors").write_bytes(b"")
+
+        # _load_model_auto is a module-level function called from from_pretrained
+        # when the adapter detection path is correctly skipped.
+        with (
+            patch(
+                "unturtle.fast_diffusion_model._load_model_auto",
+                side_effect=RuntimeError("reached full-weight load path"),
+            ),
+            pytest.raises(RuntimeError, match="reached full-weight load path"),
+        ):
+            FastDiffusionModel.from_pretrained(str(model_dir), load_in_4bit=False)
+
+    def test_skips_adapter_detection_for_sharded_safetensors(self, tmp_path):
+        """Sharded safetensors checkpoint is not treated as an adapter-only directory."""
+        import json
+        from unittest.mock import patch
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        model_dir = tmp_path / "sharded"
+        model_dir.mkdir()
+        (model_dir / "adapter_config.json").write_text(
+            json.dumps({"base_model_name_or_path": "hf/base"}), encoding="utf-8"
+        )
+        # Sharded checkpoints have an index file and shard files, not model.safetensors
+        (model_dir / "model.safetensors.index.json").write_bytes(b"{}")
+        (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"")
+
+        with (
+            patch(
+                "unturtle.fast_diffusion_model._load_model_auto",
+                side_effect=RuntimeError("reached full-weight load path"),
+            ),
+            pytest.raises(RuntimeError, match="reached full-weight load path"),
+        ):
+            FastDiffusionModel.from_pretrained(str(model_dir), load_in_4bit=False)
+
+    def test_two_stage_load_calls_peft_from_pretrained(self, tmp_path, tiny_model):
+        """adapter_config.json detection triggers recursive base-model load + PeftModel wrap.
+
+        The detection code in from_pretrained (lines ~769-810) does:
+          1. Reads base_model_name_or_path from adapter_config.json
+          2. Calls FastDiffusionModel.from_pretrained(base_model_id, ...) recursively
+          3. Calls PeftModel.from_pretrained(base_model, adapter_dir)
+          4. Returns (peft_wrapped_model, tokenizer)
+
+        To exercise the real detection branch without a network call, we intercept
+        the *recursive* call to from_pretrained by patching _load_model_auto (which
+        only runs for a non-adapter HF id, not for the adapter dir path).  The
+        local `from peft import PeftModel` inside the branch is intercepted by
+        patching the attribute directly on the already-imported peft module —
+        avoiding sys.modules replacement which interacts poorly with peft's
+        internal import machinery.
+        """
+        import json
+        from unittest.mock import MagicMock, patch
+
+        import peft as _peft_mod
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        adapter_dir = tmp_path / "my_adapter"
+        adapter_dir.mkdir()
+        (adapter_dir / "adapter_config.json").write_text(
+            json.dumps({"base_model_name_or_path": "hf/base-model"}), encoding="utf-8"
+        )
+
+        fake_tokenizer = MagicMock()
+        # Use spec to prevent hasattr from returning True for *every* attribute.
+        # _propagate_max_seq_length does `while hasattr(model, "model")` — a bare
+        # MagicMock would loop forever because MagicMock answers True for any attr.
+        fake_peft_model = MagicMock(
+            spec=[
+                "modules",
+                "named_modules",
+                "parameters",
+                "max_seq_length",
+            ]
+        )
+        fake_peft_model.modules.return_value = []
+        fake_peft_model.named_modules.return_value = []
+        fake_peft_model.parameters.return_value = iter([])
+
+        mock_peft_cls = MagicMock()
+        mock_peft_cls.from_pretrained.return_value = fake_peft_model
+
+        def fake_tokenizer_from_pretrained(name, **kw):
+            return fake_tokenizer
+
+        # Patch PeftModel on the already-imported peft module so that the
+        # `from peft import PeftModel as _PeftModel` inside from_pretrained
+        # resolves to our mock without triggering a fresh module import.
+        with (
+            patch.object(_peft_mod, "PeftModel", mock_peft_cls),
+            patch(
+                "unturtle.fast_diffusion_model._load_model_auto",
+                return_value=tiny_model,
+            ) as mock_load_auto,
+            patch(
+                "unturtle.fast_diffusion_model.AutoTokenizer.from_pretrained",
+                side_effect=fake_tokenizer_from_pretrained,
+            ),
+        ):
+            result_model, result_tok = FastDiffusionModel.from_pretrained(
+                str(adapter_dir),
+                max_seq_length=64,
+                load_in_4bit=False,
+            )
+
+        # _load_model_auto is called with the *base* model id, not the adapter dir
+        mock_load_auto.assert_called_once()
+        first_arg = mock_load_auto.call_args[0][0]
+        assert first_arg == "hf/base-model", (
+            f"Expected base model id, got {first_arg!r}"
+        )
+
+        # PeftModel.from_pretrained must be called with (base_model, adapter_dir)
+        mock_peft_cls.from_pretrained.assert_called_once_with(
+            tiny_model, str(adapter_dir)
+        )
+
+        # The returned model is the PEFT-wrapped model
+        assert result_model is fake_peft_model
+        assert result_tok is fake_tokenizer

--- a/unturtle/__init__.py
+++ b/unturtle/__init__.py
@@ -1,6 +1,89 @@
-"""Unturtle — dLLM method layer on top of unsloth."""
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unturtle — dLLM (Diffusion Language Model) method layer on top of unsloth.
+
+Unturtle is built on top of unsloth and depends on it permanently. We reuse
+unsloth's Triton kernels, model loading infrastructure, and optimizers, and
+concentrate Unturtle-specific value on diffusion-specific behavior:
+
+- bidirectional attention for Tiny-A2D / Dream / LLaDA / ModernBERT models
+- Triton-optimized masked diffusion loss
+- completion-only masking for SFT
+- dLLM generation utilities (MDLM denoising / block decode)
+"""
+
+# ============================================================================
+# Re-exported from unsloth (external dependency)
+# ============================================================================
+from unsloth import (
+    FastLanguageModel,
+    FastLlamaModel,
+    FastMistralModel,
+    FastQwen2Model,
+    FastQwen3Model,
+    PatchDPOTrainer,
+    PatchKTOTrainer,
+    UnslothTrainer,
+    UnslothTrainingArguments,
+    is_bf16_supported,
+    is_bfloat16_supported,
+)
+from unsloth.chat_templates import (
+    apply_chat_template,
+    get_chat_template,
+)
+from unsloth.save import (
+    patch_saving_functions,
+    save_to_gguf,
+    unsloth_save_model,
+)
+from unsloth.tokenizer_utils import (
+    check_tokenizer,
+    fix_sentencepiece_tokenizer,
+    get_tokenizer_info,
+    load_correct_tokenizer,
+)
+from unsloth.trainer import (
+    QGaloreConfig,
+    unsloth_train,
+)
 
 from unturtle._version import __version__
+
+# ============================================================================
+# Optimizers (re-exported from unsloth)
+# ============================================================================
+try:
+    from unsloth.optimizers import (
+        GaLoreProjector,
+        QGaLoreAdamW8bit,
+        UnslothAdamW,
+        UnslothAdamW8bit,
+        UnslothAdamWScheduleFree,
+    )
+except (ImportError, AttributeError):
+    # Older unsloth versions may not expose all optimizer symbols.
+    GaLoreProjector = None
+    QGaLoreAdamW8bit = None
+    UnslothAdamW = None
+    UnslothAdamW8bit = None
+    UnslothAdamWScheduleFree = None
+
+# ============================================================================
+# Unturtle-specific dLLM APIs
+# ============================================================================
 from unturtle.diffusion import (
     BaseAlphaScheduler,
     CosineAlphaScheduler,
@@ -18,10 +101,30 @@ from unturtle.eval import (
     GenerationEvaluator,
     MaskedDiffusionEvaluator,
 )
-from unturtle.kernels.fused_masked_diffusion_loss import fused_masked_diffusion_loss
-from unturtle.kernels.masked_diffusion_loss import (
-    fast_masked_diffusion_loss,
-    masked_diffusion_loss_from_timesteps,
+from unturtle.fast_diffusion_model import FastDiffusionModel
+from unturtle.models import (
+    A2DModernBertConfig,
+    A2DModernBertForMaskedLM,
+    A2DModernBertModel,
+    DiffusionModernBertConfig,
+    DiffusionModernBertForMaskedLM,
+    DiffusionModernBertModel,
+    DreamConfig,
+    DreamGenerationConfig,
+    DreamGenerationMixin,
+    DreamModel,
+    LLaDAConfig,
+    LLaDAModel,
+    LLaDAModelLM,
+    TinyA2DLlamaConfig,
+    TinyA2DLlamaLMHeadModel,
+    TinyA2DLlamaModel,
+    TinyA2DQwen2Config,
+    TinyA2DQwen2LMHeadModel,
+    TinyA2DQwen2Model,
+    TinyA2DQwen3Config,
+    TinyA2DQwen3LMHeadModel,
+    TinyA2DQwen3Model,
 )
 from unturtle.trainer import (
     UnturtleTrainer,
@@ -29,8 +132,55 @@ from unturtle.trainer import (
     unturtle_train,
 )
 
+DreamForDiffusionLM = DreamModel  # Alias for backward compatibility
+
+# Kernels (advanced users may import directly)
+from unturtle.kernels.fused_masked_diffusion_loss import (  # noqa: E402
+    fused_masked_diffusion_loss,
+)
+from unturtle.kernels.masked_diffusion_loss import (  # noqa: E402
+    fast_masked_diffusion_loss,
+    masked_diffusion_loss_from_timesteps,
+)
+
 __all__ = [
+    # Version
     "__version__",
+    # Re-exported from unsloth (core)
+    "FastLanguageModel",
+    "UnslothTrainer",
+    "UnslothTrainingArguments",
+    "is_bfloat16_supported",
+    "is_bf16_supported",
+    # Re-exported from unsloth (models)
+    "FastLlamaModel",
+    "FastMistralModel",
+    "FastQwen2Model",
+    "FastQwen3Model",
+    # Re-exported from unsloth (trainer patches)
+    "PatchDPOTrainer",
+    "PatchKTOTrainer",
+    # Re-exported from unsloth (tokenizer)
+    "check_tokenizer",
+    "fix_sentencepiece_tokenizer",
+    "load_correct_tokenizer",
+    "get_tokenizer_info",
+    # Re-exported from unsloth (chat templates)
+    "apply_chat_template",
+    "get_chat_template",
+    # Re-exported from unsloth (save/export)
+    "patch_saving_functions",
+    "unsloth_save_model",
+    "save_to_gguf",
+    # Re-exported from unsloth (training)
+    "unsloth_train",
+    "QGaloreConfig",
+    # Re-exported from unsloth (optimizers)
+    "GaLoreProjector",
+    "QGaLoreAdamW8bit",
+    "UnslothAdamW",
+    "UnslothAdamW8bit",
+    "UnslothAdamWScheduleFree",
     # dLLM training
     "DiffusionTrainer",
     "DiffusionTrainingArguments",
@@ -51,6 +201,32 @@ __all__ = [
     "BaseEvaluator",
     "GenerationEvaluator",
     "MaskedDiffusionEvaluator",
+    # fast model wrapper
+    "FastDiffusionModel",
+    # dLLM models
+    "TinyA2DLlamaConfig",
+    "TinyA2DLlamaModel",
+    "TinyA2DLlamaLMHeadModel",
+    "TinyA2DQwen2Config",
+    "TinyA2DQwen2Model",
+    "TinyA2DQwen2LMHeadModel",
+    "TinyA2DQwen3Config",
+    "TinyA2DQwen3Model",
+    "TinyA2DQwen3LMHeadModel",
+    "A2DModernBertConfig",
+    "A2DModernBertForMaskedLM",
+    "A2DModernBertModel",
+    "DiffusionModernBertConfig",
+    "DiffusionModernBertForMaskedLM",
+    "DiffusionModernBertModel",
+    "LLaDAConfig",
+    "LLaDAModel",
+    "LLaDAModelLM",
+    "DreamConfig",
+    "DreamModel",
+    "DreamGenerationMixin",
+    "DreamGenerationConfig",
+    "DreamForDiffusionLM",
     # kernels
     "fast_masked_diffusion_loss",
     "masked_diffusion_loss_from_timesteps",

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -114,16 +114,11 @@ def _warn_once(msg: str) -> None:
 
 # Model types that follow the standard LLaMA/Qwen2 layer hierarchy:
 # model.model.model.layers (through PeftModel → base_model → model)
-# The legacy ``a2d-*`` entries are deprecated load-compat for upstream checkpoints whose
-# config.json predates the TinyA2D rename (e.g. dllm-hub); tracked for removal in #301.
 _TINY_A2D_MODEL_TYPES = frozenset(
     [
         "tiny-a2d-llama",
         "tiny-a2d-qwen2",
         "tiny-a2d-qwen3",
-        "a2d-llama",
-        "a2d-qwen2",
-        "a2d-qwen3",
         "llama",
         "qwen2",
         "qwen3",
@@ -604,17 +599,6 @@ def _load_model_with_optional_4bit_fallback(
         return loader.from_pretrained(model_name, **fallback_kwargs)
 
 
-def _is_dllm_hub_qwen3_diffusion_repo(model_name: str) -> bool:
-    """True for dllm-hub Qwen3 diffusion checkpoints converted for Unturtle A2D.
-
-    ``AutoConfig.from_pretrained(..., trust_remote_code=True)`` on these repos
-    may import optional Hub code that declares a dependency on the ``dllm``
-    PyPI package. Loading via :class:`TinyA2DQwen3LMHeadModel` avoids that path.
-    """
-    m = model_name.strip().lower()
-    return m.startswith("dllm-hub/qwen3") and "diffusion" in m
-
-
 def _load_model_auto(
     model_name: str, load_kwargs: dict, trust_remote_code: bool
 ) -> Any:
@@ -659,8 +643,6 @@ def _load_model_auto(
         )
 
         _UNTURTLE_MODEL_CLASSES["tiny-a2d-llama"] = TinyA2DLlamaLMHeadModel
-        # Legacy load-compat: upstream checkpoints with model_type='a2d-llama' (#301).
-        _UNTURTLE_MODEL_CLASSES["a2d-llama"] = TinyA2DLlamaLMHeadModel
     except ImportError:
         pass
     try:
@@ -669,7 +651,6 @@ def _load_model_auto(
         )
 
         _UNTURTLE_MODEL_CLASSES["tiny-a2d-qwen2"] = TinyA2DQwen2LMHeadModel
-        _UNTURTLE_MODEL_CLASSES["a2d-qwen2"] = TinyA2DQwen2LMHeadModel
     except ImportError:
         pass
     try:
@@ -678,23 +659,8 @@ def _load_model_auto(
         )
 
         _UNTURTLE_MODEL_CLASSES["tiny-a2d-qwen3"] = TinyA2DQwen3LMHeadModel
-        _UNTURTLE_MODEL_CLASSES["a2d-qwen3"] = TinyA2DQwen3LMHeadModel
     except ImportError:
         pass
-
-    # Known Tiny-A2D Qwen3 diffusion repos: skip AutoConfig peek (Hub may require ``dllm``).
-    if (
-        _is_dllm_hub_qwen3_diffusion_repo(model_name)
-        and "tiny-a2d-qwen3" in _UNTURTLE_MODEL_CLASSES
-    ):
-        native_cls = _UNTURTLE_MODEL_CLASSES["tiny-a2d-qwen3"]
-        _logger.debug(
-            "FastDiffusionModel: using native %s for dllm-hub Qwen3 diffusion repo (skip AutoConfig peek)",
-            native_cls.__name__,
-        )
-        return _load_model_with_optional_4bit_fallback(
-            native_cls, model_name, load_kwargs
-        )
 
     # Peek at model_type without loading weights.
     try:

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -599,42 +599,29 @@ def _load_model_with_optional_4bit_fallback(
         return loader.from_pretrained(model_name, **fallback_kwargs)
 
 
-def _load_model_auto(
-    model_name: str, load_kwargs: dict, trust_remote_code: bool
-) -> Any:
-    """Try to load a model via AutoModel, AutoModelForMaskedLM, AutoModelForCausalLM.
+def _native_model_classes() -> dict[str, Any]:
+    """Build the ``model_type`` → unturtle native model class map.
 
-    Registers unturtle model types so AutoConfig resolves them before trying.
-    Falls back through the chain and raises if all attempts fail.
-
-    Strategy: peek at the model_type in AutoConfig, and if it matches an unturtle
-    native class (llada, Dream/dream, tiny-a2d-llama, tiny-a2d-qwen2, tiny-a2d-qwen3), use that
-    class directly — bypassing
-    trust_remote_code so the Hub's potentially older modeling code is never loaded.
-    This ensures fixes in unturtle model classes (e.g. _tied_weights_keys) take effect.
+    These classes are the from-scratch / wrapper implementations Unturtle owns
+    (LLaDA, Dream, Tiny-A2D Llama/Qwen2/Qwen3). Loading through them bypasses any
+    ``trust_remote_code`` Hub modeling code, so fixes in the unturtle classes
+    (e.g. ``_tied_weights_keys``) always take effect.
     """
-    from transformers import (
-        AutoModel,
-        AutoModelForCausalLM,
-        AutoModelForMaskedLM,
-    )
-
     import unturtle.models  # noqa: F401 — registers A2D/LLaDA/Dream AutoConfig entries
 
-    # Map model_type → unturtle model class (bypasses trust_remote_code Hub code).
-    _UNTURTLE_MODEL_CLASSES: dict[str, Any] = {}
+    classes: dict[str, Any] = {}
     try:
         from unturtle.models.backbones.llada import LLaDAModelLM
 
-        _UNTURTLE_MODEL_CLASSES["llada"] = LLaDAModelLM
+        classes["llada"] = LLaDAModelLM
     except ImportError:
         pass
     try:
         from unturtle.models.backbones.dream import DreamModel
 
-        _UNTURTLE_MODEL_CLASSES["dream"] = DreamModel
+        classes["dream"] = DreamModel
         # DreamConfig.model_type is "Dream" (capital D) — match Hub configs.
-        _UNTURTLE_MODEL_CLASSES["Dream"] = DreamModel
+        classes["Dream"] = DreamModel
     except ImportError:
         pass
     try:
@@ -642,7 +629,7 @@ def _load_model_auto(
             TinyA2DLlamaLMHeadModel,
         )
 
-        _UNTURTLE_MODEL_CLASSES["tiny-a2d-llama"] = TinyA2DLlamaLMHeadModel
+        classes["tiny-a2d-llama"] = TinyA2DLlamaLMHeadModel
     except ImportError:
         pass
     try:
@@ -650,7 +637,7 @@ def _load_model_auto(
             TinyA2DQwen2LMHeadModel,
         )
 
-        _UNTURTLE_MODEL_CLASSES["tiny-a2d-qwen2"] = TinyA2DQwen2LMHeadModel
+        classes["tiny-a2d-qwen2"] = TinyA2DQwen2LMHeadModel
     except ImportError:
         pass
     try:
@@ -658,11 +645,24 @@ def _load_model_auto(
             TinyA2DQwen3LMHeadModel,
         )
 
-        _UNTURTLE_MODEL_CLASSES["tiny-a2d-qwen3"] = TinyA2DQwen3LMHeadModel
+        classes["tiny-a2d-qwen3"] = TinyA2DQwen3LMHeadModel
     except ImportError:
         pass
+    return classes
 
-    # Peek at model_type without loading weights.
+
+def _load_native(
+    model_name: str, load_kwargs: dict, trust_remote_code: bool
+) -> Any | None:
+    """Load via an Unturtle native class when ``model_name``'s ``model_type`` is one.
+
+    Peeks at the config (no weights) and, if the ``model_type`` maps to a native
+    Unturtle class, loads through it directly — preserving the ``trust_remote_code``
+    bypass contract. Returns ``None`` when the model is *not* a native dLLM, so the
+    caller can delegate the load elsewhere. CUDA OOM propagates.
+    """
+    native_classes = _native_model_classes()
+
     try:
         peek_kwargs: dict[str, Any] = {}
         if "token" in load_kwargs:
@@ -671,8 +671,8 @@ def _load_model_auto(
             model_name, trust_remote_code=trust_remote_code, **peek_kwargs
         )
         model_type = getattr(config, "model_type", "")
-        if model_type in _UNTURTLE_MODEL_CLASSES:
-            native_cls = _UNTURTLE_MODEL_CLASSES[model_type]
+        if model_type in native_classes:
+            native_cls = native_classes[model_type]
             _logger.debug(
                 "FastDiffusionModel: using native unturtle class %s for model_type=%r",
                 native_cls.__name__,
@@ -682,9 +682,33 @@ def _load_model_auto(
                 native_cls, model_name, load_kwargs
             )
     except torch.cuda.OutOfMemoryError:
-        raise  # OOM should propagate, not fall through to slower AutoModel loaders
+        raise  # OOM should propagate, not fall through to slower loaders
     except Exception as exc:  # noqa: BLE001
         _logger.debug("FastDiffusionModel: native class lookup failed: %s", exc)
+
+    return None
+
+
+def _load_via_automodel(model_name: str, load_kwargs: dict) -> Any:
+    """Load a non-native (HF-registered) model_type via the AutoModel fallback chain.
+
+    This is the fallback path for backbones Unturtle does not implement natively:
+    loading/quantization is handled by ``transformers``' ``Auto*`` loaders. The
+    diffusion patch is applied afterwards by :func:`_patch_for_diffusion`, so the
+    resulting model behaves as a bidirectional dLLM regardless of which path
+    produced it. Raises if every loader fails.
+
+    NOTE: delegating this path to ``unsloth.FastModel.from_pretrained`` (so that
+    HF-registered dLLM backbones such as DiffusionGemma get unsloth's loading /
+    quantization / patch chain) is planned but deliberately NOT done during the
+    migration — the AutoModel chain is the tested behavioral contract. Tracked as
+    a follow-up issue.
+    """
+    from transformers import (
+        AutoModel,
+        AutoModelForCausalLM,
+        AutoModelForMaskedLM,
+    )
 
     loaders = [
         ("AutoModel", AutoModel),
@@ -705,6 +729,23 @@ def _load_model_auto(
         f"FastDiffusionModel: could not load {model_name!r} via any AutoModel variant. "
         f"Pass model_class= explicitly.\nLast error: {last_exc}"
     ) from last_exc
+
+
+def _load_model_auto(
+    model_name: str, load_kwargs: dict, trust_remote_code: bool
+) -> Any:
+    """Resolve and load a model: native dLLM class first, else HF delegation.
+
+    Native Unturtle backbones (llada / Dream / tiny-a2d-*) are loaded through their
+    own classes (``_load_native``), bypassing ``trust_remote_code`` Hub code. Any
+    other ``model_type`` is delegated to the ``transformers`` ``Auto*`` loaders via
+    ``_load_via_automodel``. Kept as a single module-level entry point for callers and
+    tests that patch it by name.
+    """
+    model = _load_native(model_name, load_kwargs, trust_remote_code)
+    if model is not None:
+        return model
+    return _load_via_automodel(model_name, load_kwargs)
 
 
 def _load_tokenizer(
@@ -760,6 +801,22 @@ def _propagate_max_seq_length(model: Any, max_seq_length: int) -> None:
     internal.max_seq_length = max_seq_length
     for module in model.modules():
         module.max_seq_length = max_seq_length
+
+
+def _patch_for_diffusion(model: Any, max_seq_length: int) -> Any:
+    """Apply the Unturtle diffusion patch shared by every load path.
+
+    Both the native loader and the unsloth/HF delegation path funnel through here,
+    as does the PEFT-adapter branch. It installs the apply_qkv/apply_o stubs (so the
+    bidirectional fast-forward and LoRA fast paths can attach), records
+    ``max_seq_length`` across the nested model, and extends RoPE when supported.
+    Returns the (mutated) model for call-site clarity.
+    """
+    _install_apply_stubs(model)
+    model.max_seq_length = max_seq_length
+    _propagate_max_seq_length(model, max_seq_length)
+    _extend_rope_if_possible(model, max_seq_length)
+    return model
 
 
 # ---------------------------------------------------------------------------
@@ -892,10 +949,7 @@ class FastDiffusionModel:
                     f"FastDiffusionModel: failed to load PEFT adapter from {_local!r} "
                     f"onto base model {_base_model_id!r}: {_e}"
                 ) from _e
-            _install_apply_stubs(model)
-            model.max_seq_length = max_seq_length
-            _propagate_max_seq_length(model, max_seq_length)
-            _extend_rope_if_possible(model, max_seq_length)
+            _patch_for_diffusion(model, max_seq_length)
             _logger.info(
                 "FastDiffusionModel: PEFT adapter loaded from %r.", str(_local)
             )
@@ -950,17 +1004,14 @@ class FastDiffusionModel:
                 "falling back to full-precision loading on CPU."
             )
 
-        # --- Resolve model class ---
+        # --- Resolve model class (explicit override → native dLLM → HF delegation) ---
         if model_class is None:
             model = _load_model_auto(model_name, load_kwargs, trust_remote_code)
         else:
             model = model_class.from_pretrained(model_name, **load_kwargs)
 
-        # --- Apply stubs and sequence length ---
-        _install_apply_stubs(model)
-        model.max_seq_length = max_seq_length
-        _propagate_max_seq_length(model, max_seq_length)
-        _extend_rope_if_possible(model, max_seq_length)
+        # --- Diffusion patch (shared across load paths) ---
+        _patch_for_diffusion(model, max_seq_length)
 
         # --- Tokenizer ---
         tokenizer = _load_tokenizer(model_name, trust_remote_code, token)


### PR DESCRIPTION
Closes #14

## 概要
クリーン移植 Task 7。3コミット構成。

### 移植コミット
- テスト4本（fast_diffusion_model / generate / e2e_integration / e2e_real_checkpoint）を無修正移植（legacy `a2d-*` 依存ゼロを grep 確認）
- `unturtle/__init__.py` の公開面を legacy 同等に完成（unsloth 再エクスポート群 + FastDiffusionModel + models 全クラス + kernels）

### compat 除去コミット
- `_TINY_A2D_MODEL_TYPES` / `_UNTURTLE_MODEL_CLASSES` の legacy `a2d-*` エントリ除去（#301 残課題の完済）
- dllm-hub repo-id 分岐（`_is_dllm_hub_qwen3_diffusion_repo`）除去 — 純粋な repo-id 前置判定で、汎用 native-class peek が同等処理することを確認済み

### リファクタコミット
- `from_pretrained` を責務分離: `_load_native`（trust_remote_code bypass、契約維持）/ `_load_via_automodel`（AutoModel フォールバック連鎖）/ `_patch_for_diffusion`（diffusion パッチ集約）/ `_load_model_auto`（名前・シグネチャ維持のオーケストレータ、モック契約3本保持）
- **真の unsloth FastModel 委譲は意図的に見送り**（テストが AutoModel 連鎖を契約しているため）→ #15 に切り出し（DiffusionGemma 対応とセット）

## テスト
- fast: 66 passed / full not-slow: **478 passed, 1 skipped**
- **GPU チェック②**: e2e_real_checkpoint + tests/models = 169 passed, 1 skipped, **1 failed**
  - 失敗は `TestAdapterSaveReload`（bf16 LoRA reload 乖離）。**legacy main + 同一 venv でも再現**＝スタック更新起因の既存問題 → #16 で追跡（本 PR の変更とは無関係、save 経路未接触）
- ruff グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)