### PR TITLE
✨ feat(eval): port lm-eval-harness adapter / runner / DecodingConfig (#18)

### DIFF
--- a/tests/eval/test_eval_import_boundary.py
+++ b/tests/eval/test_eval_import_boundary.py
@@ -1,0 +1,84 @@
+"""Guards that the optional lm_eval dependency is not required to import eval modules."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Run the "import without lm_eval" check in a SUBPROCESS. Blocking lm_eval and
+# re-importing unturtle.eval in-process would mutate global sys.modules state and leak
+# into other tests (e.g. a freshly re-imported unturtle.eval drops its `experimental`
+# subpackage attribute, breaking dotted monkeypatch targets elsewhere). A subprocess
+# isolates that completely and faithfully simulates lm_eval being absent.
+_BOUNDARY_SCRIPT = textwrap.dedent(
+    """
+    import sys
+
+    # Make any import of lm_eval fail, as if it were not installed.
+    class _BlockLmEval:
+        def find_spec(self, name, path=None, target=None):
+            if name == "lm_eval" or name.startswith("lm_eval."):
+                raise ImportError("simulated: lm_eval not installed")
+            return None
+
+    sys.meta_path.insert(0, _BlockLmEval())
+    sys.modules.pop("lm_eval", None)
+
+    # These must all import WITHOUT lm_eval present.
+    import unturtle.eval  # noqa: F401
+    import unturtle.eval.harness  # noqa: F401
+    import unturtle.eval.harness.configs  # noqa: F401
+    import unturtle.eval.harness.model_adapter  # noqa: F401
+    import unturtle.eval.harness.runner  # noqa: F401
+
+    # Sanity: lm_eval really was blocked.
+    try:
+        import lm_eval  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        raise AssertionError("lm_eval import was not blocked in the subprocess")
+
+    print("OK")
+    """
+)
+
+
+def test_import_eval_without_lm_eval(tmp_path) -> None:  # noqa: ANN001
+    script = tmp_path / "boundary_check.py"
+    script.write_text(_BOUNDARY_SCRIPT)
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"import boundary failed:\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+    )
+    assert "OK" in proc.stdout
+
+
+def test_harness_call_without_lm_eval_raises_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "lm_eval", None)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    class _M:
+        def parameters(self):
+            import torch
+
+            yield torch.zeros(1)
+
+    with pytest.raises(ImportError):
+        build_harness_lm(
+            model=_M(),
+            tokenizer=object(),
+            num_steps=1,
+            max_new_tokens=1,
+            temperature=0.0,
+            use_chat_template=False,
+        )

--- a/tests/eval/test_harness_adapter.py
+++ b/tests/eval/test_harness_adapter.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+class _FakeInstance:
+    def __init__(self, context: str, gen_kwargs: dict[str, Any]) -> None:
+        self.args = (context, gen_kwargs)
+
+
+def _install_fake_lm_eval(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a minimal fake lm_eval.api.model.LM so the adapter can subclass it."""
+    api_mod = types.ModuleType("lm_eval.api")
+    model_mod = types.ModuleType("lm_eval.api.model")
+
+    class _LM:
+        def __init__(self) -> None:
+            pass
+
+    model_mod.LM = _LM
+    root = types.ModuleType("lm_eval")
+    root.api = api_mod
+    api_mod.model = model_mod
+    monkeypatch.setitem(sys.modules, "lm_eval", root)
+    monkeypatch.setitem(sys.modules, "lm_eval.api", api_mod)
+    monkeypatch.setitem(sys.modules, "lm_eval.api.model", model_mod)
+
+
+class _StubModel:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def diffusion_generate(self, input_ids, **kwargs):
+        import torch
+
+        self.calls.append(kwargs)
+        new = torch.tensor([[101, 102, 103]])
+        return torch.cat([input_ids, new], dim=1)
+
+    def parameters(self):
+        import torch
+
+        yield torch.zeros(1)
+
+
+class _StubTokenizer:
+    model_max_length = 4096
+
+    def encode(self, text, return_tensors=None, add_special_tokens=True):
+        import torch
+
+        return torch.tensor([[1, 2, 3, 4]])
+
+    def decode(self, ids, skip_special_tokens=True):
+        return "the answer is 42 STOP trailing"
+
+
+def test_build_harness_lm_requires_lm_eval(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "lm_eval", None)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    with pytest.raises(ImportError):
+        build_harness_lm(
+            model=_StubModel(),
+            tokenizer=_StubTokenizer(),
+            num_steps=4,
+            max_new_tokens=8,
+            temperature=0.0,
+            use_chat_template=False,
+        )
+
+
+def test_generate_until_routes_through_diffusion_generate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_lm_eval(monkeypatch)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    model = _StubModel()
+    lm = build_harness_lm(
+        model=model,
+        tokenizer=_StubTokenizer(),
+        num_steps=4,
+        max_new_tokens=8,
+        temperature=0.0,
+        use_chat_template=False,
+    )
+    out = lm.generate_until([_FakeInstance("Q: 2+2?", {"until": ["STOP"]})])
+    assert isinstance(out, list) and len(out) == 1
+    assert model.calls, "diffusion_generate was not called"
+    assert "STOP" not in out[0]
+    assert out[0].startswith("the answer is 42")
+
+
+def test_generate_until_handles_string_until(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # lm-eval passes ``until`` as a bare string for many tasks (e.g. until: "STOP").
+    # A naive list(until) would split it into characters and truncate at the first
+    # matching char; the adapter must wrap a string into a single-element list.
+    _install_fake_lm_eval(monkeypatch)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    lm = build_harness_lm(
+        model=_StubModel(),
+        tokenizer=_StubTokenizer(),
+        num_steps=4,
+        max_new_tokens=8,
+        temperature=0.0,
+        use_chat_template=False,
+    )
+    out = lm.generate_until([_FakeInstance("Q", {"until": "trailing"})])
+    # decoded stub = "the answer is 42 STOP trailing". With the bug, list("trailing")
+    # truncates at the first 't' (index 0 of "the") → "". Fixed: truncates cleanly
+    # before the whole word "trailing".
+    assert out[0] == "the answer is 42 STOP "
+
+
+def test_normalize_until_variants() -> None:
+    from unturtle.eval.harness.model_adapter import _normalize_until
+
+    assert _normalize_until(None) == []
+    assert _normalize_until("Question:") == ["Question:"]
+    assert _normalize_until(["a", "b"]) == ["a", "b"]
+
+
+def test_generate_until_respects_max_gen_toks_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_lm_eval(monkeypatch)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    model = _StubModel()
+    lm = build_harness_lm(
+        model=model,
+        tokenizer=_StubTokenizer(),
+        num_steps=4,
+        max_new_tokens=8,
+        temperature=0.0,
+        use_chat_template=False,
+    )
+    lm.generate_until([_FakeInstance("Q", {"until": [], "max_gen_toks": 5})])
+    assert model.calls[-1]["max_length"] == 9
+
+
+def test_loglikelihood_raises_not_implemented(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_lm_eval(monkeypatch)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    lm = build_harness_lm(
+        model=_StubModel(),
+        tokenizer=_StubTokenizer(),
+        num_steps=4,
+        max_new_tokens=8,
+        temperature=0.0,
+        use_chat_template=False,
+    )
+    with pytest.raises(NotImplementedError):
+        lm.loglikelihood([_FakeInstance("ctx", {})])
+    with pytest.raises(NotImplementedError):
+        lm.loglikelihood_rolling([_FakeInstance("ctx", {})])

--- a/tests/eval/test_harness_configs.py
+++ b/tests/eval/test_harness_configs.py
@@ -1,0 +1,63 @@
+# tests/eval/test_harness_configs.py
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from unturtle.eval.harness.configs import (
+    DecodingConfig,
+    get_decoding_config,
+    list_decoding_configs,
+)
+
+
+def test_decoding_config_is_frozen_and_records_hyperparams() -> None:
+    cfg = DecodingConfig(
+        model_family="a2d_qwen3",
+        task="gsm8k",
+        max_new_tokens=256,
+        num_steps=256,
+        temperature=0.0,
+        use_chat_template=True,
+        fewshot=0,
+    )
+    assert cfg.max_new_tokens == 256
+    with pytest.raises(FrozenInstanceError):
+        cfg.max_new_tokens = 1  # frozen dataclass
+
+
+def test_get_known_config_returns_recorded_hyperparams() -> None:
+    cfg = get_decoding_config("a2d_qwen3", "gsm8k_cot")
+    assert cfg.task == "gsm8k_cot"
+    assert cfg.model_family == "a2d_qwen3"
+    assert cfg.max_new_tokens > 0
+    assert cfg.num_steps > 0
+
+
+def test_get_unknown_config_raises_keyerror_with_context() -> None:
+    with pytest.raises(KeyError) as exc:
+        get_decoding_config("a2d_qwen3", "does_not_exist")
+    assert "does_not_exist" in str(exc.value)
+
+
+def test_list_configs_includes_gsm8k_and_gsm8k_cot() -> None:
+    keys = list_decoding_configs()
+    assert ("a2d_qwen3", "gsm8k") in keys
+    assert ("a2d_qwen3", "gsm8k_cot") in keys
+
+
+def test_as_dict_roundtrips_for_recording() -> None:
+    cfg = get_decoding_config("a2d_qwen3", "gsm8k")
+    d = cfg.as_dict()
+    assert d["task"] == "gsm8k"
+    assert d["max_new_tokens"] == cfg.max_new_tokens
+    assert set(d) >= {
+        "model_family",
+        "task",
+        "max_new_tokens",
+        "num_steps",
+        "temperature",
+        "use_chat_template",
+        "fewshot",
+    }

--- a/tests/eval/test_harness_runner.py
+++ b/tests/eval/test_harness_runner.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+def _install_fake_lm_eval(
+    monkeypatch: pytest.MonkeyPatch, captured: dict[str, Any]
+) -> None:
+    root = types.ModuleType("lm_eval")
+
+    def simple_evaluate(*, model, tasks, **kwargs):  # noqa: ANN001, ANN003
+        captured["model"] = model
+        captured["tasks"] = tasks
+        captured["kwargs"] = kwargs
+        return {"results": {tasks[0]: {"exact_match,strict-match": 0.5}}}
+
+    root.simple_evaluate = simple_evaluate
+    api_mod = types.ModuleType("lm_eval.api")
+    model_mod = types.ModuleType("lm_eval.api.model")
+
+    class _LM:
+        def __init__(self) -> None: ...
+
+    model_mod.LM = _LM
+    root.api = api_mod
+    api_mod.model = model_mod
+    monkeypatch.setitem(sys.modules, "lm_eval", root)
+    monkeypatch.setitem(sys.modules, "lm_eval.api", api_mod)
+    monkeypatch.setitem(sys.modules, "lm_eval.api.model", model_mod)
+
+
+class _StubModel:
+    def parameters(self):
+        import torch
+
+        yield torch.zeros(1)
+
+
+def _patch_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    import unturtle.eval.harness.runner as runner_mod
+
+    class _FDM:
+        @staticmethod
+        def from_pretrained(name, **kwargs):  # noqa: ANN001, ANN003
+            return _StubModel(), object()
+
+        @staticmethod
+        def for_inference(model):  # noqa: ANN001
+            return model
+
+    monkeypatch.setattr(runner_mod, "FastDiffusionModel", _FDM)
+
+
+def test_runner_records_decoding_config_in_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_lm_eval(monkeypatch, captured)
+    from unturtle.eval.harness.runner import run_harness_evaluation
+
+    _patch_loader(monkeypatch)
+    summary = run_harness_evaluation(
+        model_name="dummy/model",
+        model_family="a2d_qwen3",
+        task="gsm8k",
+    )
+    assert summary["task"] == "gsm8k"
+    assert summary["model"] == "dummy/model"
+    assert summary["decoding_config"]["max_new_tokens"] == 256
+    assert summary["decoding_config"]["num_steps"] == 256
+    assert summary["decoding_config"]["task"] == "gsm8k"
+    assert "results" in summary
+    assert captured["tasks"] == ["gsm8k"]
+
+
+def test_runner_rejects_unknown_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    _install_fake_lm_eval(monkeypatch, captured)
+    from unturtle.eval.harness.runner import run_harness_evaluation
+
+    _patch_loader(monkeypatch)
+    with pytest.raises(KeyError):
+        run_harness_evaluation(
+            model_name="dummy/model",
+            model_family="a2d_qwen3",
+            task="not_a_task",
+        )
+
+
+def test_runner_requires_lm_eval(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "lm_eval", None)
+    from unturtle.eval.harness.runner import run_harness_evaluation
+
+    _patch_loader(monkeypatch)
+    with pytest.raises(ImportError):
+        run_harness_evaluation(
+            model_name="dummy/model",
+            model_family="a2d_qwen3",
+            task="gsm8k",
+        )

--- a/unturtle/eval/harness/__init__.py
+++ b/unturtle/eval/harness/__init__.py
@@ -1,0 +1,31 @@
+# unturtle/eval/harness/__init__.py
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle.eval.harness — canonical lm-evaluation-harness integration.
+
+This is the authoritative benchmark path for Unturtle dLLMs. ``lm_eval`` is an optional
+dependency; importing this package does NOT require it (the adapter and runner import
+``lm_eval`` lazily at call time).
+"""
+
+from .configs import DecodingConfig, get_decoding_config, list_decoding_configs
+from .runner import run_harness_evaluation
+
+__all__ = [
+    "DecodingConfig",
+    "get_decoding_config",
+    "list_decoding_configs",
+    "run_harness_evaluation",
+]

--- a/unturtle/eval/harness/configs.py
+++ b/unturtle/eval/harness/configs.py
@@ -1,0 +1,90 @@
+# unturtle/eval/harness/configs.py
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-(model_family, task) decoding configs for canonical dLLM evaluation.
+
+The dLLM paper shows benchmark scores swing sharply with inference hyperparameters
+(max_new_tokens, eos-suppression, parallel-decode steps, temperature). To make scores
+reproducible and comparable, every canonical evaluation pins an explicit, versioned
+``DecodingConfig`` and records it alongside the score.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DecodingConfig:
+    """Explicit decoding hyperparameters for one (model_family, task) pair."""
+
+    model_family: str
+    task: str
+    max_new_tokens: int
+    num_steps: int
+    temperature: float
+    use_chat_template: bool
+    fewshot: int
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize for recording alongside benchmark results."""
+        return asdict(self)
+
+
+# NOTE: only hyperparameters that actually take effect in the adapter/generation path are
+# recorded here, so a recorded config never misrepresents the real decoding. Knobs the dLLM
+# paper highlights but that are not yet wired into generation (e.g. eos-suppression,
+# parallel-decode width) will be added when the generation path honors them.
+
+
+# Canonical decoding configs. Keyed by (model_family, task).
+# Values follow dLLM / d1 reasoning-eval conventions; tune as reproductions are verified.
+_DECODING_CONFIGS: dict[tuple[str, str], DecodingConfig] = {
+    ("a2d_qwen3", "gsm8k"): DecodingConfig(
+        model_family="a2d_qwen3",
+        task="gsm8k",
+        max_new_tokens=256,
+        num_steps=256,
+        temperature=0.0,
+        use_chat_template=True,
+        fewshot=0,
+    ),
+    ("a2d_qwen3", "gsm8k_cot"): DecodingConfig(
+        model_family="a2d_qwen3",
+        task="gsm8k_cot",
+        max_new_tokens=512,
+        num_steps=512,
+        temperature=0.0,
+        use_chat_template=True,
+        fewshot=8,
+    ),
+}
+
+
+def get_decoding_config(model_family: str, task: str) -> DecodingConfig:
+    """Return the canonical decoding config for (model_family, task)."""
+    try:
+        return _DECODING_CONFIGS[(model_family, task)]
+    except KeyError as exc:
+        available = sorted(_DECODING_CONFIGS)
+        raise KeyError(
+            f"No decoding config for {(model_family, task)!r}. Available: {available}"
+        ) from exc
+
+
+def list_decoding_configs() -> list[tuple[str, str]]:
+    """List all registered (model_family, task) config keys."""
+    return sorted(_DECODING_CONFIGS)

--- a/unturtle/eval/harness/model_adapter.py
+++ b/unturtle/eval/harness/model_adapter.py
@@ -1,0 +1,159 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""lm-evaluation-harness adapter for Unturtle diffusion models.
+
+``lm_eval`` is optional, so the ``lm_eval.api.model.LM`` subclass is defined inside a lazy
+factory (``build_harness_lm``) rather than at module top level. Importing this module never
+requires ``lm_eval``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+
+def _import_lm_base() -> type:
+    try:
+        from lm_eval.api.model import LM
+    except Exception as exc:
+        raise ImportError(
+            "lm-evaluation-harness is required for the canonical harness adapter. "
+            "Install it (optional 'eval' extra) to run canonical benchmarks."
+        ) from exc
+    return LM
+
+
+def _normalize_until(until: Any) -> list[str]:
+    """Normalize lm-eval's ``until`` (str | list[str] | None) to a list of stops.
+
+    lm-eval passes a task's ``generation_kwargs["until"]`` through verbatim, and it is
+    legitimately either a bare string (e.g. ``until: "Question:"``) or a list. ``list()``
+    on a string would split it into characters and silently truncate generations at the
+    first matching character — so a string must be wrapped, not iterated. Mirrors
+    lm-eval's own ``handle_stop_sequences``.
+    """
+    if until is None:
+        return []
+    if isinstance(until, str):
+        return [until]
+    return [s for s in until if isinstance(s, str)]
+
+
+def _apply_stop_sequences(text: str, stops: list[str]) -> str:
+    idxs = [text.find(s) for s in stops if s and s in text]
+    return text[: min(idxs)] if idxs else text
+
+
+def build_harness_lm(
+    *,
+    model: Any,
+    tokenizer: Any,
+    num_steps: int,
+    max_new_tokens: int,
+    temperature: float,
+    use_chat_template: bool,
+) -> Any:
+    """Build an lm_eval LM wrapping an Unturtle diffusion model.
+
+    Defined as a factory because ``lm_eval.api.model.LM`` (the base class) is an optional
+    dependency that must not be imported at module load time.
+    """
+    lm_base = _import_lm_base()
+
+    class UnturtleHarnessLM(lm_base):  # type: ignore[misc, valid-type]
+        """Routes lm-eval ``generate_until`` through ``diffusion_generate``."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._model = model
+            self._tokenizer = tokenizer
+            self._num_steps = num_steps
+            self._max_new_tokens = max_new_tokens
+            self._temperature = temperature
+            self._use_chat_template = use_chat_template
+
+        def _build_prompt(self, context: str) -> str:
+            apply = getattr(self._tokenizer, "apply_chat_template", None)
+            if self._use_chat_template and callable(apply):
+                return apply(
+                    [{"role": "user", "content": context}],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+            return context
+
+        def _generate_one(self, context: str, gen_kwargs: dict[str, Any]) -> str:
+            prompt = self._build_prompt(context)
+            input_ids = self._tokenizer.encode(
+                prompt, return_tensors="pt", add_special_tokens=False
+            )
+            device = next(iter(self._model.parameters())).device
+            input_ids = input_ids.to(device)
+            prompt_len = input_ids.shape[1]
+            max_new = int(gen_kwargs.get("max_gen_toks", self._max_new_tokens))
+            max_length = prompt_len + max_new
+
+            mask_token_id = getattr(self._tokenizer, "mask_token_id", None)
+            if mask_token_id is None:
+                mask_token_id = getattr(
+                    getattr(self._model, "config", None), "mask_token_id", None
+                )
+
+            diffusion_generate = getattr(self._model, "diffusion_generate", None)
+            if callable(diffusion_generate):
+                sequences = diffusion_generate(
+                    input_ids,
+                    max_length=max_length,
+                    mask_token_id=mask_token_id,
+                    steps=self._num_steps,
+                    temperature=self._temperature,
+                )
+            else:
+                warnings.warn(
+                    f"{type(self._model).__name__} has no diffusion_generate method. "
+                    "Falling back to model.generate — results are NOT diffusion results.",
+                    stacklevel=2,
+                )
+                sequences = self._model.generate(input_ids, max_length=max_length)
+
+            if hasattr(sequences, "sequences"):
+                sequences = sequences.sequences
+            generated_ids = sequences[0, prompt_len:].detach().cpu()
+            text = self._tokenizer.decode(generated_ids, skip_special_tokens=True)
+            return _apply_stop_sequences(
+                text, _normalize_until(gen_kwargs.get("until"))
+            )
+
+        def generate_until(self, requests: list[Any]) -> list[str]:
+            outputs: list[str] = []
+            for req in requests:
+                context, gen_kwargs = req.args
+                outputs.append(self._generate_one(context, dict(gen_kwargs or {})))
+            return outputs
+
+        def loglikelihood(self, requests: list[Any]) -> list[tuple[float, bool]]:
+            raise NotImplementedError(
+                "loglikelihood is not supported for diffusion models in this adapter"
+            )
+
+        def loglikelihood_rolling(
+            self, requests: list[Any]
+        ) -> list[tuple[float, bool]]:
+            raise NotImplementedError(
+                "loglikelihood_rolling is not supported for diffusion models"
+            )
+
+    return UnturtleHarnessLM()

--- a/unturtle/eval/harness/runner.py
+++ b/unturtle/eval/harness/runner.py
@@ -1,0 +1,82 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical harness evaluation runner.
+
+Loads an Unturtle diffusion model via the canonical loader, wraps it in the lm-eval
+adapter, runs ``lm_eval.simple_evaluate``, and returns a summary that embeds the exact
+``DecodingConfig`` used — so every score is reproducible.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from unturtle.fast_diffusion_model import FastDiffusionModel
+
+from .configs import get_decoding_config
+from .model_adapter import build_harness_lm
+
+
+def _import_simple_evaluate():  # noqa: ANN202
+    try:
+        from lm_eval import simple_evaluate
+    except Exception as exc:
+        raise ImportError(
+            "lm-evaluation-harness is required to run canonical evaluations. "
+            "Install it (optional 'eval' extra)."
+        ) from exc
+    return simple_evaluate
+
+
+def run_harness_evaluation(
+    *,
+    model_name: str,
+    model_family: str,
+    task: str,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Run a canonical lm-eval-harness evaluation for one (model_family, task).
+
+    Returns a summary embedding the recorded decoding config and raw results.
+    """
+    config = get_decoding_config(model_family, task)
+    simple_evaluate = _import_simple_evaluate()
+
+    model, tokenizer = FastDiffusionModel.from_pretrained(model_name)
+    FastDiffusionModel.for_inference(model)
+
+    lm = build_harness_lm(
+        model=model,
+        tokenizer=tokenizer,
+        num_steps=config.num_steps,
+        max_new_tokens=config.max_new_tokens,
+        temperature=config.temperature,
+        use_chat_template=config.use_chat_template,
+    )
+
+    results = simple_evaluate(
+        model=lm,
+        tasks=[task],
+        num_fewshot=config.fewshot,
+        limit=limit,
+    )
+
+    return {
+        "task": task,
+        "model": model_name,
+        "model_family": model_family,
+        "decoding_config": config.as_dict(),
+        "results": results,
+    }


### PR DESCRIPTION
Closes #18

## 概要
クリーン移植 Task 8。canonical 評価パスを移植。

- `unturtle/eval/harness/`（model_adapter / runner / configs）を legacy からバイト一致で移植（diff -r 検証済み）
- lm-eval 0.4.12 で API 非互換なし、本体修正ゼロ
- 不変条件検証: `lm_eval` を import ブロックしたサブプロセスで `import unturtle.eval` 成功（lazy import 維持、test_eval_import_boundary が担保）

## テスト
- tests/eval/ 46 passed / **全量回帰 494 passed, 1 skipped**
- ruff グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)