### PR TITLE
✨ feat(cli,docs): integrate CLI as unturtle.cli, port benchmarks / examples / docs (#20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,136 @@
+# AGENTS.md — Unturtle Project
+
+> Keep this file concise and actionable.
+> See also: `CLAUDE.md` for the main project workflow and invariants.
+
+---
+
+## Project Overview
+
+**Unturtle** is a dLLM method layer built on `unsloth`, with Triton-optimized support for
+diffusion language models such as LLaDA and Dream.
+
+Core behavioral differences from autoregressive LLM training:
+- tokens are randomly masked
+- loss is computed only at masked positions
+- attention is bidirectional (`is_causal=False`)
+- timestep-dependent masking / weighting may be used
+
+Layering (Unturtle does not own the training loop):
+
+```text
+transformers  model implementations + in-model loss / generation
+TRL           objective trainers (DiffusionTrainer is a peer of DPOTrainer)
+unsloth       acceleration patches (fast LoRA, Triton kernels)
+unturtle      dLLM method layer
+```
+
+Models that carry their own loss/generation (e.g. DiffusionGemma) train through the standard
+`transformers`/`FastModel` path; `DiffusionTrainer` supplies the objective only for backbones
+that lack a built-in diffusion objective.
+
+## Model taxonomy — three orthogonal axes
+
+- **Backbone architecture** (`unturtle.models.backbones.{llada,dream,modernbert}`):
+  native diffusion backbones Unturtle implements.
+- **Conversion method** (`unturtle.models.conversion`): a *method*, not a model. `a2d` is
+  the AR→Diffusion family; the recipe is **Tiny-A2D** (`conversion.a2d.tiny_a2d`, classes
+  `TinyA2D*`, model_types `tiny-a2d-*`) — thin adapters over `transformers` Qwen/Llama.
+- **Training objective** (`unturtle.diffusion`): MDLM, BD3LM.
+- **Shared infra** (`unturtle.models.generation`): cache / block-decode / generation mixin.
+
+New code goes on the correct axis. `AutoConfig.register(...)` fires once per model_type.
+
+## Important Paths
+
+```text
+.
+├── unturtle/
+│   ├── diffusion/          # trainer / collator / scheduler / GRPO
+│   ├── kernels/            # masked diffusion loss / fast LoRA
+│   ├── models/
+│   │   ├── backbones/      # llada / dream / modernbert (native backbones)
+│   │   ├── conversion/     # a2d/ (family) → tiny_a2d/ (recipe)
+│   │   └── generation/     # cache / block-decode / generation mixins
+│   ├── eval/               # smoke evaluators + lm-eval-harness adapter
+│   ├── cli/                # unturtle CLI (train / generate / export / eval)
+│   └── fast_diffusion_model.py
+├── tests/                  # incl. test_cli_smoke.py, tests/examples/
+├── benchmarks/             # tracked benchmark scripts
+├── examples/               # runnable examples + configs
+└── dev/repos/              # local reference repos (ignored)
+```
+
+## Testing Requirements
+
+```bash
+uv run python -m pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py tests/test_e2e_integration.py -m "not slow" -v
+uv run python -m pytest tests/ -v
+```
+
+Rules:
+1. Relevant fast tests must pass before PR merge.
+2. Triton / Flash changes must be checked on CPU fallback and CUDA.
+3. Triton kernel numerical checks should compare against reference behavior, not only shapes.
+4. Real-checkpoint tests should stay `slow` + `gpu`.
+5. Root `conftest.py` autouse clears distributed launcher env vars (`WORLD_SIZE`, `LOCAL_RANK`, `MASTER_ADDR`, …) before each test. Tests that call `torch.distributed.init_process_group` must set those vars again for that test (e.g. `monkeypatch.setenv`).
+
+## Code Review Checklist
+
+For algorithmic changes, compare against:
+- `dev/repos/d1/SFT/sft_trainer.py`
+- `dev/repos/d1/diffu-grpo/diffu_grpo_trainer.py`
+- `dev/repos/dllm/dllm/core/trainers/mdlm.py`
+- `dev/repos/transformers/src/transformers/modeling_utils.py`
+- `dev/repos/transformers/src/transformers/integrations/bitsandbytes.py`
+- `dev/repos/fast-dllm/dream/model/generation_utils_block.py`
+- `dev/repos/fast-dllm/llada/model/modeling_llada.py`
+
+Always check:
+1. reference alignment
+2. CPU/GPU correctness
+3. CUDA guards on Triton / Flash paths
+4. bidirectional attention preserved
+5. packed-sequence / varlen behavior preserved
+
+Use the current PR review tooling / review agents for review.
+
+## Model Path Reminders
+
+### A2D
+
+```text
+PeftModel
+ └─ base_model.model.model.layers[i]
+```
+
+### LLaDA
+
+```text
+PeftModel
+ └─ base_model.model
+     └─ model
+         └─ transformer.blocks[i]
+```
+
+### Dream
+
+```text
+PeftModel
+ └─ base_model.model.model.layers[i]
+```
+
+## Common Gotchas
+
+| Gotcha | Symptom | Fix |
+|--------|---------|-----|
+| `DiffusionTrainer` without tokenizer | `Repo id must be alphanumeric` | pass `processing_class=tokenizer` |
+| `packed_seq_lengths` vs `cu_seqlens` | packed path silently disabled | use `packed_seq_lengths` for packed fast path |
+| `build_sdpa_packed_attention_mask()` is causal | packed dLLM attention silently regresses | do not reuse it for dLLM packed attention |
+| Flash varlen on CPU | crash despite package installed | guard on `Q.device.type == "cuda"` |
+| A2D CUDA RoPE reuses pre-aligned `position_ids` | packed / reset positions break CUDA outputs | flatten pre-aligned cos/sin and index by flat row ids, not reused `position_ids` |
+| Dream q/k/v has bias | QKV Triton patch skipped | use `apply_lora_qkv_with_bias` |
+| LLaDA extra nesting | transformer path lookup fails | use runtime attribute fallback |
+| loss normalized by `n_masked` | reference-aligned loss scale drifts | normalize by `n_maskable` |
+| `load_in_4bit` without `device_map` | OOM / wrong fallback path | use `device_map="auto"` |
+| wrong package for dLLM trainers | `ModuleNotFoundError` / wrong API | `from unturtle.diffusion import …` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,341 @@
+# Unturtle — operational guide
+
+## Purpose
+
+Unturtle is a dLLM-focused method layer built on top of `unsloth`. Work here should
+preserve `unsloth` integration and concentrate on diffusion-specific value:
+- masked diffusion loss
+- bidirectional attention fast paths
+- dLLM generation / block decode / cache behavior
+- dLLM training and the canonical evaluation harness
+
+## Layering — who owns what
+
+Unturtle does **not** own the training loop. It composes four layers:
+
+```text
+transformers   model implementations + in-model loss / generation primitives
+TRL            objective trainers (DPOTrainer, GRPOTrainer, … as peers)
+unsloth        hardware-acceleration patches (fast LoRA, Triton kernels) — not a loop
+unturtle       dLLM method layer: conversion, objective trainers, inference accel, eval
+```
+
+`DiffusionTrainer` sits in the TRL objective-trainer tier — it is a peer of TRL's
+`DPOTrainer`, supplying the masked-diffusion objective. The line:
+
+- **Models that carry their own loss / generation** (e.g. DiffusionGemma) train through the
+  standard `transformers` / `FastModel` path; `DiffusionTrainer` is **not** used for them.
+- **Backbones without a built-in diffusion objective** are trained by `DiffusionTrainer`,
+  which supplies the masked-diffusion loss as an objective layer.
+
+## Core invariants
+
+- dLLM attention is bidirectional. Do not reintroduce causal masking; preserve `is_causal=False`.
+- Diffusion loss is computed only on masked positions (`labels == -100` elsewhere).
+- Loss normalization aligns with `n_maskable`, not `n_masked`, to match MDLM/d1 semantics.
+- Canonical imports for this stack are under `unturtle.diffusion` (or `from unturtle import …`).
+- Unturtle depends on `unsloth`; do not spend effort trying to fully decouple it.
+- For algorithm changes, check the reference implementations in `dev/repos/` before deciding
+  behavior is wrong.
+
+## Model taxonomy — three orthogonal axes
+
+A concrete dLLM is a point in three independent axes. Place new code on the right axis:
+
+- **Backbone architecture** (`unturtle.models.backbones.{llada,dream,modernbert}`):
+  native diffusion backbones Unturtle implements. LLaDA/Dream are full from-scratch
+  implementations; ModernBERT-diffusion wraps the upstream bidirectional encoder.
+- **Conversion method** (`unturtle.models.conversion`): how a non-diffusion backbone
+  becomes a dLLM — a *method*, not a model. `a2d` is the AR→Diffusion family; the
+  implemented recipe is **Tiny-A2D** (`unturtle.models.conversion.a2d.tiny_a2d`, classes
+  `TinyA2D*`, model_types `tiny-a2d-{llama,qwen2,qwen3}`). These are thin adapters over
+  `transformers` Qwen/Llama backbones.
+- **Training objective** (`unturtle.diffusion`): MDLM, BD3LM.
+- **Shared infra** (`unturtle.models.generation`): cache, block-decode, and the
+  masked-diffusion generation mixin used by all families (neither backbone nor method).
+
+`AutoConfig.register(...)` fires once per model_type.
+
+See `docs/dllm-gap-map.md` for the implemented-vs-missing method map and the roadmap.
+
+## Minimal repo map
+
+```text
+.
+├── unturtle/
+│   ├── diffusion/          # trainer, collator, scheduler, GRPO
+│   ├── kernels/            # Triton kernels / fast LoRA
+│   ├── models/
+│   │   ├── backbones/      # native diffusion backbones: llada / dream / modernbert
+│   │   ├── conversion/     # methods: a2d/ (family) → tiny_a2d/ (recipe)
+│   │   └── generation/     # shared infra: cache / block-decode / generation mixins
+│   ├── eval/               # smoke evaluators + lm-evaluation-harness adapter
+│   ├── utils/              # shared helpers
+│   ├── cli/                # unturtle CLI (train / generate / export / eval)
+│   └── fast_diffusion_model.py
+├── tests/
+│   ├── diffusion/
+│   ├── models/
+│   ├── examples/
+│   ├── test_cli_smoke.py
+│   ├── test_fast_diffusion_model.py
+│   └── test_e2e_*.py
+├── benchmarks/             # tracked benchmark scripts and result helpers
+├── examples/               # runnable training / inference examples + configs
+└── dev/
+    ├── repos/              # local cloned reference repos (ignored)
+    ├── papers/             # local papers / notes (ignored)
+    ├── local/              # local archival notes / exploratory scripts (ignored)
+    └── *.md                # local-only design notes (ignored)
+```
+
+## Reference implementations
+
+Clone locally when needed:
+
+```bash
+mkdir -p dev/repos
+git clone https://github.com/dllm-reasoning/d1.git dev/repos/d1
+git clone https://github.com/zhziszz/dllm.git dev/repos/dllm
+git clone --depth=1 https://github.com/huggingface/transformers.git dev/repos/transformers
+git clone --depth=1 https://github.com/NVlabs/Fast-dLLM.git dev/repos/fast-dllm
+```
+
+Most important reference files:
+- `dev/repos/d1/SFT/sft_trainer.py`
+- `dev/repos/d1/diffu-grpo/diffu_grpo_trainer.py`
+- `dev/repos/dllm/dllm/core/trainers/mdlm.py`
+- `dev/repos/transformers/src/transformers/modeling_utils.py`
+- `dev/repos/transformers/src/transformers/integrations/bitsandbytes.py`
+- `dev/repos/fast-dllm/dream/model/generation_utils_block.py`
+- `dev/repos/fast-dllm/llada/model/modeling_llada.py`
+
+Deep reference material and benchmark archives can live in ignored local docs under `dev/local/`.
+
+## Environment
+
+`./install.sh` is the supported setup path (uv venv + CUDA-matched torch + editable install,
+with verification). See the header of `install.sh` for `TORCH_INDEX` / `PYTHON_VERSION`
+overrides.
+
+```bash
+./install.sh          # base install
+./install.sh --eval   # additionally install the lm-eval-harness extra
+```
+
+Notes:
+- Plain `pip` is **not** supported — use `uv` (torch must be installed before the editable
+  install so the CUDA-matched build is preserved; the script handles ordering).
+- Unsloth is pinned to `>=2026.6.2`.
+- After setup, use `uv run python` (or `.venv/bin/python`) to execute scripts.
+
+## Common commands
+
+```bash
+# focused fast tests
+uv run python -m pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py tests/test_e2e_integration.py -m "not slow" -v
+
+# full suite
+uv run python -m pytest tests/ -v
+
+# lint / format
+uv run ruff check .
+uv run ruff format .
+```
+
+## Testing expectations
+
+- All relevant fast tests must pass before opening or updating a PR.
+- Triton / Flash changes must be checked on both CPU fallback and CUDA paths.
+- Triton kernel correctness must be compared against `F.cross_entropy` or the appropriate
+  reference behavior, not just shape checks.
+- Real-checkpoint tests should remain `@pytest.mark.slow` and `@pytest.mark.gpu`.
+- For generation / cache work, run the targeted model regressions instead of only broad
+  smoke tests.
+
+## Evaluation
+
+Two tiers, different guarantees:
+
+- **Smoke / in-loop** (`unturtle.eval` — `GSM8KEvaluator`, `MaskedDiffusionEvaluator`,
+  `GenerationEvaluator`): fast local sanity checks during training/CI. NOT authoritative.
+- **Canonical benchmark** (`unturtle.eval.harness`, lm-evaluation-harness): the
+  authoritative, paper-comparable path. Routes through `FastDiffusionModel` +
+  `diffusion_generate`. Every run pins an explicit per-(model_family, task)
+  `DecodingConfig` and records it with the score (dLLM scores are highly sensitive to
+  decoding hyperparameters such as max_new_tokens, eos-suppression, steps, temperature).
+
+`lm_eval` is an optional dependency (`./install.sh --eval`); `import unturtle.eval`
+must not require it (the adapter/runner import `lm_eval` lazily).
+
+## High-level generation
+
+`FastDiffusionModel.generate(model, inputs, algorithm="auto", **kwargs)` is the high-level
+inference entry. `algorithm` is explicit: `"auto"` (default — fastest discrete path the model
+supports: block-decode when available, else MDLM; BD3LM when requested), or force
+`"mdlm"` / `"block_decode"` / `"bd3lm"`. It delegates to `model.diffusion_generate(...)` with
+the flag set the named algorithm implies, so output is identical to the equivalent
+`diffusion_generate` call; the low-level `diffusion_generate` entry stays for existing callers.
+Decoding algorithms are registered in `unturtle/models/generation/sampler.py`
+(discrete-masked-only today; the registry is open for future continuous-diffusion algorithms).
+
+## Issue, branch, commit, PR workflow
+
+### Issues
+
+Create an issue before implementation.
+
+Title pattern:
+
+```text
+[Phase N] <verb> <target>
+```
+
+Issue body should include:
+- background / goal
+- acceptance criteria
+- links to relevant issue context, local notes if useful, or reference code
+
+Typical labels:
+- `type: feat`, `type: fix`, `type: docs`, `type: test`, `type: perf`, `type: refactor`, `type: chore`
+- `diffusion`, `triton`
+
+### Branches
+
+```text
+<type>/<issue-number>-<short-description>
+```
+
+Examples:
+- `feat/42-masked-diffusion-loss`
+- `fix/55-collator-masking-bug`
+- `docs/124-slim-claude-md`
+
+Rules:
+- do not push directly to `main`
+- upstream sync should keep history explicit
+
+### Commits
+
+Format:
+
+```text
+<emoji> <type>(<scope>): <description> (#<issue>)
+```
+
+Common types:
+- `✨ feat`
+- `🐛 fix`
+- `📚 docs`
+- `✅ test`
+- `⚡ perf`
+- `♻️ refactor`
+- `🔧 chore`
+
+### Pull requests
+
+- Prefer 1 PR = 1 issue.
+- Use Draft PRs while work is in progress.
+- Reconcile with `main` before merge.
+- Default merge strategy is **Squash and merge**.
+- If docs or workflow changed, update the relevant tracked docs in the same PR.
+
+## PR review process
+
+Before marking a PR ready or merging it, run the current PR review tooling.
+
+Use the repo's review agents / PR review toolkit for review.
+Focus review on:
+1. reference implementation alignment
+2. transformers API compatibility
+3. CUDA guards on Triton / Flash paths
+4. preservation of bidirectional attention
+5. packed-sequence / varlen correctness
+6. meaningful regression coverage
+
+Fix all critical/high findings before merge.
+
+## Mandatory review checks
+
+For any dLLM algorithm or generation change, explicitly compare against:
+- `d1` for SFT / Diffu-GRPO behavior
+- `dllm` for MDLM / LLaDA behavior
+- `transformers` for init / tie-weights / quantization compatibility
+- `Fast-dLLM` for KV-cache / block-decode / replace-position behavior
+
+Do not call a difference a bug until you verify whether it was an intentional design choice.
+
+## Model-specific path reminders
+
+### A2D
+
+```text
+PeftModel
+ └─ base_model.model.model.layers[i]
+     ├─ self_attn.{q_proj,k_proj,v_proj,o_proj}
+     └─ mlp.{gate_proj,up_proj,down_proj}
+```
+
+### LLaDA
+
+```text
+PeftModel
+ └─ base_model.model
+     └─ model
+         └─ transformer.blocks[i]
+```
+
+Use runtime fallback when resolving the transformer path:
+
+```python
+inner = model.base_model.model
+transformer = (
+    inner.model.transformer
+    if hasattr(inner, "model") and hasattr(inner.model, "transformer")
+    else inner.transformer
+)
+```
+
+### Dream
+
+```text
+PeftModel
+ └─ base_model.model.model.layers[i]
+     ├─ self_attn.{q_proj,k_proj,v_proj}  # bias=True
+     ├─ self_attn.o_proj
+     └─ mlp.{gate_proj,up_proj,down_proj}
+```
+
+Dream q/k/v uses bias, so standard bias-free QKV patching rules do not apply.
+
+## Fast-path patching rules
+
+- Guard on the actual parameter device, not just `torch.cuda.is_available()`.
+- Skip Triton patching on CPU.
+- Standard `apply_lora_qkv` requires `bias=False`.
+- Dream q/k/v requires `apply_lora_qkv_with_bias`.
+- `lora_dropout != 0` disables the Triton LoRA path.
+- Preserve bidirectional attention fast-forward behavior even when LoRA is absent.
+
+## High-signal gotchas
+
+- Pass `processing_class=tokenizer` explicitly to `DiffusionTrainer` in tests/custom setups.
+- Do not confuse `packed_seq_lengths` with `cu_seqlens`; packed fast paths read `packed_seq_lengths`.
+- Flash varlen must guard on `Q.device.type == "cuda"`; package availability alone is not enough.
+- `build_sdpa_packed_attention_mask()` is causal and must not be reused for dLLM packed attention.
+- For real checkpoints, `mask_token_id` may need to come from `model.config`, not the tokenizer.
+- `LLaDAModelLM` must preserve HF compatibility requirements such as `post_init()`, `tie_weights(**kwargs)`, and tolerant `forward(..., **kwargs)` behavior.
+- `load_in_4bit=True` should usually pair with `device_map="auto"`.
+- Loss normalization should align with `n_maskable`, not `n_masked`, to match MDLM/d1 reference semantics.
+- A2D CUDA RoPE must not re-index pre-aligned `position_embeddings` with `position_ids`.
+- Use `unturtle.diffusion` for trainers and collators; do not rely on non-existent third-party diffusion package paths.
+
+## Local archival notes
+
+The following are intentionally **not** kept inline here:
+- long benchmark result tables
+- historical phase summaries
+- extended troubleshooting writeups
+- one-off investigation notes
+
+Put that material in ignored local docs under `dev/local/` when it is useful for future work.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ unturtle              dLLM method layer (this repo)
                         ├── models/generation/    shared cache / block-decode / generation mixin
                         ├── diffusion/            MDLM / BD3LM trainer, collator, GRPO
                         ├── kernels/              Triton kernels, fast LoRA paths
-                        └── eval/                 smoke evaluators + lm-evaluation-harness adapter
+                        ├── eval/                 smoke evaluators + lm-evaluation-harness adapter
+                        └── cli/                  unturtle CLI (train / generate / export / eval)
 ```
 
 ## Quick start

--- a/benchmarks/a2d/benchmark_block_decode.py
+++ b/benchmarks/a2d/benchmark_block_decode.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Benchmark block-decode KV cache performance (Phase M.1 baseline).
+
+Compares:
+- origin: No caching, full forward every step
+- block_decode: Tuple cache with trimming (Phase M.1)
+
+Expected Phase M.1 baseline: ~1.0x speedup (infrastructure only, no optimization yet)
+Phase M target: ≥2.0x speedup (block-decode + parallel sampling)
+"""
+
+import time
+
+import torch
+
+from unturtle.models.conversion.a2d.tiny_a2d import (
+    TinyA2DLlamaConfig,
+    TinyA2DLlamaLMHeadModel,
+)
+from unturtle.models.generation.diffusion_generation_utils import (
+    MaskedDiffusionGenerationConfig,
+)
+
+
+def benchmark_generation(model, input_ids, gen_config, warmup=3, iters=10):
+    """Benchmark generation with warmup."""
+    # Warmup
+    for _ in range(warmup):
+        with torch.no_grad():
+            _ = model.diffusion_generate(inputs=input_ids, generation_config=gen_config)
+
+    # Benchmark
+    torch.cuda.synchronize() if torch.cuda.is_available() else None
+    start = time.perf_counter()
+    for _ in range(iters):
+        with torch.no_grad():
+            _ = model.diffusion_generate(inputs=input_ids, generation_config=gen_config)
+    torch.cuda.synchronize() if torch.cuda.is_available() else None
+    elapsed = time.perf_counter() - start
+
+    return elapsed / iters
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    # Tiny model for fast benchmarking
+    config = TinyA2DLlamaConfig(
+        vocab_size=256,
+        hidden_size=256,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        intermediate_size=512,
+        max_position_embeddings=512,
+    )
+    model = TinyA2DLlamaLMHeadModel(config)
+    model = model.to(device)
+    model.eval()
+
+    # Test parameters
+    batch_size = 2
+    prompt_len = 16
+    max_new_tokens = 32
+    num_steps = 4
+    block_length = 8
+    mask_token_id = 1
+
+    input_ids = torch.randint(
+        low=3,
+        high=config.vocab_size,
+        size=(batch_size, prompt_len),
+        device=device,
+    )
+
+    print("\nModel: A2D-4L-256H (tiny)")
+    print(f"Batch: {batch_size}, Prompt: {prompt_len}, Max new: {max_new_tokens}")
+    print(f"Steps: {num_steps}, Block length: {block_length}")
+    print("-" * 60)
+
+    # Benchmark origin (no cache)
+    gen_config_origin = MaskedDiffusionGenerationConfig(
+        max_new_tokens=max_new_tokens,
+        steps=num_steps,
+        alg="origin",
+        use_cache=False,
+        mask_token_id=mask_token_id,
+    )
+    time_origin = benchmark_generation(
+        model, input_ids, gen_config_origin, warmup=3, iters=10
+    )
+
+    # Benchmark block_decode (tuple cache)
+    gen_config_block = MaskedDiffusionGenerationConfig(
+        max_new_tokens=max_new_tokens,
+        steps=num_steps,
+        alg="origin",
+        use_cache=True,
+        block_length=block_length,
+        mask_token_id=mask_token_id,
+    )
+    time_block = benchmark_generation(
+        model, input_ids, gen_config_block, warmup=3, iters=10
+    )
+
+    # Results
+    speedup = time_origin / time_block
+    print(f"\nOrigin (no cache):     {time_origin * 1000:.2f} ms")
+    print(f"Block-decode (tuple):  {time_block * 1000:.2f} ms")
+    print(f"Speedup:               {speedup:.2f}x")
+    print()
+    print(
+        "Phase M.1 baseline: ~1.0x (infrastructure only, no block-decode optimization)"
+    )
+    print("Phase M target: ≥2.0x (block-decode + parallel sampling)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/a2d/benchmark_training.py
+++ b/benchmarks/a2d/benchmark_training.py
@@ -1,0 +1,212 @@
+"""Benchmark: A2D forward/loss/backward training throughput.
+
+Measures forward + masked diffusion loss + backward (no optimizer step)
+throughput across representative dLLM training shapes.
+
+Usage:
+    python benchmarks/a2d/benchmark_training.py
+
+Output:
+    Markdown table suitable for CLAUDE.md / PR comments.
+"""
+
+from __future__ import annotations
+
+import gc
+import time
+from dataclasses import dataclass
+
+import torch
+
+from unturtle.kernels.masked_diffusion_loss import fast_masked_diffusion_loss
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+WARMUP = 5
+ITERS = 20
+HIDDEN = 256
+N_HEADS = 4
+N_LAYERS = 2
+MAX_POS = 256
+
+SHAPES: list[tuple[int, int, int, str]] = [
+    # (batch, seq_len, vocab, loss_weight_type)
+    (2, 128, 32000, "uniform"),
+    (2, 512, 32000, "uniform"),
+    (4, 128, 128256, "uniform"),
+    (4, 512, 128256, "uniform"),
+    (2, 128, 32000, "timestep"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def _make_tiny_a2d_model(vocab: int) -> torch.nn.Module:
+    """Create a tiny A2D LLaMA model for benchmarking (randinit, no download)."""
+    from unturtle.models.conversion.a2d.tiny_a2d import (
+        TinyA2DLlamaConfig,
+        TinyA2DLlamaLMHeadModel,
+    )
+
+    cfg = TinyA2DLlamaConfig(
+        vocab_size=vocab,
+        hidden_size=HIDDEN,
+        intermediate_size=HIDDEN * 4,
+        num_hidden_layers=N_LAYERS,
+        num_attention_heads=N_HEADS,
+        num_key_value_heads=N_HEADS,
+        max_position_embeddings=MAX_POS,
+    )
+    model = TinyA2DLlamaLMHeadModel(cfg)
+    model.train()
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Benchmark
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchResult:
+    label: str
+    B: int
+    L: int
+    V: int
+    weight_type: str
+    tokens_per_sec: float
+    mem_mb: float
+
+
+def _bench_forward_backward(
+    model: torch.nn.Module,
+    input_ids: torch.Tensor,
+    labels: torch.Tensor,
+    diffusion_mask: torch.Tensor,
+    loss_weight_type: str,
+    timesteps: torch.Tensor,
+    warmup: int,
+    iters: int,
+) -> tuple[float, float]:
+    """Return (tokens_per_sec, peak_memory_mb)."""
+    torch.cuda.reset_peak_memory_stats()
+    mem_before = torch.cuda.memory_allocated()
+
+    # Warmup
+    for _ in range(warmup):
+        out = model(input_ids)
+        logits = out.logits
+        weights = None
+        if loss_weight_type == "timestep":
+            weights = (
+                (1.0 / timesteps.clamp_min(1e-6)).unsqueeze(1).expand_as(logits[..., 0])
+            )
+        loss = fast_masked_diffusion_loss(
+            logits=logits,
+            labels=labels,
+            diffusion_mask=diffusion_mask,
+            loss_weights=weights,
+        )
+        loss.backward()
+        model.zero_grad(set_to_none=True)
+    torch.cuda.synchronize()
+
+    start = time.perf_counter()
+    for _ in range(iters):
+        out = model(input_ids)
+        logits = out.logits
+        weights = None
+        if loss_weight_type == "timestep":
+            weights = (
+                (1.0 / timesteps.clamp_min(1e-6)).unsqueeze(1).expand_as(logits[..., 0])
+            )
+        loss = fast_masked_diffusion_loss(
+            logits=logits,
+            labels=labels,
+            diffusion_mask=diffusion_mask,
+            loss_weights=weights,
+        )
+        loss.backward()
+        model.zero_grad(set_to_none=True)
+    torch.cuda.synchronize()
+    end = time.perf_counter()
+
+    B, L = input_ids.shape
+    total_tokens = B * L * iters
+    elapsed = end - start
+    tokens_per_sec = total_tokens / elapsed
+
+    peak = torch.cuda.max_memory_allocated()
+    mem_mb = (peak - mem_before) / 1024**2
+    return tokens_per_sec, mem_mb
+
+
+def run_benchmarks() -> list[BenchResult]:
+    assert torch.cuda.is_available(), "CUDA required"
+    device = "cuda"
+    results: list[BenchResult] = []
+
+    for B, L, V, weight_type in SHAPES:
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        model = _make_tiny_a2d_model(V).to(device).to(torch.float32)
+
+        torch.manual_seed(0)
+        input_ids = torch.randint(0, V, (B, L), device=device)
+        labels = torch.randint(0, V, (B, L), device=device)
+        diffusion_mask = torch.rand(B, L, device=device) < 0.5
+        diffusion_mask[:, 0] = True
+        timesteps = torch.rand(B, device=device) * 0.9 + 0.1
+
+        tp, mem = _bench_forward_backward(
+            model,
+            input_ids,
+            labels,
+            diffusion_mask,
+            weight_type,
+            timesteps,
+            WARMUP,
+            ITERS,
+        )
+
+        label = f"unturtle (A2D-{N_LAYERS}L-{HIDDEN}H, {weight_type})"
+        results.append(BenchResult(label, B, L, V, weight_type, tp, mem))
+        print(
+            f"[B={B:2d} L={L:4d} V={V:7d} {weight_type}]  "
+            f"{tp:10,.0f} tokens/sec  "
+            f"mem={mem:.1f} MB"
+        )
+
+        del model
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    return results
+
+
+def _md_table(results: list[BenchResult]) -> str:
+    rows = []
+    rows.append("| Batch | SeqLen | Vocab | Weight | Tokens/sec | Mem (MB) |")
+    rows.append("|------:|-------:|------:|--------|-----------:|---------:|")
+    for r in results:
+        rows.append(
+            f"| {r.B} | {r.L} | {r.V:,} | {r.weight_type} | {r.tokens_per_sec:,.0f} | {r.mem_mb:6.1f} |"
+        )
+    return "\n".join(rows)
+
+
+if __name__ == "__main__":
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(f"Model: A2D-{N_LAYERS}L-{HIDDEN}H (tiny)")
+    print(f"Warmup={WARMUP} Iters={ITERS}\n")
+
+    results = run_benchmarks()
+
+    print("\n## Training Throughput Results\n")
+    print(_md_table(results))

--- a/benchmarks/gsm8k.py
+++ b/benchmarks/gsm8k.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GSM8K accuracy benchmark for masked-diffusion language models.
+
+Usage:
+    uv run python benchmarks/gsm8k.py --model dllm-hub/Qwen3-0.6B-diffusion-mdlm-v0.1 \\
+        --num-examples 100 --num-steps 128
+
+Results are saved to benchmarks/results/gsm8k_<model_slug>_<date>.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="GSM8K benchmark for dLLM models")
+    p.add_argument("--model", required=True, help="HF model ID or local path")
+    p.add_argument(
+        "--num-examples",
+        type=int,
+        default=None,
+        help="Number of test examples (default: all)",
+    )
+    p.add_argument(
+        "--num-steps", type=int, default=128, help="Diffusion steps (default: 128)"
+    )
+    p.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=256,
+        help="Max generated tokens (default: 256)",
+    )
+    p.add_argument(
+        "--temperature",
+        type=float,
+        default=0.0,
+        help="Sampling temperature (default: 0.0)",
+    )
+    p.add_argument(
+        "--load-in-4bit", action="store_true", help="Enable 4-bit quantisation"
+    )
+    p.add_argument(
+        "--split",
+        default="test",
+        choices=["test", "train"],
+        help="Dataset split (default: test)",
+    )
+    p.add_argument(
+        "--output-dir", default="benchmarks/results", help="Directory for JSON output"
+    )
+    p.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    return p.parse_args()
+
+
+def _load_model_and_tokenizer(model_id: str, load_in_4bit: bool):
+    try:
+        from unsloth import FastLanguageModel
+
+        model, tokenizer = FastLanguageModel.from_pretrained(
+            model_name=model_id,
+            load_in_4bit=load_in_4bit,
+        )
+        FastLanguageModel.for_inference(model)
+        return model, tokenizer
+    except ImportError:
+        import warnings
+
+        warnings.warn(
+            "unsloth is not installed; falling back to AutoModelForCausalLM. "
+            "diffusion_generate will not be available — benchmark results will use "
+            "model.generate and are NOT comparable to diffusion-model baselines.",
+            stacklevel=2,
+        )
+    # Only ImportError triggers the fallback. All other errors (OOM, bad model
+    # ID, for_inference failures) propagate so they are not silently swallowed.
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id,
+        load_in_4bit=load_in_4bit,
+        device_map="auto",
+    )
+    model.eval()
+    return model, tokenizer
+
+
+def _model_slug(model_id: str) -> str:
+    return Path(model_id).name
+
+
+def main() -> None:
+    args = _parse_args()
+
+    print(f"Loading model: {args.model}")
+    model, tokenizer = _load_model_and_tokenizer(args.model, args.load_in_4bit)
+
+    from unturtle.eval.gsm8k import GSM8KEvaluator
+
+    evaluator = GSM8KEvaluator(
+        model=model,
+        tokenizer=tokenizer,
+        num_steps=args.num_steps,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+    )
+
+    print(f"\nGSM8K Evaluation — {args.model}")
+    print(f"  examples : {args.num_examples or 'all'}")
+    print(f"  steps    : {args.num_steps}")
+    print("  " + "─" * 29)
+
+    metrics = evaluator.evaluate(
+        split=args.split,
+        num_examples=args.num_examples,
+        seed=args.seed,
+    )
+
+    prefix = "gsm8k"
+    n_correct = int(metrics[f"{prefix}_num_correct"])
+    n_total = int(metrics[f"{prefix}_num_examples"])
+    accuracy = metrics[f"{prefix}_accuracy"] * 100
+    parse_failures = int(metrics[f"{prefix}_parse_failures"])
+    gold_parse_failures = int(metrics[f"{prefix}_gold_parse_failures"])
+
+    print(f"  accuracy : {accuracy:.2f}% ({n_correct}/{n_total})")
+    print(f"  parse_failures: {parse_failures}")
+    if gold_parse_failures > 0:
+        print(f"  gold_parse_failures: {gold_parse_failures} (check dataset format)")
+    print("  " + "─" * 29)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    slug = _model_slug(args.model)
+    today = date.today().isoformat()
+    output_path = output_dir / f"gsm8k_{slug}_{today}.json"
+
+    result = {
+        "benchmark": "gsm8k",
+        "model": args.model,
+        "date": today,
+        "config": {
+            "num_steps": args.num_steps,
+            "max_new_tokens": args.max_new_tokens,
+            "temperature": args.temperature,
+            "num_examples": args.num_examples,
+            "split": args.split,
+            "seed": args.seed,
+        },
+        "metrics": metrics,
+    }
+    output_path.write_text(json.dumps(result, indent=2))
+    print(f"Results saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/gsm8k_sft.py
+++ b/benchmarks/gsm8k_sft.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GSM8K SFT verification: fine-tune a dLLM on GSM8K train, measure before/after accuracy.
+
+Usage (smoke test — ~5 min on one GPU):
+    uv run python benchmarks/gsm8k_sft.py \\
+        --num-train-samples 200 --num-epochs 1 --eval-examples 20
+
+Usage (full run — ~30–60 min):
+    uv run python benchmarks/gsm8k_sft.py
+
+Results saved to benchmarks/results/gsm8k_sft_<slug>_<date>.json.
+Checkpoint saved to outputs/gsm8k_sft/<date>/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import time
+from datetime import date
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import peft  # noqa: F401
+import torch
+import transformers  # noqa: F401
+import trl  # noqa: F401
+from datasets import load_dataset
+from peft import PeftModel
+
+import unturtle  # noqa: F401
+from unturtle import FastDiffusionModel
+from unturtle.diffusion import DiffusionTrainer, DiffusionTrainingArguments
+from unturtle.eval.gsm8k import DEFAULT_SYSTEM_PROMPT, GSM8KEvaluator
+from unturtle.models import TinyA2DQwen3LMHeadModel
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="GSM8K SFT verification for dLLM models")
+    p.add_argument(
+        "--model",
+        default="dllm-hub/Qwen3-0.6B-diffusion-mdlm-v0.1",
+        help=(
+            "HF model ID or local path for an A2D Qwen3 checkpoint "
+            "(default: Qwen3-0.6B-diffusion-mdlm-v0.1)"
+        ),
+    )
+    p.add_argument(
+        "--num-train-samples",
+        type=int,
+        default=7473,
+        help="GSM8K train examples for SFT (default: 7473 = full dataset)",
+    )
+    p.add_argument(
+        "--num-epochs", type=int, default=3, help="Training epochs (default: 3)"
+    )
+    p.add_argument(
+        "--eval-examples",
+        type=int,
+        default=100,
+        help="GSM8K test examples for before/after eval (default: 100)",
+    )
+    p.add_argument(
+        "--num-steps",
+        type=int,
+        default=128,
+        help="Diffusion steps for eval (default: 128)",
+    )
+    p.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=256,
+        help="Max generated tokens for eval (default: 256)",
+    )
+    p.add_argument("--lora-r", type=int, default=16, help="LoRA rank (default: 16)")
+    p.add_argument(
+        "--lora-alpha", type=int, default=32, help="LoRA alpha (default: 32)"
+    )
+    p.add_argument(
+        "--load-in-4bit", action="store_true", help="Enable 4-bit quantisation"
+    )
+    p.add_argument(
+        "--output-dir",
+        default="outputs/gsm8k_sft",
+        help="Parent directory for checkpoints (default: outputs/gsm8k_sft)",
+    )
+    p.add_argument(
+        "--results-dir",
+        default="benchmarks/results",
+        help="Directory for JSON results (default: benchmarks/results)",
+    )
+    p.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    return p.parse_args()
+
+
+def _set_seeds(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _model_slug(model_id: str) -> str:
+    return Path(model_id).name
+
+
+def _move_model_to_cuda_if_available(model: torch.nn.Module) -> torch.nn.Module:
+    if not torch.cuda.is_available():
+        return model
+
+    inner_model = model.get_base_model() if isinstance(model, PeftModel) else model
+    if getattr(inner_model, "is_loaded_in_4bit", False):
+        return model
+
+    return model.to("cuda")
+
+
+def _boxed_completion(answer: str) -> str:
+    reasoning, _, final = answer.partition("####")
+    final_value = final.strip() if final else answer.strip()
+    number_matches = re.findall(r"-?\d[\d,]*(?:\.\d+)?", final_value)
+    boxed_value = number_matches[-1].replace(",", "") if number_matches else final_value
+    reasoning = reasoning.rstrip()
+    if reasoning:
+        return f"{reasoning}\n\\boxed{{{boxed_value}}}"
+    return f"\\boxed{{{boxed_value}}}"
+
+
+def main() -> None:
+    args = _parse_args()
+    _set_seeds(args.seed)
+    print(f"Config: {json.dumps(vars(args), indent=2)}", flush=True)
+    # ------------------------------------------------------------------
+    # [1/5] Load model & tokenizer
+    # ------------------------------------------------------------------
+    print(f"\n[1/5] Loading model: {args.model} …", flush=True)
+
+    model, tokenizer = FastDiffusionModel.from_pretrained(
+        args.model,
+        model_class=TinyA2DQwen3LMHeadModel,
+        dtype=torch.bfloat16,
+        load_in_4bit=args.load_in_4bit,
+        trust_remote_code=True,
+    )
+    n_params = sum(p.numel() for p in model.parameters())
+    mask_token_id = tokenizer.mask_token_id or getattr(
+        model.config, "mask_token_id", None
+    )
+    if mask_token_id is not None:
+        model.config.mask_token_id = mask_token_id
+        if getattr(model, "generation_config", None) is not None:
+            model.generation_config.mask_token_id = mask_token_id
+    print(f"  Loaded: {n_params / 1e9:.3f}B params", flush=True)
+    print(f"  mask_token_id: {mask_token_id}", flush=True)
+
+    # ------------------------------------------------------------------
+    # [2/5] Apply LoRA
+    # ------------------------------------------------------------------
+    print("\n[2/5] Applying LoRA …", flush=True)
+
+    model = FastDiffusionModel.get_peft_model(
+        model,
+        r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        target_modules=[
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ],
+        lora_dropout=0,
+        bias="none",
+    )
+    n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    print(
+        f"  Trainable: {n_trainable / 1e6:.1f}M / {n_params / 1e9:.3f}B "
+        f"({n_trainable / n_params * 100:.2f}%)",
+        flush=True,
+    )
+
+    # ------------------------------------------------------------------
+    # [3/5] Evaluate BEFORE fine-tuning
+    # ------------------------------------------------------------------
+    print(
+        f"\n[3/5] Evaluating BEFORE fine-tuning ({args.eval_examples} examples) …",
+        flush=True,
+    )
+
+    model = _move_model_to_cuda_if_available(model)
+
+    evaluator = GSM8KEvaluator(
+        model=model,
+        tokenizer=tokenizer,
+        num_steps=args.num_steps,
+        max_new_tokens=args.max_new_tokens,
+        temperature=0.0,
+    )
+    before_metrics = evaluator.evaluate(
+        split="test",
+        num_examples=args.eval_examples,
+        seed=args.seed,
+    )
+    before_acc = before_metrics["gsm8k_accuracy"] * 100
+    before_correct = int(before_metrics["gsm8k_num_correct"])
+    before_total = int(before_metrics["gsm8k_num_examples"])
+    before_parse_failures = int(before_metrics["gsm8k_parse_failures"])
+    print(
+        f"  accuracy : {before_acc:.2f}% ({before_correct}/{before_total})",
+        flush=True,
+    )
+    print(f"  parse failures: {before_parse_failures}", flush=True)
+
+    # ------------------------------------------------------------------
+    # [4/5] Fine-tune on GSM8K train
+    # ------------------------------------------------------------------
+    print(
+        f"\n[4/5] Fine-tuning on GSM8K train "
+        f"({args.num_train_samples} samples, {args.num_epochs} epochs) …",
+        flush=True,
+    )
+
+    _SYSTEM = DEFAULT_SYSTEM_PROMPT
+    _MAX_LENGTH = 512
+
+    raw_train = cast(
+        Any,
+        load_dataset(
+            "openai/gsm8k",
+            "main",
+            split=f"train[:{args.num_train_samples}]",
+        ),
+    )
+
+    def _preprocess(example: dict) -> dict:
+        completion = _boxed_completion(example["answer"])
+        messages = [
+            {"role": "system", "content": _SYSTEM},
+            {"role": "user", "content": example["question"]},
+            {"role": "assistant", "content": completion},
+        ]
+        # Build full text to find prompt boundary
+        prompt_text = tokenizer.apply_chat_template(
+            messages[:-1],
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        completion_text = completion + (tokenizer.eos_token or "")
+        prompt_ids = tokenizer(prompt_text, add_special_tokens=False)["input_ids"]
+        completion_ids = tokenizer(completion_text, add_special_tokens=False)[
+            "input_ids"
+        ]
+        input_ids = (prompt_ids + completion_ids)[:_MAX_LENGTH]
+        labels = ([-100] * len(prompt_ids) + completion_ids)[:_MAX_LENGTH]
+        return {"input_ids": input_ids, "labels": labels}
+
+    train_dataset = raw_train.map(
+        _preprocess,
+        remove_columns=raw_train.column_names,
+        desc="Tokenising GSM8K train",
+    )
+    train_dataset = train_dataset.filter(
+        lambda x: sum(1 for lbl in x["labels"] if lbl != -100) > 0
+    )
+    print(f"  train examples after filter: {len(train_dataset)}", flush=True)
+
+    today_str = date.today().isoformat()
+    run_id = time.strftime("%Y%m%d-%H%M%S")
+    checkpoint_dir = os.path.join(args.output_dir, run_id)
+    os.makedirs(checkpoint_dir, exist_ok=False)
+
+    use_cuda = torch.cuda.is_available()
+    use_bf16 = use_cuda and torch.cuda.is_bf16_supported()
+    training_args = cast(Any, DiffusionTrainingArguments)(
+        output_dir=checkpoint_dir,
+        num_train_epochs=args.num_epochs,
+        per_device_train_batch_size=4,
+        gradient_accumulation_steps=1,
+        learning_rate=1e-4,
+        lr_scheduler_type="cosine",
+        warmup_ratio=0.05,
+        bf16=use_bf16,
+        fp16=use_cuda and not use_bf16,
+        logging_steps=10,
+        disable_tqdm=True,
+        eval_strategy="no",
+        save_strategy="epoch",
+        report_to="none",
+        loss_weight_type="uniform",
+        completion_only=True,
+        dataloader_num_workers=0,
+    )
+
+    trainer = DiffusionTrainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        processing_class=tokenizer,
+    )
+
+    if use_cuda:
+        torch.cuda.reset_peak_memory_stats()
+    t0 = time.time()
+    train_result = trainer.train()
+    elapsed = time.time() - t0
+    peak_vram_gb = torch.cuda.max_memory_allocated() / 1e9 if use_cuda else 0.0
+
+    train_losses = [
+        e["loss"]
+        for e in trainer.state.log_history
+        if "loss" in e and "eval_loss" not in e
+    ]
+    train_loss_final = train_losses[-1] if train_losses else float("nan")
+
+    print(f"  train_loss : {train_loss_final:.4f}", flush=True)
+    print(f"  steps      : {train_result.global_step}", flush=True)
+    print(f"  elapsed    : {elapsed / 60:.1f} min", flush=True)
+    print(f"  peak VRAM  : {peak_vram_gb:.2f} GB", flush=True)
+    print(f"  checkpoint : {checkpoint_dir}", flush=True)
+
+    # ------------------------------------------------------------------
+    # [5/5] Evaluate AFTER fine-tuning
+    # ------------------------------------------------------------------
+    print(
+        f"\n[5/5] Evaluating AFTER fine-tuning ({args.eval_examples} examples) …",
+        flush=True,
+    )
+
+    evaluator = GSM8KEvaluator(
+        model=model,
+        tokenizer=tokenizer,
+        num_steps=args.num_steps,
+        max_new_tokens=args.max_new_tokens,
+        temperature=0.0,
+    )
+    after_metrics = evaluator.evaluate(
+        split="test",
+        num_examples=args.eval_examples,
+        seed=args.seed,
+    )
+    after_acc = after_metrics["gsm8k_accuracy"] * 100
+    after_correct = int(after_metrics["gsm8k_num_correct"])
+    after_total = int(after_metrics["gsm8k_num_examples"])
+    after_parse_failures = int(after_metrics["gsm8k_parse_failures"])
+    delta_pp = after_acc - before_acc
+
+    print(
+        f"  accuracy : {after_acc:.2f}% ({after_correct}/{after_total})",
+        flush=True,
+    )
+    print(f"  parse failures: {after_parse_failures}", flush=True)
+    print("  " + "─" * 38, flush=True)
+    sign = "+" if delta_pp >= 0 else ""
+    print(f"  delta    : {sign}{delta_pp:.2f}pp", flush=True)
+
+    # ------------------------------------------------------------------
+    # Save JSON result
+    # ------------------------------------------------------------------
+    result = {
+        "benchmark": "gsm8k_sft",
+        "model": args.model,
+        "date": today_str,
+        "config": {
+            "num_train_samples": args.num_train_samples,
+            "num_epochs": args.num_epochs,
+            "lora_r": args.lora_r,
+            "lora_alpha": args.lora_alpha,
+            "eval_examples": args.eval_examples,
+            "num_steps": args.num_steps,
+            "max_new_tokens": args.max_new_tokens,
+            "load_in_4bit": args.load_in_4bit,
+            "seed": args.seed,
+        },
+        "before": {
+            "gsm8k_accuracy": before_metrics["gsm8k_accuracy"],
+            "gsm8k_num_correct": before_correct,
+            "gsm8k_num_examples": before_total,
+            "gsm8k_parse_failures": int(before_metrics["gsm8k_parse_failures"]),
+        },
+        "after": {
+            "gsm8k_accuracy": after_metrics["gsm8k_accuracy"],
+            "gsm8k_num_correct": after_correct,
+            "gsm8k_num_examples": after_total,
+            "gsm8k_parse_failures": int(after_metrics["gsm8k_parse_failures"]),
+        },
+        "delta": {
+            "gsm8k_accuracy": after_metrics["gsm8k_accuracy"]
+            - before_metrics["gsm8k_accuracy"],
+        },
+        "training": {
+            "train_loss_final": train_loss_final,
+            "elapsed_seconds": elapsed,
+            "steps": train_result.global_step,
+            "peak_vram_gb": peak_vram_gb,
+        },
+    }
+
+    results_dir = Path(args.results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+    slug = _model_slug(args.model)
+    output_path = results_dir / f"gsm8k_sft_{slug}_{run_id}.json"
+    output_path.write_text(json.dumps(result, indent=2))
+    print(f"Results saved to {output_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_loss.py
+++ b/benchmarks/kernels/benchmark_loss.py
@@ -1,0 +1,264 @@
+"""Benchmark: fast_masked_diffusion_loss (Triton) vs reference dLLM implementations.
+
+Four implementations are compared:
+
+1. **Triton** (unturtle): fast_masked_diffusion_loss — chunked Triton CE kernel,
+   operates only on masked positions (label=-100 trick).
+
+2. **d1-style** (reference): F.cross_entropy over all tokens with labels=-100 at
+   unmasked positions, then divide by t.  This is exactly what d1/LLaDA use in
+   practice (dev/repos/d1/SFT/sft_trainer.py).
+
+3. **PyTorch masked** (baseline): same mask logic as Triton but using stock
+   F.cross_entropy — the minimal Python-level equivalent without Triton.
+
+4. **Fused** (unturtle D4): fused masked diffusion loss path for comparison with
+   the chunked Triton implementation and Python/reference baselines.
+
+Measuring throughput (ms/iter) and peak GPU memory across typical dLLM shapes.
+
+Usage:
+    python benchmarks/kernels/benchmark_loss.py
+
+Output:
+    Markdown table suitable for CLAUDE.md / PR comments.
+"""
+
+from __future__ import annotations
+
+import gc
+import time
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from unturtle.kernels.fused_masked_diffusion_loss import fused_masked_diffusion_loss
+from unturtle.kernels.masked_diffusion_loss import fast_masked_diffusion_loss
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+WARMUP = 10
+ITERS = 100
+MASK_RATIO = 0.5  # typical for dLLM training
+
+SHAPES: list[tuple[int, int, int]] = [
+    # (batch, seq_len, vocab)   — representative dLLM shapes
+    (4, 128, 32000),  # LLaMA-3 vocab, short seq
+    (4, 512, 32000),  # LLaMA-3 vocab, medium seq
+    (2, 128, 128256),  # LLaMA-3.1 vocab (128K)
+    (2, 512, 128256),  # LLaMA-3.1 vocab, medium seq
+    (1, 1024, 128256),  # long seq
+    (4, 128, 126464),  # LLaDA vocab (~126K)
+    (4, 512, 126464),  # LLaDA vocab, medium seq
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_inputs(
+    B: int, L: int, V: int, device: str = "cuda"
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(0)
+    logits = torch.randn(B, L, V, device=device, dtype=torch.float32)
+    labels = torch.randint(0, V, (B, L), device=device)
+    mask = torch.rand(B, L, device=device) < MASK_RATIO
+    mask[:, 0] = True
+    return logits, labels, mask
+
+
+def _pytorch_masked_loss(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    diffusion_mask: torch.Tensor,
+) -> torch.Tensor:
+    """PyTorch baseline: same mask logic as Triton, no Triton kernel."""
+    B, L, V = logits.shape
+    masked_labels = labels.clone()
+    masked_labels[~diffusion_mask] = -100
+    per_token = F.cross_entropy(
+        logits.reshape(B * L, V),
+        masked_labels.reshape(-1),
+        ignore_index=-100,
+        reduction="none",
+    ).view(B, L)
+    return per_token.sum() / diffusion_mask.sum().clamp_min(1)
+
+
+def _d1_style_loss(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    diffusion_mask: torch.Tensor,
+    t: float = 0.5,
+) -> torch.Tensor:
+    """d1/LLaDA reference: F.cross_entropy over all tokens, then divide by t.
+
+    Source: dev/repos/d1/SFT/sft_trainer.py  dLLMTrainer.compute_loss()
+    Labels at unmasked positions are already -100 (as set by the collator).
+    """
+    B, L, V = logits.shape
+    # d1 uses labels=-100 at unmasked positions (same convention as ours)
+    masked_labels = labels.clone()
+    masked_labels[~diffusion_mask] = -100
+    unscaled = F.cross_entropy(
+        logits.view(-1, V),
+        masked_labels.view(-1),
+        reduction="none",
+    ).view(B, L)
+    # d1 divides by t (scalar broadcast per sequence)
+    loss = unscaled / t
+    # normalize by the number of non-ignored (maskable) positions
+    n_total = (masked_labels != -100).sum().clamp_min(1)
+    return loss.sum() / n_total
+
+
+@dataclass
+class BenchResult:
+    label: str
+    B: int
+    L: int
+    V: int
+    time_ms: float  # mean wall time per iteration (ms)
+    mem_mb: float  # peak GPU memory delta (MB)
+    loss: float  # sanity-check loss value
+
+
+def _bench_fn(
+    fn, logits, labels, mask, warmup: int, iters: int
+) -> tuple[float, float, float]:
+    """Return (mean_ms, peak_memory_delta_mb, loss_value)."""
+    loss = fn(logits, labels, mask)
+
+    # Warmup
+    for _ in range(warmup):
+        loss = fn(logits, labels, mask)
+    torch.cuda.synchronize()
+
+    torch.cuda.reset_peak_memory_stats()
+    mem_before = torch.cuda.memory_allocated()
+
+    start = time.perf_counter()
+    for _ in range(iters):
+        loss = fn(logits, labels, mask)
+    torch.cuda.synchronize()
+    end = time.perf_counter()
+
+    peak = torch.cuda.max_memory_allocated()
+    mean_ms = (end - start) / iters * 1000
+    mem_mb = (peak - mem_before) / 1024**2
+    return mean_ms, mem_mb, float(loss.item())
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def run_benchmarks() -> list[BenchResult]:
+    assert torch.cuda.is_available(), "CUDA required"
+    device = "cuda"
+    results: list[BenchResult] = []
+
+    for B, L, V in SHAPES:
+        logits, labels, mask = _make_inputs(B, L, V, device)
+
+        # --- Triton (unturtle) ---
+        gc.collect()
+        torch.cuda.empty_cache()
+        tri_ms, tri_mem, tri_loss = _bench_fn(
+            fast_masked_diffusion_loss, logits, labels, mask, WARMUP, ITERS
+        )
+        results.append(
+            BenchResult("Triton (unturtle)", B, L, V, tri_ms, tri_mem, tri_loss)
+        )
+
+        # --- d1/LLaDA reference ---
+        gc.collect()
+        torch.cuda.empty_cache()
+        d1_ms, d1_mem, d1_loss = _bench_fn(
+            _d1_style_loss, logits, labels, mask, WARMUP, ITERS
+        )
+        results.append(
+            BenchResult("d1-style (reference)", B, L, V, d1_ms, d1_mem, d1_loss)
+        )
+
+        # --- PyTorch masked baseline ---
+        gc.collect()
+        torch.cuda.empty_cache()
+        py_ms, py_mem, py_loss = _bench_fn(
+            _pytorch_masked_loss, logits, labels, mask, WARMUP, ITERS
+        )
+        results.append(BenchResult("PyTorch masked", B, L, V, py_ms, py_mem, py_loss))
+
+        # --- Fused (unturtle Phase D4) ---
+        gc.collect()
+        torch.cuda.empty_cache()
+        fused_ms, fused_mem, fused_loss = _bench_fn(
+            fused_masked_diffusion_loss, logits, labels, mask, WARMUP, ITERS
+        )
+        results.append(
+            BenchResult("Fused (unturtle D4)", B, L, V, fused_ms, fused_mem, fused_loss)
+        )
+
+        print(
+            f"[B={B:2d} L={L:4d} V={V:6d}]  "
+            f"Triton {tri_ms:6.2f}ms  "
+            f"d1-ref {d1_ms:6.2f}ms (x{d1_ms / tri_ms:.2f})  "
+            f"PyTorch {py_ms:6.2f}ms (x{py_ms / tri_ms:.2f})  "
+            f"Fused {fused_ms:6.2f}ms (x{fused_ms / tri_ms:.2f})  "
+            f"| mem Triton={tri_mem:.1f}MB d1={d1_mem:.1f}MB Fused={fused_mem:.1f}MB"
+        )
+
+    return results
+
+
+def _md_table(results: list[BenchResult]) -> str:
+    rows = []
+    rows.append(
+        "| Batch | SeqLen | Vocab | Impl | Time (ms) | Mem (MB) | vs d1-ref | vs PyTorch |"
+    )
+    rows.append(
+        "|------:|-------:|------:|------|----------:|---------:|----------:|-----------:|"
+    )
+
+    it = iter(results)
+    for tri in it:
+        d1 = next(it)
+        py = next(it)
+        fused = next(it)
+        rows.append(
+            f"| {tri.B} | {tri.L} | {tri.V:,} | **Triton (unturtle)** |"
+            f" {tri.time_ms:7.2f} | {tri.mem_mb:6.1f} |"
+            f" **{d1.time_ms / tri.time_ms:.2f}x** |"
+            f" **{py.time_ms / tri.time_ms:.2f}x** |"
+        )
+        rows.append(
+            f"| | | | d1-style (reference) |"
+            f" {d1.time_ms:7.2f} | {d1.mem_mb:6.1f} | — | — |"
+        )
+        rows.append(
+            f"| | | | PyTorch masked | {py.time_ms:7.2f} | {py.mem_mb:6.1f} | — | — |"
+        )
+        rows.append(
+            f"| | | | **Fused (unturtle D4)** |"
+            f" {fused.time_ms:7.2f} | {fused.mem_mb:6.1f} |"
+            f" **{d1.time_ms / fused.time_ms:.2f}x** |"
+            f" **{py.time_ms / fused.time_ms:.2f}x** |"
+        )
+    return "\n".join(rows)
+
+
+if __name__ == "__main__":
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(f"Shapes: {SHAPES}")
+    print(f"Warmup={WARMUP} Iters={ITERS} mask_ratio={MASK_RATIO}\n")
+
+    results = run_benchmarks()
+
+    print("\n## Benchmark Results\n")
+    print(_md_table(results))

--- a/benchmarks/modernbert/benchmark_dllm.py
+++ b/benchmarks/modernbert/benchmark_dllm.py
@@ -1,0 +1,273 @@
+"""
+Headless benchmark script for ModernBERT-base dLLM SFT with dllm (reference).
+
+REQUIRES: a separate venv with dllm installed (dllm depends on transformers 4.x).
+Setup:
+    uv venv .venvDllm --python 3.12
+    .venvDllm/bin/python -m pip install torch torchvision torchaudio \
+        --index-url https://download.pytorch.org/whl/cu124
+    .venvDllm/bin/python -m pip install -e dev/repos/dllm/
+
+Usage (from project root):
+    .venvDllm/bin/python benchmarks/modernbert/benchmark_dllm.py
+
+Metrics saved to: outputs/benchmark_modernbert_dllm/benchmark.json
+Loss history: outputs/benchmark_modernbert_dllm/loss_history.json
+"""
+
+import json
+import logging
+import os
+import random
+import time
+
+import numpy as np
+import torch
+from datasets import load_dataset
+from dllm.core.trainers import MDLMConfig, MDLMTrainer
+from peft import LoraConfig, get_peft_model
+from transformers import (
+    AutoTokenizer,
+    ModernBertForMaskedLM,
+)
+
+# Silence excessive logging
+logging.getLogger("transformers").setLevel(logging.WARNING)
+logging.getLogger("datasets").setLevel(logging.WARNING)
+
+# ---------------------------------------------------------------------------
+# Config — matched to unturtle benchmark for apples-to-apples comparison
+# ---------------------------------------------------------------------------
+CFG = {
+    "model_name": "answerdotai/ModernBERT-base",
+    "output_dir": "outputs/benchmark_modernbert_dllm",
+    "train_samples": 2000,
+    "eval_samples": 200,
+    "num_epochs": 2,
+    "batch_size": 4,
+    "lora_r": 16,
+    "lora_alpha": 32,
+    "lr": 1e-5,
+    "max_length": 512,
+    "loss_weight_type": "uniform",
+    "seed": 42,
+}
+print(json.dumps(CFG, indent=2), flush=True)
+
+# ---------------------------------------------------------------------------
+# Seed for reproducibility
+# ---------------------------------------------------------------------------
+random.seed(CFG["seed"])
+np.random.seed(CFG["seed"])
+torch.manual_seed(CFG["seed"])
+if torch.cuda.is_available():
+    torch.cuda.manual_seed_all(CFG["seed"])
+
+# ---------------------------------------------------------------------------
+# Model & tokenizer
+# ---------------------------------------------------------------------------
+print(f"\n[1/4] Loading model: {CFG['model_name']} …", flush=True)
+tokenizer = AutoTokenizer.from_pretrained(CFG["model_name"])
+tokenizer.padding_side = "right"  # required by MDLMTrainer
+
+model = ModernBertForMaskedLM.from_pretrained(
+    CFG["model_name"],
+    torch_dtype=torch.bfloat16,
+)
+model.cuda()
+model.train()
+n_params = sum(p.numel() for p in model.parameters())
+print(f"  Loaded: {n_params / 1e9:.3f}B params", flush=True)
+
+# ---------------------------------------------------------------------------
+# LoRA
+# ---------------------------------------------------------------------------
+print("\n[2/4] Applying LoRA …", flush=True)
+lora_config = LoraConfig(
+    r=CFG["lora_r"],
+    lora_alpha=CFG["lora_alpha"],
+    target_modules=["Wqkv", "Wo"],
+    lora_dropout=0,
+    bias="none",
+)
+model = get_peft_model(model, lora_config)
+n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+print(
+    f"  Trainable: {n_trainable / 1e6:.1f}M / {n_params / 1e9:.3f}B "
+    f"({n_trainable / n_params * 100:.2f}%)",
+    flush=True,
+)
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+print("\n[3/4] Loading dataset …", flush=True)
+
+raw = load_dataset(
+    "allenai/tulu-3-sft-mixture",
+    split={
+        "train": f"train[:{CFG['train_samples']}]",
+        "test": f"train[10000:{10000 + CFG['eval_samples']}]",
+    },
+)
+
+eos = tokenizer.eos_token or ""
+
+
+def preprocess(example):
+    """Flatten messages to text; ModernBERT tokenizer lacks chat_template."""
+    msgs = example["messages"]
+    prompt_parts = []
+    for m in msgs:
+        if m["role"] != "assistant":
+            prompt_parts.append(f"<|{m['role']}|>\n{m['content']}")
+        else:
+            # Last assistant message = completion
+            prompt_text = "\n\n".join(prompt_parts) + "\n\n<|assistant|>\n"
+            completion_text = m["content"] + eos
+            prompt_ids = tokenizer(prompt_text, add_special_tokens=False)["input_ids"]
+            completion_ids = tokenizer(completion_text, add_special_tokens=False)[
+                "input_ids"
+            ]
+            input_ids = (prompt_ids + completion_ids)[: CFG["max_length"]]
+            labels = ([-100] * len(prompt_ids) + completion_ids)[: CFG["max_length"]]
+            return {
+                "input_ids": input_ids,
+                "labels": labels,
+                "attention_mask": [1] * len(input_ids),
+            }
+    # Fallback: no completion
+    return {"input_ids": [], "labels": [], "attention_mask": []}
+
+
+dataset = raw.map(
+    preprocess, remove_columns=raw["train"].column_names, desc="Tokenising"
+)
+dataset = dataset.filter(lambda x: sum(1 for _l in x["labels"] if _l != -100) > 0)
+print(f"  train: {len(dataset['train'])}  /  test: {len(dataset['test'])}", flush=True)
+
+
+def data_collator_fn(features):
+    """Simple collator for SDLM: pads and stacks input_ids/labels/attention_mask."""
+    input_ids = [f["input_ids"] for f in features]
+    labels = [f["labels"] for f in features]
+    attention_mask = [f["attention_mask"] for f in features]
+
+    max_len = max(len(x) for x in input_ids)
+    pad_id = tokenizer.pad_token_id or 0
+
+    batch_input_ids = []
+    batch_labels = []
+    batch_attention_mask = []
+
+    for ids, lbs, mask in zip(input_ids, labels, attention_mask, strict=False):
+        pad_len = max_len - len(ids)
+        batch_input_ids.append(ids + [pad_id] * pad_len)
+        batch_labels.append(lbs + [-100] * pad_len)
+        batch_attention_mask.append(mask + [0] * pad_len)
+
+    return {
+        "input_ids": torch.tensor(batch_input_ids, dtype=torch.long),
+        "labels": torch.tensor(batch_labels, dtype=torch.long),
+        "attention_mask": torch.tensor(batch_attention_mask, dtype=torch.long),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Trainer (dllm MDLMTrainer)
+# ---------------------------------------------------------------------------
+print("\n[4/4] Training …", flush=True)
+os.makedirs(CFG["output_dir"], exist_ok=True)
+
+# MDLMConfig from dllm (inherits from transformers TrainingArguments)
+mdlm_args = MDLMConfig(
+    output_dir=CFG["output_dir"],
+    num_train_epochs=CFG["num_epochs"],
+    per_device_train_batch_size=CFG["batch_size"],
+    per_device_eval_batch_size=CFG["batch_size"],
+    learning_rate=CFG["lr"],
+    lr_scheduler_type="cosine",
+    warmup_ratio=0.05,
+    loss_weight_type=CFG["loss_weight_type"],
+    loss_norm_type="token",
+    right_shift_logits=False,  # disable to match unturtle behavior
+    logging_steps=10,
+    eval_strategy="epoch",
+    save_strategy="epoch",
+    report_to="none",
+    bf16=True,
+    dataloader_num_workers=0,
+)
+
+# Collect metrics
+losses = []
+original_log = getattr(MDLMTrainer, "log", None)
+
+
+def capturing_log(self_inner, logs, start_time=None, **kw):
+    if "loss" in logs:
+        losses.append(float(logs["loss"]))
+    if original_log:
+        original_log(self_inner, logs, start_time=start_time, **kw)
+
+
+torch.cuda.reset_peak_memory_stats()
+
+MDLMTrainer.log = capturing_log
+t0 = time.time()
+
+trainer = MDLMTrainer(
+    args=mdlm_args,
+    model=model,
+    train_dataset=dataset["train"],
+    eval_dataset=dataset["test"],
+    data_collator=data_collator_fn,
+    processing_class=tokenizer,
+)
+result = trainer.train()
+
+elapsed = time.time() - t0
+MDLMTrainer.log = original_log
+
+peak_vram = torch.cuda.max_memory_allocated() / 1e9
+
+print(f"\n{'=' * 60}", flush=True)
+print("Training complete!", flush=True)
+print(f"  train_loss : {result.training_loss:.4f}", flush=True)
+print(f"  steps      : {result.global_step}", flush=True)
+print(f"  elapsed    : {elapsed / 60:.1f} min", flush=True)
+print(f"  peak VRAM  : {peak_vram:.2f} GB", flush=True)
+print(f"  checkpoint : {CFG['output_dir']}", flush=True)
+
+# Save loss history (normalized schema: step + loss/eval_loss)
+loss_history = [{"step": (i + 1) * 10, "loss": l} for i, l in enumerate(losses)]
+with open(os.path.join(CFG["output_dir"], "loss_history.json"), "w") as f:
+    json.dump(loss_history, f, indent=2)
+print(f"  loss log   : {CFG['output_dir']}/loss_history.json", flush=True)
+
+# Save benchmark summary
+all_losses = [e for e in losses]
+benchmark = {
+    "framework": "dllm",
+    "model": CFG["model_name"],
+    "train_loss_avg": sum(all_losses) / len(all_losses) if all_losses else None,
+    "train_loss_first50": sum(all_losses[:50]) / min(50, len(all_losses))
+    if all_losses
+    else None,
+    "train_loss_last50": sum(all_losses[-50:]) / min(50, len(all_losses))
+    if all_losses
+    else None,
+    "elapsed_seconds": elapsed,
+    "peak_vram_gb": peak_vram,
+    "steps": result.global_step,
+    "steps_per_second": result.global_step / elapsed if elapsed > 0 else 0,
+    "n_params_total": n_params,
+    "n_params_trainable": n_trainable,
+    "epochs": CFG["num_epochs"],
+    "batch_size": CFG["batch_size"],
+    "lora_r": CFG["lora_r"],
+    "loss_weight_type": CFG["loss_weight_type"],
+}
+with open(os.path.join(CFG["output_dir"], "benchmark.json"), "w") as f:
+    json.dump(benchmark, f, indent=2)
+print(f"  benchmark  : {CFG['output_dir']}/benchmark.json", flush=True)

--- a/benchmarks/modernbert/benchmark_unturtle.py
+++ b/benchmarks/modernbert/benchmark_unturtle.py
@@ -1,0 +1,237 @@
+"""
+Headless benchmark script for ModernBERT-base dLLM SFT with unturtle.
+
+Usage:
+    nohup uv run python benchmarks/modernbert/benchmark_unturtle.py > logs/benchmark_modernbert_unturtle.log 2>&1 &
+
+Metrics saved to: outputs/benchmark_modernbert_unturtle/benchmark.json
+Loss history: outputs/benchmark_modernbert_unturtle/loss_history.json
+"""
+
+import json
+import os
+import random
+import time
+
+import numpy as np
+import peft  # noqa: F401
+import torch
+import transformers
+import trl  # noqa: F401
+from datasets import load_dataset
+
+import unturtle  # noqa: F401
+from unturtle import FastDiffusionModel
+from unturtle.diffusion import DiffusionTrainer, DiffusionTrainingArguments
+from unturtle.models.backbones.modernbert import DiffusionModernBertForMaskedLM
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+CFG = {
+    "model_name": "answerdotai/ModernBERT-base",
+    "output_dir": "outputs/benchmark_modernbert_unturtle",
+    "train_samples": 2000,
+    "eval_samples": 200,
+    "num_epochs": 2,
+    "batch_size": 4,
+    "lora_r": 16,
+    "lora_alpha": 32,
+    "lr": 1e-5,
+    "max_length": 512,
+    "seed": 42,
+}
+print(json.dumps(CFG, indent=2), flush=True)
+
+# ---------------------------------------------------------------------------
+# Seed for reproducibility
+# ---------------------------------------------------------------------------
+random.seed(CFG["seed"])
+np.random.seed(CFG["seed"])
+torch.manual_seed(CFG["seed"])
+if torch.cuda.is_available():
+    torch.cuda.manual_seed_all(CFG["seed"])
+
+# ---------------------------------------------------------------------------
+# Model & tokenizer
+# ---------------------------------------------------------------------------
+print(f"\n[1/5] Loading model: {CFG['model_name']} …", flush=True)
+
+# ModernBERT auto-detect doesn't work (model_type="modernbert"), so we pass
+# the diffusion class explicitly.
+model, tokenizer = FastDiffusionModel.from_pretrained(
+    CFG["model_name"],
+    model_class=DiffusionModernBertForMaskedLM,
+    dtype=torch.bfloat16,
+    load_in_4bit=False,
+)
+n_params = sum(p.numel() for p in model.parameters())
+print(f"  Loaded: {n_params / 1e9:.3f}B params", flush=True)
+
+mask_token_id = tokenizer.mask_token_id or getattr(model.config, "mask_token_id", None)
+print(f"  mask_token_id: {mask_token_id}", flush=True)
+
+# DiffusionModernBertForMaskedLM overrides model_type to "modernbert-diffusion",
+# but the upstream config loaded from the hub retains "modernbert".
+# Overwrite so patch_peft_model recognizes it.
+model.config.model_type = "modernbert-diffusion"
+
+# ---------------------------------------------------------------------------
+# LoRA
+# ---------------------------------------------------------------------------
+print("\n[2/5] Applying LoRA …", flush=True)
+
+# ModernBERT uses fused Wqkv and Wo for attention (not split q/k/v/o_proj).
+# MLP modules (Wi, Wii, Wo) can also be targeted but won't get Triton kernels
+# yet — see issue #59 Phase 2.
+model = FastDiffusionModel.get_peft_model(
+    model,
+    r=CFG["lora_r"],
+    lora_alpha=CFG["lora_alpha"],
+    target_modules=["Wqkv", "Wo"],
+    lora_dropout=0,
+    bias="none",
+)
+n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+print(
+    f"  Trainable: {n_trainable / 1e6:.1f}M / {n_params / 1e9:.3f}B "
+    f"({n_trainable / n_params * 100:.2f}%)",
+    flush=True,
+)
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+print("\n[3/5] Loading dataset …", flush=True)
+
+raw = load_dataset(
+    "allenai/tulu-3-sft-mixture",
+    split={
+        "train": f"train[:{CFG['train_samples']}]",
+        "test": f"train[10000:{10000 + CFG['eval_samples']}]",
+    },
+)
+
+eos = tokenizer.eos_token or ""
+
+
+def preprocess(example):
+    """Flatten messages to text; ModernBERT tokenizer lacks chat_template."""
+    msgs = example["messages"]
+    prompt_parts = []
+    for m in msgs:
+        if m["role"] != "assistant":
+            prompt_parts.append(f"<|{m['role']}|>\n{m['content']}")
+        else:
+            # Last assistant message = completion
+            prompt_text = "\n\n".join(prompt_parts) + "\n\n<|assistant|>\n"
+            completion_text = m["content"] + eos
+            prompt_ids = tokenizer(prompt_text, add_special_tokens=False)["input_ids"]
+            completion_ids = tokenizer(completion_text, add_special_tokens=False)[
+                "input_ids"
+            ]
+            input_ids = (prompt_ids + completion_ids)[: CFG["max_length"]]
+            labels = ([-100] * len(prompt_ids) + completion_ids)[: CFG["max_length"]]
+            return {"input_ids": input_ids, "labels": labels}
+    # Fallback: no completion
+    return {"input_ids": [], "labels": []}
+
+
+dataset = raw.map(
+    preprocess, remove_columns=raw["train"].column_names, desc="Tokenising"
+)
+dataset = dataset.filter(lambda x: sum(1 for l in x["labels"] if l != -100) > 0)
+print(f"  train: {len(dataset['train'])}  /  test: {len(dataset['test'])}", flush=True)
+
+# ---------------------------------------------------------------------------
+# Trainer
+# ---------------------------------------------------------------------------
+print("\n[4/5] Setting up trainer …", flush=True)
+os.makedirs(CFG["output_dir"], exist_ok=True)
+
+training_args = DiffusionTrainingArguments(
+    output_dir=CFG["output_dir"],
+    num_train_epochs=CFG["num_epochs"],
+    per_device_train_batch_size=CFG["batch_size"],
+    per_device_eval_batch_size=CFG["batch_size"],
+    learning_rate=CFG["lr"],
+    lr_scheduler_type="cosine",
+    warmup_ratio=0.05,
+    bf16=True,
+    logging_steps=10,
+    disable_tqdm=True,
+    eval_strategy="epoch",
+    save_strategy="epoch",
+    report_to="none",
+    loss_weight_type="uniform",
+    dataloader_num_workers=0,
+)
+
+trainer = DiffusionTrainer(
+    model=model,
+    args=training_args,
+    train_dataset=dataset["train"],
+    eval_dataset=dataset["test"],
+    processing_class=tokenizer,
+)
+
+# ---------------------------------------------------------------------------
+# Train
+# ---------------------------------------------------------------------------
+print("\n[5/5] Training …", flush=True)
+
+torch.cuda.reset_peak_memory_stats()
+
+t0 = time.time()
+result = trainer.train()
+elapsed = time.time() - t0
+
+peak_vram = torch.cuda.max_memory_allocated() / 1e9
+print(f"\n{'=' * 60}", flush=True)
+print("Training complete!", flush=True)
+print(f"  train_loss : {result.training_loss:.4f}", flush=True)
+print(f"  steps      : {result.global_step}", flush=True)
+print(f"  elapsed    : {elapsed / 60:.1f} min", flush=True)
+print(f"  peak VRAM  : {peak_vram:.2f} GB", flush=True)
+print(f"  checkpoint : {CFG['output_dir']}", flush=True)
+
+# Save loss history (normalized schema: step + loss/eval_loss)
+loss_history = [
+    {"step": int(e.get("step", 0)), "loss": e["loss"]}
+    for e in trainer.state.log_history
+    if "loss" in e and "eval_" not in e
+]
+loss_history.extend(
+    [
+        {"step": int(e.get("step", 0)), "eval_loss": e["eval_loss"]}
+        for e in trainer.state.log_history
+        if "eval_loss" in e
+    ]
+)
+loss_history.sort(key=lambda x: x["step"])
+with open(os.path.join(CFG["output_dir"], "loss_history.json"), "w") as f:
+    json.dump(loss_history, f, indent=2)
+print(f"  loss log   : {CFG['output_dir']}/loss_history.json", flush=True)
+
+# Save benchmark summary
+losses = [e["loss"] for e in loss_history if "loss" in e]
+benchmark = {
+    "framework": "unturtle",
+    "model": CFG["model_name"],
+    "train_loss_avg": sum(losses) / len(losses) if losses else None,
+    "train_loss_first50": sum(losses[:50]) / min(50, len(losses)) if losses else None,
+    "train_loss_last50": sum(losses[-50:]) / min(50, len(losses)) if losses else None,
+    "elapsed_seconds": elapsed,
+    "peak_vram_gb": peak_vram,
+    "steps": result.global_step,
+    "steps_per_second": result.global_step / elapsed if elapsed > 0 else 0,
+    "n_params_total": n_params,
+    "n_params_trainable": n_trainable,
+    "epochs": CFG["num_epochs"],
+    "batch_size": CFG["batch_size"],
+    "lora_r": CFG["lora_r"],
+    "loss_weight_type": training_args.loss_weight_type,
+}
+with open(os.path.join(CFG["output_dir"], "benchmark.json"), "w") as f:
+    json.dump(benchmark, f, indent=2)
+print(f"  benchmark  : {CFG['output_dir']}/benchmark.json", flush=True)

--- a/benchmarks/modernbert/compare.py
+++ b/benchmarks/modernbert/compare.py
@@ -1,0 +1,196 @@
+"""
+Compare benchmark results from unturtle and dllm.
+
+Usage:
+    python benchmarks/modernbert/compare.py [--unturtle-dir OUTPUT_DIR [--dllm-dir DIR]]
+
+Reads benchmark.json and loss_history.json from both frameworks and prints
+a comparison table.
+"""
+
+import json
+import os
+import sys
+
+DEFAULT_UNTURTLE_DIR = "outputs/benchmark_modernbert_unturtle"
+DEFAULT_DLLM_DIR = "outputs/benchmark_modernbert_dllm"
+
+
+def load_results(dir_path, label):
+    bench_path = os.path.join(dir_path, "benchmark.json")
+    loss_path = os.path.join(dir_path, "loss_history.json")
+    if not os.path.isfile(bench_path):
+        print(f"Warning: {bench_path} not found. Skipping {label}.")
+        return None
+    with open(bench_path) as f:
+        bench = json.load(f)
+    loss_history = []
+    if os.path.isfile(loss_path):
+        with open(loss_path) as f:
+            loss_history = json.load(f)
+    bench["loss_history"] = loss_history
+    return bench
+
+
+def fmt(val, unit=""):
+    if val is None:
+        return "N/A"
+    if unit == "s":
+        return f"{val:.1f}s"
+    if unit == "min":
+        return f"{val / 60:.1f}min"
+    if unit == "gb":
+        return f"{val:.2f}GB"
+    if unit == "/s":
+        return f"{val:.2f}"
+    if unit == "%":
+        return f"{val:.1f}%"
+    return f"{val:.4f}"
+
+
+def main():
+    unturtle_dir = DEFAULT_UNTURTLE_DIR
+    dllm_dir = DEFAULT_DLLM_DIR
+
+    # Parse simple CLI args
+    i = 1
+    while i < len(sys.argv):
+        if sys.argv[i] == "--unturtle-dir":
+            unturtle_dir = sys.argv[i + 1]
+            i += 2
+        elif sys.argv[i] == "--dllm-dir":
+            dllm_dir = sys.argv[i + 1]
+            i += 2
+        else:
+            print(f"Unknown arg: {sys.argv[i]}")
+            i += 1
+
+    unturtle_r = load_results(unturtle_dir, "unturtle")
+    dllm_r = load_results(dllm_dir, "dllm")
+
+    print("\n" + "=" * 65)
+    print("  Benchmark: ModernBERT-base dLLM SFT")
+    print("=" * 65)
+
+    rows = [
+        ("Model", "unturtle", "dllm"),
+        (
+            "Train loss (avg)",
+            unturtle_r["train_loss_avg"] if unturtle_r else None,
+            dllm_r["train_loss_avg"] if dllm_r else None,
+        ),
+        (
+            "Train loss (first 50)",
+            unturtle_r["train_loss_first50"] if unturtle_r else None,
+            dllm_r["train_loss_first50"] if dllm_r else None,
+        ),
+        (
+            "Train loss (last 50)",
+            unturtle_r["train_loss_last50"] if unturtle_r else None,
+            dllm_r["train_loss_last50"] if dllm_r else None,
+        ),
+        (
+            "Elapsed",
+            unturtle_r["elapsed_seconds"] if unturtle_r else None,
+            dllm_r["elapsed_seconds"] if dllm_r else None,
+        ),
+        (
+            "Peak VRAM",
+            unturtle_r["peak_vram_gb"] if unturtle_r else None,
+            dllm_r["peak_vram_gb"] if dllm_r else None,
+        ),
+        (
+            "Steps/sec",
+            unturtle_r["steps_per_second"] if unturtle_r else None,
+            dllm_r["steps_per_second"] if dllm_r else None,
+        ),
+        (
+            "Total steps",
+            unturtle_r["steps"] if unturtle_r else None,
+            dllm_r["steps"] if dllm_r else None,
+        ),
+        (
+            "LoRA params (M)",
+            unturtle_r["n_params_trainable"] / 1e6 if unturtle_r else None,
+            dllm_r["n_params_trainable"] / 1e6 if dllm_r else None,
+        ),
+        (
+            "LoRA r",
+            unturtle_r["lora_r"] if unturtle_r else None,
+            dllm_r["lora_r"] if dllm_r else None,
+        ),
+    ]
+
+    print(f"\n  {'Metric':<25} {'unturtle':>15} {'dllm':>15} {'Delta':>10}")
+    print(f"  {'-' * 25} {'-' * 15} {'-' * 15} {'-' * 10}")
+
+    for name, u, d in rows:
+        # Format values for display
+        if name in (
+            "Elapsed",
+            "Peak VRAM",
+            "Steps/sec",
+            "Train loss (avg)",
+            "Train loss (first 50)",
+            "Train loss (last 50)",
+            "Total steps",
+            "LoRA params (M)",
+            "LoRA r",
+        ):
+            if isinstance(u, (int, float)) and isinstance(d, (int, float)):
+                if name == "Elapsed":
+                    u_s = f"{u / 60:.1f}min"
+                    d_s = f"{d / 60:.1f}min"
+                elif name == "Peak VRAM":
+                    u_s = f"{u:.2f}GB"
+                    d_s = f"{d:.2f}GB"
+                elif name == "Steps/sec":
+                    u_s = f"{u:.2f}"
+                    d_s = f"{d:.2f}"
+                elif "loss" in name.lower():
+                    u_s = f"{u:.4f}"
+                    d_s = f"{d:.4f}"
+                elif name == "Total steps":
+                    u_s = str(int(u))
+                    d_s = str(int(d))
+                elif name == "LoRA params (M)":
+                    u_s = f"{u:.1f}"
+                    d_s = f"{d:.1f}"
+                elif name == "LoRA r":
+                    u_s = str(int(u))
+                    d_s = str(int(d))
+                else:
+                    u_s = "N/A"
+                    d_s = "N/A"
+
+                # Compute delta for numeric rows
+                if d != 0:
+                    delta = ((u - d) / d) * 100
+                    if name in ("Elapsed", "Peak VRAM"):
+                        arrow_sym = "\u2193" if delta < 0 else "\u2191"
+                    elif name in ("Steps/sec",):
+                        arrow_sym = "\u2191" if delta > 0 else "\u2193"
+                    elif "loss" in name.lower():
+                        arrow_sym = "\u2193" if delta < 0 else "\u2191"
+                    else:
+                        arrow_sym = "\u2191" if delta > 0 else "\u2193"
+                    delta_s = f"{arrow_sym} {abs(delta):.1f}%"
+                else:
+                    delta_s = "\u2014"
+            else:
+                u_s = "N/A"
+                d_s = "N/A"
+                delta_s = "\u2014"
+        else:
+            u_s = "unturtle"
+            d_s = "dllm"
+            delta_s = "\u2014"
+
+        print(f"  {name:<25} {u_s:>15} {d_s:>15} {delta_s:>10}")
+
+    print("\n" + "=" * 65)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/qwen3/benchmark_dllm.py
+++ b/benchmarks/qwen3/benchmark_dllm.py
@@ -1,0 +1,281 @@
+"""
+Headless benchmark script for Qwen3-0.6B-diffusion dLLM SFT with dllm (reference).
+
+REQUIRES: a separate venv with dllm installed (dllm depends on transformers 4.x).
+Setup:
+    uv venv .venvDllm --python 3.12
+    .venvDllm/bin/python -m pip install torch torchvision torchaudio \
+        --index-url https://download.pytorch.org/whl/cu124
+    .venvDllm/bin/python -m pip install -e dev/repos/dllm/
+
+Usage (from project root):
+    .venvDllm/bin/python benchmarks/qwen3/benchmark_dllm.py
+
+Metrics saved to: outputs/benchmark_qwen3_dllm/benchmark.json
+Loss history: outputs/benchmark_qwen3_dllm/loss_history.json
+"""
+
+import json
+import logging
+import os
+import random
+import time
+
+import numpy as np
+import torch
+from datasets import load_dataset
+from dllm.core.trainers import MDLMConfig, MDLMTrainer
+from dllm.utils import NoAttentionMaskWrapper
+from peft import LoraConfig, get_peft_model
+from transformers import (
+    AutoModelForMaskedLM,
+    AutoTokenizer,
+    DataCollatorForSeq2Seq,
+)
+
+# Silence excessive logging
+logging.getLogger("transformers").setLevel(logging.WARNING)
+logging.getLogger("datasets").setLevel(logging.WARNING)
+
+# ---------------------------------------------------------------------------
+# Config — matched to ModernBERT benchmark for fair comparison
+# ---------------------------------------------------------------------------
+CFG = {
+    "model_name": "dllm-hub/Qwen3-0.6B-diffusion-mdlm-v0.1",
+    "output_dir": "outputs/benchmark_qwen3_dllm",
+    "train_samples": 2000,
+    "eval_samples": 200,
+    "num_epochs": 2,
+    "batch_size": 4,  # same as ModernBERT (not 16)
+    "lora_r": 16,
+    "lora_alpha": 32,
+    "lr": 1e-4,  # Qwen3-specific (10x ModernBERT, per dllm examples/a2d/README.md)
+    "max_length": 512,  # same as ModernBERT (not 1024)
+    "loss_weight_type": "uniform",
+    "seed": 42,
+}
+print(json.dumps(CFG, indent=2), flush=True)
+
+# ---------------------------------------------------------------------------
+# Seed for reproducibility
+# ---------------------------------------------------------------------------
+random.seed(CFG["seed"])
+np.random.seed(CFG["seed"])
+torch.manual_seed(CFG["seed"])
+if torch.cuda.is_available():
+    torch.cuda.manual_seed_all(CFG["seed"])
+
+# ---------------------------------------------------------------------------
+# Model & tokenizer
+# ---------------------------------------------------------------------------
+print(f"\n[1/4] Loading model: {CFG['model_name']} …", flush=True)
+tokenizer = AutoTokenizer.from_pretrained(CFG["model_name"], trust_remote_code=True)
+tokenizer.padding_side = "right"  # required by MDLMTrainer
+
+model = AutoModelForMaskedLM.from_pretrained(
+    CFG["model_name"],
+    torch_dtype=torch.bfloat16,
+    trust_remote_code=True,
+)
+model.cuda()
+model.train()
+n_params = sum(p.numel() for p in model.parameters())
+print(f"  Loaded: {n_params / 1e9:.3f}B params", flush=True)
+
+# ---------------------------------------------------------------------------
+# LoRA
+# ---------------------------------------------------------------------------
+print("\n[2/4] Applying LoRA …", flush=True)
+lora_config = LoraConfig(
+    r=CFG["lora_r"],
+    lora_alpha=CFG["lora_alpha"],
+    target_modules=[
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ],
+    lora_dropout=0,
+    bias="none",
+)
+model = get_peft_model(model, lora_config)
+n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+print(
+    f"  Trainable: {n_trainable / 1e6:.1f}M / {n_params / 1e9:.3f}B "
+    f"({n_trainable / n_params * 100:.2f}%)",
+    flush=True,
+)
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+print("\n[3/4] Loading dataset …", flush=True)
+
+raw = load_dataset(
+    "allenai/tulu-3-sft-mixture",
+    split={
+        "train": f"train[:{CFG['train_samples']}]",
+        "test": f"train[10000:{10000 + CFG['eval_samples']}]",
+    },
+)
+
+eos = tokenizer.eos_token or ""
+
+
+def preprocess(example):
+    """Flatten messages to text; Qwen3 tokenizer has chat_template but we use flat for consistency."""
+    msgs = example["messages"]
+    prompt_parts = []
+    for m in msgs:
+        if m["role"] != "assistant":
+            prompt_parts.append(f"<|{m['role']}|>\n{m['content']}")
+        else:
+            # Last assistant message = completion
+            prompt_text = "\n\n".join(prompt_parts) + "\n\n<|assistant|>\n"
+            completion_text = m["content"] + eos
+            prompt_ids = tokenizer(prompt_text, add_special_tokens=False)["input_ids"]
+            completion_ids = tokenizer(completion_text, add_special_tokens=False)[
+                "input_ids"
+            ]
+            input_ids = (prompt_ids + completion_ids)[: CFG["max_length"]]
+            labels = ([-100] * len(prompt_ids) + completion_ids)[: CFG["max_length"]]
+            return {
+                "input_ids": input_ids,
+                "labels": labels,
+                "attention_mask": [1] * len(input_ids),
+            }
+    # Fallback: no completion
+    return {"input_ids": [], "labels": [], "attention_mask": []}
+
+
+dataset = raw.map(
+    preprocess, remove_columns=raw["train"].column_names, desc="Tokenising"
+)
+# Filter out samples with no completion (all labels are -100)
+dataset = dataset.filter(
+    lambda x: len(x["input_ids"]) > 0 and sum(1 for _l in x["labels"] if _l != -100) > 0
+)
+print(f"  train: {len(dataset['train'])}  /  test: {len(dataset['test'])}", flush=True)
+
+
+# Use dllm's reference data collator (from examples/a2d/mdlm/sft.py)
+data_collator = NoAttentionMaskWrapper(  # removes attention_mask so dllm uses full bidirectional attention
+    DataCollatorForSeq2Seq(
+        tokenizer,
+        return_tensors="pt",
+        padding=True,
+        label_pad_token_id=-100,  # exclude padding from maskable_mask (labels != -100); loss normalization aligned with unturtle
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Trainer (dllm MDLMTrainer)
+# ---------------------------------------------------------------------------
+print("\n[4/4] Training …", flush=True)
+os.makedirs(CFG["output_dir"], exist_ok=True)
+
+# MDLMConfig from dllm (inherits from transformers TrainingArguments)
+mdlm_args = MDLMConfig(
+    output_dir=CFG["output_dir"],
+    num_train_epochs=CFG["num_epochs"],
+    per_device_train_batch_size=CFG["batch_size"],
+    per_device_eval_batch_size=CFG["batch_size"],
+    gradient_accumulation_steps=1,  # explicitly set to 1 to match unturtle; dllm may default to 3 in some configurations
+    learning_rate=CFG["lr"],
+    lr_scheduler_type="cosine",
+    warmup_ratio=0.05,
+    loss_weight_type=CFG["loss_weight_type"],
+    loss_norm_type="token",
+    right_shift_logits=False,  # disable to match unturtle behavior
+    logging_steps=10,
+    eval_strategy="epoch",
+    save_strategy="epoch",
+    report_to="none",
+    bf16=True,
+    dataloader_num_workers=0,
+)
+
+# Collect metrics
+losses = []
+original_log = getattr(MDLMTrainer, "log", None)
+
+
+def capturing_log(self_inner, logs, start_time=None, **kw):
+    if "loss" in logs:
+        losses.append(float(logs["loss"]))
+    if original_log:
+        original_log(self_inner, logs, start_time=start_time, **kw)
+
+
+torch.cuda.reset_peak_memory_stats()
+
+MDLMTrainer.log = capturing_log
+t0 = time.time()
+
+trainer = MDLMTrainer(
+    args=mdlm_args,
+    model=model,
+    train_dataset=dataset["train"],
+    eval_dataset=dataset["test"],
+    data_collator=data_collator,
+    processing_class=tokenizer,
+)
+result = trainer.train()
+
+elapsed = time.time() - t0
+MDLMTrainer.log = original_log
+
+peak_vram = torch.cuda.max_memory_allocated() / 1e9
+
+print(f"\n{'=' * 60}", flush=True)
+print("Training complete!", flush=True)
+print(f"  train_loss : {result.training_loss:.4f}", flush=True)
+print(f"  steps      : {result.global_step}", flush=True)
+print(f"  elapsed    : {elapsed / 60:.1f} min", flush=True)
+print(f"  peak VRAM  : {peak_vram:.2f} GB", flush=True)
+print(f"  checkpoint : {CFG['output_dir']}", flush=True)
+
+results_dir = CFG["output_dir"]
+os.makedirs(results_dir, exist_ok=True)
+
+# Save loss history (normalized schema: step + loss/eval_loss)
+loss_history = [{"step": (i + 1) * 10, "loss": l} for i, l in enumerate(losses)]
+loss_path = os.path.join(results_dir, "loss_history.json")
+with open(loss_path, "w") as f:
+    json.dump(loss_history, f, indent=2)
+print(f"  loss log   : {loss_path}", flush=True)
+
+# Save benchmark summary
+all_losses = [e for e in losses]
+total_samples = len(dataset["train"]) * CFG["num_epochs"]
+benchmark = {
+    "framework": "dllm",
+    "model": CFG["model_name"],
+    "train_loss_avg": sum(all_losses) / len(all_losses) if all_losses else None,
+    "train_loss_first50": sum(all_losses[:50]) / min(50, len(all_losses))
+    if all_losses
+    else None,
+    "train_loss_last50": sum(all_losses[-50:]) / min(50, len(all_losses))
+    if all_losses
+    else None,
+    "elapsed_seconds": elapsed,
+    "peak_vram_gb": peak_vram,
+    "steps": result.global_step,
+    "steps_per_second": result.global_step / elapsed if elapsed > 0 else 0,
+    "samples_per_second": total_samples / elapsed if elapsed > 0 else 0,
+    "gradient_accumulation_steps": mdlm_args.gradient_accumulation_steps,
+    "n_params_total": n_params,
+    "n_params_trainable": n_trainable,
+    "epochs": CFG["num_epochs"],
+    "batch_size": CFG["batch_size"],
+    "lora_r": CFG["lora_r"],
+    "loss_weight_type": CFG["loss_weight_type"],
+}
+benchmark_path = os.path.join(results_dir, "benchmark.json")
+with open(benchmark_path, "w") as f:
+    json.dump(benchmark, f, indent=2)
+print(f"  benchmark  : {benchmark_path}", flush=True)

--- a/benchmarks/qwen3/benchmark_unturtle.py
+++ b/benchmarks/qwen3/benchmark_unturtle.py
@@ -1,0 +1,248 @@
+"""
+Headless benchmark script for Qwen3-0.6B-diffusion dLLM SFT with unturtle.
+
+Usage:
+    nohup uv run python benchmarks/qwen3/benchmark_unturtle.py > logs/benchmark_qwen3_unturtle.log 2>&1 &
+
+Metrics saved to: outputs/benchmark_qwen3_unturtle/benchmark.json
+Loss history: outputs/benchmark_qwen3_unturtle/loss_history.json
+"""
+
+import json
+import os
+import random
+import time
+
+import numpy as np
+import peft  # noqa: F401
+import torch
+import transformers  # noqa: F401
+import trl  # noqa: F401
+from datasets import load_dataset
+
+import unturtle  # noqa: F401
+from unturtle import FastDiffusionModel
+from unturtle.diffusion import DiffusionTrainer, DiffusionTrainingArguments
+from unturtle.models import TinyA2DQwen3LMHeadModel
+
+# ---------------------------------------------------------------------------
+# Config — matched to dllm version for fair comparison
+# ---------------------------------------------------------------------------
+CFG = {
+    "model_name": "dllm-hub/Qwen3-0.6B-diffusion-mdlm-v0.1",
+    "output_dir": "outputs/benchmark_qwen3_unturtle",
+    "train_samples": 2000,
+    "eval_samples": 200,
+    "num_epochs": 2,
+    "batch_size": 4,  # same as ModernBERT
+    "lora_r": 16,
+    "lora_alpha": 32,
+    "lr": 1e-4,  # Qwen3-specific (10x ModernBERT)
+    "max_length": 512,  # same as ModernBERT
+    "seed": 42,
+}
+print(json.dumps(CFG, indent=2), flush=True)
+
+# ---------------------------------------------------------------------------
+# Seed for reproducibility
+# ---------------------------------------------------------------------------
+random.seed(CFG["seed"])
+np.random.seed(CFG["seed"])
+torch.manual_seed(CFG["seed"])
+if torch.cuda.is_available():
+    torch.cuda.manual_seed_all(CFG["seed"])
+
+# ---------------------------------------------------------------------------
+# Model & tokenizer
+# ---------------------------------------------------------------------------
+print(f"\n[1/5] Loading model: {CFG['model_name']} …", flush=True)
+
+# Qwen3-0.6B-diffusion is A2D-converted (model_type="tiny-a2d-qwen3")
+model, tokenizer = FastDiffusionModel.from_pretrained(
+    CFG["model_name"],
+    model_class=TinyA2DQwen3LMHeadModel,  # explicit A2D class
+    dtype=torch.bfloat16,
+    load_in_4bit=False,
+    trust_remote_code=True,
+)
+n_params = sum(p.numel() for p in model.parameters())
+print(f"  Loaded: {n_params / 1e9:.3f}B params", flush=True)
+
+mask_token_id = tokenizer.mask_token_id or getattr(model.config, "mask_token_id", None)
+print(f"  mask_token_id: {mask_token_id}", flush=True)
+
+# ---------------------------------------------------------------------------
+# LoRA
+# ---------------------------------------------------------------------------
+print("\n[2/5] Applying LoRA …", flush=True)
+
+# Qwen3 uses LLaMA-style split projections (q/k/v/o_proj + MLP gates)
+model = FastDiffusionModel.get_peft_model(
+    model,
+    r=CFG["lora_r"],
+    lora_alpha=CFG["lora_alpha"],
+    target_modules=[
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ],
+    lora_dropout=0,
+    bias="none",
+)
+n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+print(
+    f"  Trainable: {n_trainable / 1e6:.1f}M / {n_params / 1e9:.3f}B "
+    f"({n_trainable / n_params * 100:.2f}%)",
+    flush=True,
+)
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+print("\n[3/5] Loading dataset …", flush=True)
+
+raw = load_dataset(
+    "allenai/tulu-3-sft-mixture",
+    split={
+        "train": f"train[:{CFG['train_samples']}]",
+        "test": f"train[10000:{10000 + CFG['eval_samples']}]",
+    },
+)
+
+eos = tokenizer.eos_token or ""
+
+
+def preprocess(example):
+    """Flatten messages to text; Qwen3 tokenizer has chat_template but we use flat for consistency."""
+    msgs = example["messages"]
+    prompt_parts = []
+    for m in msgs:
+        if m["role"] != "assistant":
+            prompt_parts.append(f"<|{m['role']}|>\n{m['content']}")
+        else:
+            # Last assistant message = completion
+            prompt_text = "\n\n".join(prompt_parts) + "\n\n<|assistant|>\n"
+            completion_text = m["content"] + eos
+            prompt_ids = tokenizer(prompt_text, add_special_tokens=False)["input_ids"]
+            completion_ids = tokenizer(completion_text, add_special_tokens=False)[
+                "input_ids"
+            ]
+            input_ids = (prompt_ids + completion_ids)[: CFG["max_length"]]
+            labels = ([-100] * len(prompt_ids) + completion_ids)[: CFG["max_length"]]
+            return {"input_ids": input_ids, "labels": labels}
+    # Fallback: no completion
+    return {"input_ids": [], "labels": []}
+
+
+dataset = raw.map(
+    preprocess, remove_columns=raw["train"].column_names, desc="Tokenising"
+)
+dataset = dataset.filter(lambda x: sum(1 for l in x["labels"] if l != -100) > 0)
+print(f"  train: {len(dataset['train'])}  /  test: {len(dataset['test'])}", flush=True)
+
+# ---------------------------------------------------------------------------
+# Trainer
+# ---------------------------------------------------------------------------
+print("\n[4/5] Setting up trainer …", flush=True)
+os.makedirs(CFG["output_dir"], exist_ok=True)
+
+training_args = DiffusionTrainingArguments(
+    output_dir=CFG["output_dir"],
+    num_train_epochs=CFG["num_epochs"],
+    per_device_train_batch_size=CFG["batch_size"],
+    per_device_eval_batch_size=CFG["batch_size"],
+    gradient_accumulation_steps=1,  # match dllm's actual setting (grad_accum=1)
+    learning_rate=CFG["lr"],
+    lr_scheduler_type="cosine",
+    warmup_ratio=0.05,
+    bf16=True,
+    logging_steps=10,
+    disable_tqdm=True,
+    eval_strategy="epoch",
+    save_strategy="epoch",
+    report_to="none",
+    loss_weight_type="uniform",
+    completion_only=True,
+    dataloader_num_workers=0,
+)
+
+trainer = DiffusionTrainer(
+    model=model,
+    args=training_args,
+    train_dataset=dataset["train"],
+    eval_dataset=dataset["test"],
+    processing_class=tokenizer,
+)
+
+# ---------------------------------------------------------------------------
+# Train
+# ---------------------------------------------------------------------------
+print("\n[5/5] Training …", flush=True)
+
+torch.cuda.reset_peak_memory_stats()
+
+t0 = time.time()
+result = trainer.train()
+elapsed = time.time() - t0
+
+peak_vram = torch.cuda.max_memory_allocated() / 1e9
+print(f"\n{'=' * 60}", flush=True)
+print("Training complete!", flush=True)
+print(f"  train_loss : {result.training_loss:.4f}", flush=True)
+print(f"  steps      : {result.global_step}", flush=True)
+print(f"  elapsed    : {elapsed / 60:.1f} min", flush=True)
+print(f"  peak VRAM  : {peak_vram:.2f} GB", flush=True)
+print(f"  checkpoint : {CFG['output_dir']}", flush=True)
+
+results_dir = CFG["output_dir"]
+os.makedirs(results_dir, exist_ok=True)
+
+# Save loss history (normalized schema: step + loss/eval_loss)
+loss_history = [
+    {"step": int(e.get("step", 0)), "loss": e["loss"]}
+    for e in trainer.state.log_history
+    if "loss" in e and "eval_" not in e
+]
+loss_history.extend(
+    [
+        {"step": int(e.get("step", 0)), "eval_loss": e["eval_loss"]}
+        for e in trainer.state.log_history
+        if "eval_loss" in e
+    ]
+)
+loss_history.sort(key=lambda x: x["step"])
+loss_path = os.path.join(results_dir, "loss_history.json")
+with open(loss_path, "w") as f:
+    json.dump(loss_history, f, indent=2)
+print(f"  loss log   : {loss_path}", flush=True)
+
+# Save benchmark summary
+losses = [e["loss"] for e in loss_history if "loss" in e]
+total_samples = len(dataset["train"]) * CFG["num_epochs"]
+benchmark = {
+    "framework": "unturtle",
+    "model": CFG["model_name"],
+    "train_loss_avg": sum(losses) / len(losses) if losses else None,
+    "train_loss_first50": sum(losses[:50]) / min(50, len(losses)) if losses else None,
+    "train_loss_last50": sum(losses[-50:]) / min(50, len(losses)) if losses else None,
+    "elapsed_seconds": elapsed,
+    "peak_vram_gb": peak_vram,
+    "steps": result.global_step,
+    "steps_per_second": result.global_step / elapsed if elapsed > 0 else 0,
+    "samples_per_second": total_samples / elapsed if elapsed > 0 else 0,
+    "gradient_accumulation_steps": training_args.gradient_accumulation_steps,
+    "n_params_total": n_params,
+    "n_params_trainable": n_trainable,
+    "epochs": CFG["num_epochs"],
+    "batch_size": CFG["batch_size"],
+    "lora_r": CFG["lora_r"],
+    "loss_weight_type": training_args.loss_weight_type,
+}
+benchmark_path = os.path.join(results_dir, "benchmark.json")
+with open(benchmark_path, "w") as f:
+    json.dump(benchmark, f, indent=2)
+print(f"  benchmark  : {benchmark_path}", flush=True)

--- a/docs/dllm-gap-map.md
+++ b/docs/dllm-gap-map.md
@@ -1,0 +1,113 @@
+# dLLM Gap-Map and Roadmap
+
+> **Living document.** Update the status and priority columns as Unturtle changes and as
+> the diffusion-LM field moves. The axes below are validated against the dLLM paper
+> (`dev/papers/dllm.md`) and the community surveys
+> [Awesome-DLMs](https://github.com/VILA-Lab/Awesome-DLMs) and
+> [Awesome-Diffusion-LLM](https://github.com/AIDASLab/Awesome-Diffusion-LLM).
+
+## North star
+
+Unturtle is **the unsloth-accelerated dLLM layer**. It adopts the field-standard
+decomposition (backbone architecture × conversion method × training objective) instead of
+inventing its own, leans on upstream for evaluation reproducibility
+(`lm-evaluation-harness`), and differentiates on Triton kernels, fast LoRA,
+bidirectional / packed-varlen fast paths, and inference acceleration.
+
+**Priority is driven by fit with that north star.** Inference acceleration ranks highest
+because it is Unturtle's reason to exist; multimodal/VLA/agentic are deferred — not
+unimportant, but not this library's job.
+
+## Status legend
+
+- ✅ implemented
+- 🟡 partial
+- ❌ missing
+- ⛔ out of scope (deliberately not Unturtle's lane)
+
+## Gap-map
+
+> Sharpened 2026-05-31 from the literature survey (`.references/survey-matrix.md` +
+> `.references/adoption-queue.md`).
+
+| Category | Representative methods | Unturtle status | Where | Fit | Priority |
+|---|---|---|---|---|---|
+| Training objectives | MDLM, BD3LM | ✅ | `unturtle/diffusion/trainer.py`, `block_diffusion_trainer.py` | core | maintain |
+| AR→Diffusion conversion | A2D family; Tiny-A2D recipe (DiffuLLaMA / TESS-2 / SDAR family) | ✅ | `unturtle/models/conversion/a2d/tiny_a2d/` | core | maintain |
+| Encoder backbones | ModernBERT-chat | ✅ | `unturtle/models/backbones/modernbert/` | medium | maintain |
+| Block-AR diffusion backbone | **DiffusionGemma** (Google, 26B-A4B MoE, block-AR diffusion; `transformers` `models/diffusion_gemma` wrapper) | ❌ (candidate) | — | high | **P1** |
+| Tri-mode AR+diffusion backbone | **Nemotron-Labs-Diffusion** (NVIDIA 3B/8B/14B, AR + diffusion + self-spec; HF weights public) | ❌ (candidate) | — | medium | evaluate |
+| Evaluation discipline | lm-eval-harness, hyperparam sensitivity | ✅ | `unturtle/eval/harness/` | high | maintain |
+| High-level generation entry | `FastDiffusionModel.generate(algorithm=…)` | ✅ | `unturtle/models/generation/sampler.py` + `fast_diffusion_model.py` | high | maintain |
+| Inference: block decode / KV cache | Fast-dLLM (have); **dLLM-Cache** (training-free adaptive, 9×), **dKV-Cache** (delayed KV) | 🟡 | `unturtle/models/generation/{block_decode_mixin,cache,cache_utils}.py` | high | **P1** |
+| Inference: parallel / adaptive decode | Fast-dLLM parallel (partial); **APD** (adaptive parallel) | 🟡 | `unturtle/models/generation/diffusion_generation_utils.py` | high | **P1→P2** |
+| Hybrid faster-than-AR | **D2F** (discrete diffusion forcing), E2D2, Fast-dLLM v2 | ❌ | — | high | P2 |
+| Distillation / few-step | **SDTT** (self-distill, 32–64× steps), CDLM (consistency), FS-DFM | ❌ | — | high (speed) | P2 |
+| Quantization / sparsity | DLLMQuant (PTQ), SparseD / Sparse-dLLM | ❌ | — | medium | P2 |
+| Post-training / RL | d1 (GRPO) + wd1 (have); **VRPO** (LLaDA-1.5), MDPO, DiFFPO, DARE | 🟡 GRPO+wd1 | `unturtle/diffusion/grpo_trainer.py` | medium | P2 |
+| Inference frameworks | dInfer (modular, >1100 TPS), dlmserve | ❌ | — | medium | defer (reference) |
+| Continuous / latent diffusion | Diffusion-LM, TESS, CCDD | ⛔ | — | future extension point | defer |
+| Multimodal / VLA / driving / agentic | LaViDa, MMaDA, LLaDA-VLA, Dream-VLA | ⛔ | — | out of scope | defer |
+
+## Roadmap
+
+> Detailed per-technique rationale: `.references/adoption-queue.md` (deep-read evaluations).
+
+### Done
+
+- Taxonomy axis-split (PR #292), eval canonicalization (PR #294), gap-map (PR #296),
+  physical taxonomy migration (PR #298), high-level `FastDiffusionModel.generate` +
+  algorithm registry (PR #300).
+
+### First roadmap after the clean migration
+
+Now that the clean port (CLI / benchmarks / examples / docs) is complete, the immediate
+sequence is:
+
+1. **DiffusionGemma backbone** — wrap the upstream `transformers` `models/diffusion_gemma`
+   implementation as a native block-AR diffusion backbone. Pairs with the `FastModel`
+   delegation work (#15): models that carry their own loss/generation route through the
+   standard path, so this lands as a backbone wrapper, not a new objective.
+2. **Nemotron evaluation** — evaluate Nemotron-Labs-Diffusion (tri-mode AR+diffusion+self-spec)
+   on the canonical harness to decide whether to add it as a backbone.
+3. **unsloth CLI plugin mechanism** — propose the `unturtle` CLI integration as a plugin
+   mechanism upstream to unsloth.
+4. **dLLM-Cache (P1)** — the highest-value training-free inference speedup (see below).
+
+### P1 — now / immediate next
+
+- **Inference caching (training-free):** adopt **dLLM-Cache** (training-free adaptive
+  caching, ~9× on LLaDA/Dream, no quality loss) as a cache strategy in
+  `unturtle/models/generation/`, composing with the existing Fast-dLLM block decode. This is
+  the single highest-value training-free speedup. Evaluate **dKV-Cache** alongside and ship
+  whichever benchmarks best as default.
+
+### P2 — after P1
+
+- **Adaptive parallel decode:** APD (auxiliary-AR-guided adaptive parallel width).
+- **Hybrid faster-than-AR:** D2F (discrete diffusion forcing; distillation + pipelined decode).
+- **Few-step distillation:** SDTT / CDLM / FS-DFM (training-based; cluster as one workstream).
+- **RL beyond GRPO:** VRPO (LLaDA-1.5; variance-reduced DPO) as the lead, then MDPO / DiFFPO.
+- **Quantization / sparsity:** DLLMQuant, SparseD (lower priority).
+
+### Deferred (reference / future)
+
+- **Inference-framework architecture:** mine dInfer's 4-component decomposition (model /
+  iteration manager / decoding strategy / KV-cache manager) when consolidating the
+  generation/sampler layer — it validates the `FastDiffusionModel.generate` direction.
+- **Continuous / latent-space diffusion:** future extension point (the `generate` algorithm
+  registry is already open for it; current loops are discrete-masked-only).
+
+### Out of scope (YAGNI)
+
+- Multimodal / VLA / agentic dLLMs.
+- Decoupling from `unsloth`.
+- Rewriting the MDLM / BD3LM objectives.
+
+## How to update this doc
+
+- When a category's status changes (e.g. a P2 item lands), update its **status**, **where**,
+  and **priority** cells in the same PR.
+- When the field adds a category the surveys track and it fits the north star, add a row.
+- Keep the priority logic tied to fit with the unsloth-acceleration north star, not to
+  novelty.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# Examples
+
+## Diffu-GRPO (GPU smoke)
+
+End-to-end `DiffuGRPOTrainer.train()` for a few steps on a tiny random masked LM (no checkpoint download).
+
+**Dependencies:** `uv pip install -e ".[huggingface,grpo]"` (or `trl`, `mergekit`, `tokenizers` on top of the Hugging Face extra). **CUDA** is required for this script.
+
+```bash
+.venv/bin/python examples/grpo_diffu_train_smoke.py
+```
+
+Options: `--wd1` (wd1 loss), `--wd1++` (wd1++ loss). See the module docstring in `grpo_diffu_train_smoke.py` for details.
+
+Design note: [docs/diffu-grpo-d1-notes.md](../docs/diffu-grpo-d1-notes.md) (d1 alignment, `scale_rewards`, Gumbel).
+
+## Configs
+
+YAML under `examples/configs/` (e.g. `llada_grpo.yaml`) for CLI-oriented experiments.

--- a/examples/benchmark_a2d_aligned.py
+++ b/examples/benchmark_a2d_aligned.py
@@ -1,0 +1,818 @@
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+CHECKPOINT = "dllm-hub/Qwen3-0.6B-diffusion-bd3lm-v0.1"
+BACKENDS = ("unturtle", "dllm")
+BENCHMARK_MODES = ("aligned-warm", "validator-warm", "cold-start")
+ENV_PATHS = {
+    "unturtle": ".venv",
+    "dllm": ".venvDllm",
+}
+UNTURTLE_MODEL_CACHE: dict[str, tuple[Any, Any]] = {}
+DLLM_MODEL_CACHE: dict[str, tuple[Any, Any]] = {}
+PROMPTS = {
+    "math": "Lily runs 12 km/h for 4 hours. How far in 8 hours?",
+    "code": "Please write an educational python function.",
+}
+DEFAULT_STEPS = (64, 128)
+DEFAULT_MAX_NEW_TOKENS = (64, 128)
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    mode: str
+    backend: str
+    prompt_name: str
+    prompt_text: str
+    settings: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    generated_text: str
+    backend_metadata: dict[str, Any]
+    output_tokens: int | None
+    runtime_seconds: float
+
+
+Runner = Callable[[RunSpec], tuple[str, dict[str, Any], int | None]]
+WORKER_MODE = "UNTURTLE_BENCHMARK_WORKER"
+WARM_WORKER_MODE = "UNTURTLE_BENCHMARK_WARM_WORKER"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=BENCHMARK_MODES, default="aligned-warm")
+    parser.add_argument("--backend", choices=[*BACKENDS, "all"], default="all")
+    parser.add_argument("--prompt", choices=[*PROMPTS, "all"], default="all")
+    parser.add_argument("--steps", type=int)
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--output-dir", default="outputs/a2d_aligned_benchmark")
+    parser.add_argument("--warmup-iters", type=int, default=2)
+    parser.add_argument("--measure-iters", type=int, default=5)
+    return parser.parse_args()
+
+
+def get_git_head() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def get_repo_root() -> Path:
+    try:
+        common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"], text=True
+        ).strip()
+        return Path(common_dir).resolve().parent
+    except Exception:
+        return Path.cwd()
+
+
+def get_env_root() -> Path:
+    executable = Path(sys.executable)
+    active_env = executable.parent.parent
+    if executable.parent.name == "bin" and active_env.name in set(ENV_PATHS.values()):
+        return active_env.parent
+    return get_repo_root()
+
+
+def build_aligned_generation_kwargs(settings: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "max_new_tokens": settings["max_new_tokens"],
+        "steps": settings["steps"],
+        "block_size": settings["block_size"],
+        "temperature": settings["temperature"],
+        "right_shift_logits": settings["right_shift_logits"],
+    }
+
+
+def build_validator_generation_kwargs(settings: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "max_new_tokens": settings["max_new_tokens"],
+        "steps": settings["steps"],
+        "temperature": settings["temperature"],
+        "use_cache": False,
+    }
+
+
+def build_dllm_sampler_config(settings: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "steps": settings["steps"],
+        "max_new_tokens": settings["max_new_tokens"],
+        "temperature": settings["temperature"],
+        "block_size": settings["block_size"],
+        "remasking": "low_confidence",
+        "right_shift_logits": settings["right_shift_logits"],
+    }
+
+
+def describe_backend_path(mode: str, backend: str) -> str:
+    if backend == "unturtle":
+        if mode == "aligned-warm":
+            return "block_diffusion_generator"
+        if mode == "validator-warm":
+            return "diffusion_generate"
+    if backend == "dllm" and mode in {"aligned-warm", "validator-warm"}:
+        return "bd3lm_sampler"
+    return f"{backend}:{mode}"
+
+
+def load_unturtle_model():
+    if CHECKPOINT in UNTURTLE_MODEL_CACHE:
+        return UNTURTLE_MODEL_CACHE[CHECKPOINT]
+
+    import torch
+
+    from unturtle.fast_diffusion_model import FastDiffusionModel
+    from unturtle.models.conversion.a2d.tiny_a2d.modeling_qwen3 import (
+        TinyA2DQwen3LMHeadModel,
+    )
+
+    model, tokenizer = FastDiffusionModel.from_pretrained(
+        CHECKPOINT,
+        model_class=TinyA2DQwen3LMHeadModel,
+        dtype=torch.bfloat16,
+        load_in_4bit=False,
+        trust_remote_code=True,
+    )
+    model.eval()
+    UNTURTLE_MODEL_CACHE[CHECKPOINT] = (model, tokenizer)
+    return model, tokenizer
+
+
+def load_dllm_model():
+    if CHECKPOINT in DLLM_MODEL_CACHE:
+        return DLLM_MODEL_CACHE[CHECKPOINT]
+
+    import torch
+    from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        CHECKPOINT,
+        padding_side="right",
+        trust_remote_code=True,
+    )
+    if not tokenizer.pad_token:
+        tokenizer.pad_token = tokenizer.eos_token
+    if not tokenizer.eos_token:
+        tokenizer.eos_token = tokenizer.pad_token
+    if not tokenizer.bos_token:
+        tokenizer.bos_token = tokenizer.pad_token
+    tokenizer.add_special_tokens({"mask_token": "<|mask|>"})
+    tokenizer.eot_token = "<|im_end|>"
+    tokenizer.eot_token_id = tokenizer.convert_tokens_to_ids(tokenizer.eot_token)
+    original_apply_chat_template = tokenizer.apply_chat_template
+
+    def _apply_chat_template(*args, **kwargs):
+        if "enable_thinking" not in kwargs:
+            kwargs["enable_thinking"] = False
+        try:
+            return original_apply_chat_template(*args, **kwargs)
+        except TypeError:
+            kwargs.pop("enable_thinking", None)
+            return original_apply_chat_template(*args, **kwargs)
+
+    tokenizer.apply_chat_template = _apply_chat_template
+    model = AutoModelForMaskedLM.from_pretrained(
+        CHECKPOINT,
+        dtype=torch.bfloat16,
+        trust_remote_code=True,
+    ).eval()
+    DLLM_MODEL_CACHE[CHECKPOINT] = (model, tokenizer)
+    return model, tokenizer
+
+
+def run_unturtle_aligned_once(run: RunSpec) -> tuple[str, dict[str, Any], int | None]:
+    model, tokenizer = load_unturtle_model()
+    from unturtle.models.block_diffusion_generator import BlockDiffusionGenerator
+
+    messages = [[{"role": "user", "content": run.prompt_text}]]
+    input_ids = tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_tensors="pt",
+    )
+    input_ids = input_ids.to(model.device)
+    prompt_token_ids = input_ids[0].tolist()
+
+    generator = BlockDiffusionGenerator(model=model, tokenizer=tokenizer)
+    generation_kwargs = build_aligned_generation_kwargs(run.settings)
+    outputs = generator.generate([prompt_token_ids], **generation_kwargs)
+    generated_tokens = outputs[:, len(prompt_token_ids) :]
+    text = tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)[0]
+    token_count = int(outputs.shape[1] - len(prompt_token_ids))
+    metadata = {"path": describe_backend_path(run.mode, run.backend)}
+    return text, metadata, token_count
+
+
+def run_unturtle_validator_once(run: RunSpec) -> tuple[str, dict[str, Any], int | None]:
+    from unturtle.models.generation.diffusion_generation_utils import (
+        MaskedDiffusionGenerationConfig,
+    )
+
+    model, tokenizer = load_unturtle_model()
+    messages = [[{"role": "user", "content": run.prompt_text}]]
+    input_ids = tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_tensors="pt",
+    )
+    input_ids = input_ids.to(model.device)
+    mask_token_id = tokenizer.mask_token_id
+    if mask_token_id is None:
+        mask_token_id = getattr(model.config, "mask_token_id", None)
+    if mask_token_id is None:
+        raise ValueError("mask_token_id is not available on tokenizer or model.config")
+
+    generation_config = MaskedDiffusionGenerationConfig(
+        **build_validator_generation_kwargs(run.settings),
+        mask_token_id=mask_token_id,
+    )
+    outputs = model.diffusion_generate(
+        inputs=input_ids, generation_config=generation_config
+    )
+    generated_tokens = outputs[:, input_ids.shape[1] :]
+    text = tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)[0]
+    token_count = int(outputs.shape[1] - input_ids.shape[1])
+    metadata = {
+        "path": describe_backend_path(run.mode, run.backend),
+        "mask_token_id": mask_token_id,
+    }
+    return text, metadata, token_count
+
+
+def run_dllm_once(run: RunSpec) -> tuple[str, dict[str, Any], int | None]:
+    try:
+        from dllm.core.samplers import BD3LMSampler, BD3LMSamplerConfig
+    except ModuleNotFoundError:
+        import dllm
+
+        BD3LMSampler = dllm.core.samplers.BD3LMSampler
+        BD3LMSamplerConfig = dllm.core.samplers.BD3LMSamplerConfig
+    from dllm.utils.sampling import sample_trim
+
+    model, tokenizer = load_dllm_model()
+    messages = [[{"role": "user", "content": run.prompt_text}]]
+    inputs = tokenizer.apply_chat_template(
+        messages, add_generation_prompt=True, tokenize=True
+    )
+    sampler_config = BD3LMSamplerConfig(**build_dllm_sampler_config(run.settings))
+    sampler = BD3LMSampler(model=model, tokenizer=tokenizer)
+    outputs = sampler.sample(inputs, sampler_config, return_dict=True)
+    text = sample_trim(tokenizer, outputs.sequences.tolist(), inputs)[0]
+    token_count = len(outputs.sequences[0]) - len(inputs[0])
+    metadata = {
+        "path": describe_backend_path(run.mode, run.backend),
+        "sampler": type(sampler).__name__,
+        "sample_trim": True,
+    }
+    return text, metadata, token_count
+
+
+def expand_runs(
+    *,
+    backends: list[str],
+    mode: str,
+    prompt_names: list[str],
+    steps_values: list[int],
+    max_new_token_values: list[int],
+) -> list[RunSpec]:
+    runs: list[RunSpec] = []
+    for backend in backends:
+        for prompt_name in prompt_names:
+            for steps in steps_values:
+                for max_new_tokens in max_new_token_values:
+                    runs.append(
+                        RunSpec(
+                            mode=mode,
+                            backend=backend,
+                            prompt_name=prompt_name,
+                            prompt_text=PROMPTS[prompt_name],
+                            settings={
+                                "steps": steps,
+                                "max_new_tokens": max_new_tokens,
+                                "block_size": 32,
+                                "temperature": 0.0,
+                                "right_shift_logits": False,
+                            },
+                        )
+                    )
+    return runs
+
+
+def normalize_benchmark_record(
+    *,
+    mode: str,
+    backend: str,
+    env_path: str,
+    checkpoint: str,
+    prompt_name: str,
+    prompt_text: str,
+    settings: dict[str, Any],
+    success: bool,
+    generated_text: str,
+    runtime_seconds: float,
+    output_tokens: int | None,
+    exception: Exception | None,
+    backend_metadata: dict[str, Any],
+    git_head: str,
+) -> dict[str, Any]:
+    return {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "git_head": git_head,
+        "mode": mode,
+        "backend": backend,
+        "environment_path": env_path,
+        "checkpoint": checkpoint,
+        "prompt_name": prompt_name,
+        "prompt_text": prompt_text,
+        "benchmark_settings": dict(settings),
+        "success": success,
+        "exception_type": None if exception is None else type(exception).__name__,
+        "exception_message": None if exception is None else str(exception),
+        "generated_text": generated_text,
+        "output_tokens": output_tokens,
+        "runtime_seconds": runtime_seconds,
+        "backend_metadata": dict(backend_metadata),
+    }
+
+
+def append_result_record(output_dir: Path, record: dict[str, Any]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "results.jsonl"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return path
+
+
+def _group_key(record: dict[str, Any]) -> tuple[Any, ...]:
+    settings = record["benchmark_settings"]
+    return (
+        record["mode"],
+        record["backend"],
+        record.get("prompt_name", record.get("prompt")),
+        tuple(sorted(settings.items())),
+    )
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        raise ValueError("values must not be empty")
+    if not 0.0 <= q <= 1.0:
+        raise ValueError("q must be between 0 and 1")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    position = (len(ordered) - 1) * q
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    if lower == upper:
+        return float(ordered[lower])
+    fraction = position - lower
+    return float(ordered[lower] + (ordered[upper] - ordered[lower]) * fraction)
+
+
+def summarize_records(records: list[dict[str, Any]]) -> str:
+    grouped: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+    for record in records:
+        grouped.setdefault(_group_key(record), []).append(record)
+
+    def format_settings(settings: dict[str, Any]) -> str:
+        return " / ".join(f"{key}={value}" for key, value in settings.items())
+
+    lines = ["# A2D aligned benchmark summary"]
+    for key in sorted(grouped):
+        group = grouped[key]
+        successful_records = [record for record in group if record.get("success")]
+        runtimes = [float(record["runtime_seconds"]) for record in successful_records]
+        first = group[0]
+        success_count = len(successful_records)
+        if runtimes:
+            timing_summary = (
+                f"mean={sum(runtimes) / len(runtimes):.2f}s | "
+                + f"median={_percentile(runtimes, 0.5):.2f}s | "
+                + f"p95={_percentile(runtimes, 0.95):.2f}s"
+            )
+        else:
+            timing_summary = "mean=n/a | median=n/a | p95=n/a"
+        lines.append(
+            " / ".join(
+                [
+                    first["mode"],
+                    first["backend"],
+                    first.get("prompt_name", first.get("prompt")),
+                    format_settings(dict(first["benchmark_settings"])),
+                ]
+            )
+            + " | "
+            + timing_summary
+            + " | "
+            + f"success={success_count}/{len(group)}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_summary(output_dir: Path, summary: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "summary.md"
+    path.write_text(summary, encoding="utf-8")
+    return path
+
+
+def _clear_backend_state(backend: str) -> None:
+    if backend == "unturtle":
+        UNTURTLE_MODEL_CACHE.clear()
+    elif backend == "dllm":
+        DLLM_MODEL_CACHE.clear()
+    gc.collect()
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            torch.cuda.synchronize()
+    except Exception:
+        pass
+
+
+def _time_runner(runner: Runner, run: RunSpec) -> ExecutionResult:
+    try:
+        import torch
+    except Exception:
+        torch = None
+
+    if torch is not None and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    started = time.perf_counter()
+    generated_text, backend_metadata, output_tokens = runner(run)
+    if torch is not None and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    runtime_seconds = time.perf_counter() - started
+    return ExecutionResult(
+        generated_text=generated_text,
+        backend_metadata=backend_metadata,
+        output_tokens=output_tokens,
+        runtime_seconds=runtime_seconds,
+    )
+
+
+def _worker_python(backend: str) -> Path:
+    return get_env_root() / ENV_PATHS[backend] / "bin" / "python"
+
+
+def _run_in_backend_env(run: RunSpec) -> ExecutionResult:
+    worker_python = _worker_python(run.backend)
+    script_path = Path(__file__).resolve()
+    source_root = script_path.parent.parent
+    payload = json.dumps(
+        {
+            "mode": run.mode,
+            "backend": run.backend,
+            "prompt_name": run.prompt_name,
+            "prompt_text": run.prompt_text,
+            "settings": run.settings,
+        }
+    )
+    env = {**os.environ, WORKER_MODE: payload, "PYTHONPATH": str(source_root)}
+    completed = subprocess.run(
+        [str(worker_python), str(script_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    return ExecutionResult(**json.loads(stdout_lines[-1]))
+
+
+def _run_warm_batch_in_backend_env(
+    run: RunSpec,
+    *,
+    warmup_iters: int,
+    measure_iters: int,
+) -> list[ExecutionResult | Exception]:
+    worker_python = _worker_python(run.backend)
+    script_path = Path(__file__).resolve()
+    source_root = script_path.parent.parent
+    payload = json.dumps(
+        {
+            "run": {
+                "mode": run.mode,
+                "backend": run.backend,
+                "prompt_name": run.prompt_name,
+                "prompt_text": run.prompt_text,
+                "settings": run.settings,
+            },
+            "warmup_iters": warmup_iters,
+            "measure_iters": measure_iters,
+        }
+    )
+    env = {**os.environ, WARM_WORKER_MODE: payload, "PYTHONPATH": str(source_root)}
+    completed = subprocess.run(
+        [str(worker_python), str(script_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    records = json.loads(stdout_lines[-1])
+    results: list[ExecutionResult | Exception] = []
+    for record in records:
+        if record["success"]:
+            results.append(
+                ExecutionResult(
+                    generated_text=record["generated_text"],
+                    backend_metadata=record["backend_metadata"],
+                    output_tokens=record["output_tokens"],
+                    runtime_seconds=record["runtime_seconds"],
+                )
+            )
+        else:
+            results.append(RuntimeError(record["exception_message"]))
+    return results
+
+
+def execute_warm_runs(
+    run: RunSpec,
+    warmup_iters: int,
+    measure_iters: int,
+    *,
+    env_path: str,
+    checkpoint: str,
+    git_head: str,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for outcome in _run_warm_batch_in_backend_env(
+        run,
+        warmup_iters=warmup_iters,
+        measure_iters=measure_iters,
+    ):
+        if isinstance(outcome, Exception):
+            records.append(
+                normalize_benchmark_record(
+                    mode=run.mode,
+                    backend=run.backend,
+                    env_path=env_path,
+                    checkpoint=checkpoint,
+                    prompt_name=run.prompt_name,
+                    prompt_text=run.prompt_text,
+                    settings=run.settings,
+                    success=False,
+                    generated_text="",
+                    runtime_seconds=0.0,
+                    output_tokens=None,
+                    exception=outcome,
+                    backend_metadata={
+                        "path": describe_backend_path(run.mode, run.backend)
+                    },
+                    git_head=git_head,
+                )
+            )
+            break
+        records.append(
+            normalize_benchmark_record(
+                mode=run.mode,
+                backend=run.backend,
+                env_path=env_path,
+                checkpoint=checkpoint,
+                prompt_name=run.prompt_name,
+                prompt_text=run.prompt_text,
+                settings=run.settings,
+                success=True,
+                generated_text=outcome.generated_text,
+                runtime_seconds=outcome.runtime_seconds,
+                output_tokens=outcome.output_tokens,
+                exception=None,
+                backend_metadata=outcome.backend_metadata,
+                git_head=git_head,
+            )
+        )
+    return records
+
+
+def execute_cold_start_run(run: RunSpec) -> ExecutionResult:
+    return _run_in_backend_env(run)
+
+
+def _execute_cold_start_run_in_process(run: RunSpec) -> ExecutionResult:
+    _clear_backend_state(run.backend)
+
+    try:
+        import torch
+    except Exception:
+        torch = None
+
+    if torch is not None and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    load_started = time.perf_counter()
+    if run.backend == "unturtle":
+        load_unturtle_model()
+    elif run.backend == "dllm":
+        load_dllm_model()
+    else:
+        raise ValueError(f"unsupported backend: {run.backend}")
+    if torch is not None and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    load_seconds = time.perf_counter() - load_started
+
+    runner = select_runner(run)
+
+    if torch is not None and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    first_generation_started = time.perf_counter()
+    generated_text, backend_metadata, output_tokens = runner(run)
+    if torch is not None and torch.cuda.is_available():
+        torch.cuda.synchronize()
+    first_generation_seconds = time.perf_counter() - first_generation_started
+
+    return ExecutionResult(
+        generated_text=generated_text,
+        backend_metadata={
+            **backend_metadata,
+            "cold_start": True,
+            "load_seconds": load_seconds,
+            "first_generation_seconds": first_generation_seconds,
+        },
+        output_tokens=output_tokens,
+        runtime_seconds=load_seconds + first_generation_seconds,
+    )
+
+
+def select_runner(run: RunSpec) -> Runner:
+    if run.backend == "unturtle":
+        if run.mode in {"aligned-warm", "cold-start"}:
+            return run_unturtle_aligned_once
+        if run.mode == "validator-warm":
+            return run_unturtle_validator_once
+    if run.backend == "dllm" and run.mode in {
+        "aligned-warm",
+        "validator-warm",
+        "cold-start",
+    }:
+        return run_dllm_once
+    raise ValueError(f"unsupported run: backend={run.backend}, mode={run.mode}")
+
+
+def _run_worker_from_env() -> int:
+    payload = os.environ.get(WORKER_MODE)
+    if not payload:
+        return 1
+    run_data = json.loads(payload)
+    run = RunSpec(**run_data)
+    if run.mode == "cold-start":
+        result = _execute_cold_start_run_in_process(run)
+    else:
+        runner = select_runner(run)
+        result = _time_runner(runner, run)
+    print(
+        json.dumps(
+            {
+                "generated_text": result.generated_text,
+                "backend_metadata": result.backend_metadata,
+                "output_tokens": result.output_tokens,
+                "runtime_seconds": result.runtime_seconds,
+            }
+        )
+    )
+    return 0
+
+
+def _run_warm_worker_from_env() -> int:
+    payload = os.environ.get(WARM_WORKER_MODE)
+    if not payload:
+        return 1
+    batch = json.loads(payload)
+    run = RunSpec(**batch["run"])
+    runner = select_runner(run)
+    for _ in range(batch["warmup_iters"]):
+        _ = _time_runner(runner, run)
+    results: list[dict[str, Any]] = []
+    for _ in range(batch["measure_iters"]):
+        try:
+            result = _time_runner(runner, run)
+            results.append(
+                {
+                    "success": True,
+                    "generated_text": result.generated_text,
+                    "backend_metadata": result.backend_metadata,
+                    "output_tokens": result.output_tokens,
+                    "runtime_seconds": result.runtime_seconds,
+                }
+            )
+        except Exception as exc:
+            results.append(
+                {
+                    "success": False,
+                    "exception_message": str(exc),
+                }
+            )
+            break
+    print(json.dumps(results))
+    return 0
+
+
+def main() -> None:
+    if WORKER_MODE in os.environ:
+        raise SystemExit(_run_worker_from_env())
+    if WARM_WORKER_MODE in os.environ:
+        raise SystemExit(_run_warm_worker_from_env())
+
+    args = parse_args()
+    backends = list(BACKENDS) if args.backend == "all" else [args.backend]
+    prompt_names = list(PROMPTS) if args.prompt == "all" else [args.prompt]
+    steps_values = [args.steps] if args.steps is not None else list(DEFAULT_STEPS)
+    max_new_token_values = (
+        [args.max_new_tokens]
+        if args.max_new_tokens is not None
+        else list(DEFAULT_MAX_NEW_TOKENS)
+    )
+    runs = expand_runs(
+        backends=backends,
+        mode=args.mode,
+        prompt_names=prompt_names,
+        steps_values=steps_values,
+        max_new_token_values=max_new_token_values,
+    )
+    output_dir = Path(args.output_dir)
+    git_head = get_git_head()
+    records: list[dict[str, Any]] = []
+
+    for run in runs:
+        try:
+            if run.mode == "cold-start":
+                run_records = [
+                    normalize_benchmark_record(
+                        mode=run.mode,
+                        backend=run.backend,
+                        env_path=ENV_PATHS[run.backend],
+                        checkpoint=CHECKPOINT,
+                        prompt_name=run.prompt_name,
+                        prompt_text=run.prompt_text,
+                        settings=run.settings,
+                        success=True,
+                        generated_text=(
+                            result := execute_cold_start_run(run)
+                        ).generated_text,
+                        runtime_seconds=result.runtime_seconds,
+                        output_tokens=result.output_tokens,
+                        exception=None,
+                        backend_metadata=result.backend_metadata,
+                        git_head=git_head,
+                    )
+                ]
+            else:
+                run_records = execute_warm_runs(
+                    run,
+                    warmup_iters=args.warmup_iters,
+                    measure_iters=args.measure_iters,
+                    env_path=ENV_PATHS[run.backend],
+                    checkpoint=CHECKPOINT,
+                    git_head=git_head,
+                )
+
+            for record in run_records:
+                append_result_record(output_dir, record)
+                records.append(record)
+        except Exception as exc:
+            record = normalize_benchmark_record(
+                mode=run.mode,
+                backend=run.backend,
+                env_path=ENV_PATHS[run.backend],
+                checkpoint=CHECKPOINT,
+                prompt_name=run.prompt_name,
+                prompt_text=run.prompt_text,
+                settings=run.settings,
+                success=False,
+                generated_text="",
+                runtime_seconds=0.0,
+                output_tokens=None,
+                exception=exc,
+                backend_metadata={"path": describe_backend_path(run.mode, run.backend)},
+                git_head=git_head,
+            )
+            append_result_record(output_dir, record)
+            records.append(record)
+
+    summary = summarize_records(records)
+    write_summary(output_dir, summary)
+    print(summary, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/configs/a2d_llama_sft.yaml
+++ b/examples/configs/a2d_llama_sft.yaml
@@ -1,0 +1,42 @@
+model:
+  model: nishide-dev/A2D-Llama3-8B-dLLM
+  model_type: a2d
+  max_seq_length: 512
+  load_in_4bit: true
+
+data:
+  dataset: allenai/tulu-3-sft-mixture
+  dataset_text_field: text
+
+training:
+  training_type: lora
+  output_dir: ./outputs/a2d_llama_sft_cli
+  num_epochs: 2
+  learning_rate: 2.0e-5
+  batch_size: 2
+  gradient_accumulation_steps: 8
+  warmup_steps: 5
+  save_steps: 0
+  weight_decay: 0.01
+  random_seed: 3407
+  packing: false
+  gradient_checkpointing: unsloth
+
+diffusion:
+  alpha_scheduler: cosine
+  time_epsilon: 0.001
+  loss_weight_type: timestep
+  completion_only: true
+
+lora:
+  lora_r: 16
+  lora_alpha: 32
+  lora_dropout: 0.0
+  target_modules: q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj
+  use_rslora: false
+
+logging:
+  enable_wandb: false
+  wandb_project: unturtle-training
+  enable_tensorboard: false
+  tensorboard_dir: runs

--- a/examples/configs/dream_sft.yaml
+++ b/examples/configs/dream_sft.yaml
@@ -1,0 +1,42 @@
+model:
+  model: nishide-dev/Dream-7B-dLLM
+  model_type: dream
+  max_seq_length: 512
+  load_in_4bit: true
+
+data:
+  dataset: allenai/tulu-3-sft-mixture
+  dataset_text_field: text
+
+training:
+  training_type: lora
+  output_dir: ./outputs/dream_sft_cli
+  num_epochs: 2
+  learning_rate: 2.0e-5
+  batch_size: 2
+  gradient_accumulation_steps: 8
+  warmup_steps: 5
+  save_steps: 0
+  weight_decay: 0.01
+  random_seed: 3407
+  packing: false
+  gradient_checkpointing: unsloth
+
+diffusion:
+  alpha_scheduler: linear
+  time_epsilon: 0.001
+  loss_weight_type: scheduler
+  completion_only: true
+
+lora:
+  lora_r: 16
+  lora_alpha: 32
+  lora_dropout: 0.0
+  target_modules: q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj
+  use_rslora: false
+
+logging:
+  enable_wandb: false
+  wandb_project: unturtle-training
+  enable_tensorboard: false
+  tensorboard_dir: runs

--- a/examples/configs/llada_grpo.yaml
+++ b/examples/configs/llada_grpo.yaml
@@ -1,0 +1,62 @@
+# Diffu-GRPO / wd1 RL via `unturtle train --config examples/configs/llada_grpo.yaml`.
+# Requires: uv pip install -e ".[huggingface,grpo]"
+#
+# The dataset is mapped to TRL's ``prompt`` column from ``data.dataset_text_field``
+# unless the dataset already exposes ``prompt``.
+
+model:
+  model: GSAI-ML/LLaDA-8B-Instruct
+  model_type: llada
+  max_seq_length: 512
+  load_in_4bit: true
+
+data:
+  dataset: allenai/tulu-3-sft-mixture
+  dataset_text_field: text
+
+training:
+  task: grpo
+  training_type: lora
+  output_dir: ./outputs/llada_grpo_cli
+  num_epochs: 1
+  learning_rate: 1.0e-5
+  batch_size: 1
+  gradient_accumulation_steps: 8
+  warmup_steps: 5
+  save_steps: 0
+  weight_decay: 0.01
+  random_seed: 3407
+  packing: false
+  gradient_checkpointing: unsloth
+
+diffusion:
+  alpha_scheduler: linear
+  time_epsilon: 0.001
+  loss_weight_type: uniform
+  completion_only: true
+
+lora:
+  lora_r: 16
+  lora_alpha: 32
+  lora_dropout: 0.0
+  target_modules: q_proj,k_proj,v_proj,attn_out,ff_proj,up_proj,ff_out
+  use_rslora: false
+
+logging:
+  enable_wandb: false
+  wandb_project: unturtle-training
+  enable_tensorboard: false
+  tensorboard_dir: runs
+
+grpo:
+  builtin_reward: length
+  num_generations: 8
+  max_completion_length: 128
+  num_iterations: 1
+  diffusion_steps: 128
+  block_length: 32
+  mask_id: null
+  cfg_scale: 0.0
+  remasking: random
+  diffu_policy_objective: grpo
+  scale_rewards: false

--- a/examples/configs/llada_sft.yaml
+++ b/examples/configs/llada_sft.yaml
@@ -1,0 +1,42 @@
+model:
+  model: GSAI-ML/LLaDA-8B-Instruct
+  model_type: llada
+  max_seq_length: 512
+  load_in_4bit: true
+
+data:
+  dataset: allenai/tulu-3-sft-mixture
+  dataset_text_field: text
+
+training:
+  training_type: lora
+  output_dir: ./outputs/llada_sft_cli
+  num_epochs: 2
+  learning_rate: 1.0e-5
+  batch_size: 4
+  gradient_accumulation_steps: 4
+  warmup_steps: 5
+  save_steps: 0
+  weight_decay: 0.01
+  random_seed: 3407
+  packing: false
+  gradient_checkpointing: unsloth
+
+diffusion:
+  alpha_scheduler: linear
+  time_epsilon: 0.001
+  loss_weight_type: uniform
+  completion_only: true
+
+lora:
+  lora_r: 16
+  lora_alpha: 32
+  lora_dropout: 0.0
+  target_modules: q_proj,k_proj,v_proj,attn_out,ff_proj,up_proj,ff_out
+  use_rslora: false
+
+logging:
+  enable_wandb: false
+  wandb_project: unturtle-training
+  enable_tensorboard: false
+  tensorboard_dir: runs

--- a/examples/demos/llada_sft_demo.py
+++ b/examples/demos/llada_sft_demo.py
@@ -1,0 +1,384 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "marimo",
+#     "altair",
+#     "polars",
+#     "torch",
+#     "transformers",
+#     "peft",
+#     "trl",
+#     "datasets",
+#     "bitsandbytes",
+# ]
+# ///
+"""
+LLaDA-8B SFT demo notebook using unturtle DiffusionTrainer.
+
+Dataset : allenai/tulu-3-sft-mixture (train[:2000] / test[:200])
+Model   : GSAI-ML/LLaDA-8B-Instruct
+Training: DiffusionTrainer + LoRA r=16, 2 epochs, bf16
+
+Run interactively:
+    marimo edit examples/demos/llada_sft_demo.py
+
+Run headless training:
+    nohup python examples/training/run_training.py > logs/llada_sft.log 2>&1 &
+"""
+
+import marimo
+
+__generated_with = "0.22.4"
+app = marimo.App(width="full")
+
+
+# ---------------------------------------------------------------------------
+# Cell 1: imports & environment check
+# NOTE: trl / transformers / peft must be imported BEFORE unturtle.
+#       All imports in a single cell to control order.
+# ---------------------------------------------------------------------------
+@app.cell
+def _():
+    import json
+    import os
+    import sys
+    import time
+    from pathlib import Path
+
+    import marimo as mo
+    import peft
+    import torch
+
+    # Import order: trl/transformers/peft FIRST, then unturtle
+    import transformers
+    import trl
+
+    import unturtle
+
+    cuda_ok = torch.cuda.is_available()
+    gpu_name = torch.cuda.get_device_name(0) if cuda_ok else "N/A"
+    vram_gb = (
+        round(torch.cuda.get_device_properties(0).total_memory / 1e9, 1)
+        if cuda_ok
+        else 0
+    )
+
+    mo.md(f"""
+    ## Environment
+
+    | | |
+    |---|---|
+    | CUDA | {"✅ " + gpu_name + f" ({vram_gb} GB)" if cuda_ok else "❌ CPU only"} |
+    | torch | `{torch.__version__}` |
+    | transformers | `{transformers.__version__}` |
+    | peft | `{peft.__version__}` |
+    | trl | `{trl.__version__}` |
+    | unturtle | `{unturtle.__version__}` |
+    """)
+    return Path, cuda_ok, gpu_name, json, mo, os, peft, sys, time, torch, transformers, trl, unturtle, vram_gb
+
+
+# ---------------------------------------------------------------------------
+# Cell 3: hyperparameter controls (UI)
+# ---------------------------------------------------------------------------
+@app.cell
+def _(mo):
+    train_samples = mo.ui.slider(200, 4000, value=2000, step=200, label="Train samples")
+    eval_samples  = mo.ui.slider(50,  500,  value=200,  step=50,  label="Eval samples")
+    num_epochs    = mo.ui.slider(1,   5,    value=2,    step=1,   label="Epochs")
+    batch_size    = mo.ui.slider(1,   16,   value=4,    step=1,   label="Batch size / device")
+    lora_r        = mo.ui.slider(4,   64,   value=16,   step=4,   label="LoRA rank r")
+    lr_exp        = mo.ui.slider(-6,  -3,   value=-5,   step=1,   label="log10(lr)")
+
+    mo.md("## Hyperparameters"), train_samples, eval_samples, num_epochs, batch_size, lora_r, lr_exp
+    return batch_size, eval_samples, lora_r, lr_exp, num_epochs, train_samples
+
+
+# ---------------------------------------------------------------------------
+# Cell 4: config dict (derived from UI)
+# ---------------------------------------------------------------------------
+@app.cell
+def _(batch_size, eval_samples, lora_r, lr_exp, mo, num_epochs, train_samples):
+    CFG = {
+        "model_name":     "GSAI-ML/LLaDA-8B-Instruct",
+        "output_dir":     "outputs/llada_sft_demo",
+        "train_samples":  train_samples.value,
+        "eval_samples":   eval_samples.value,
+        "num_epochs":     num_epochs.value,
+        "batch_size":     batch_size.value,
+        "lora_r":         lora_r.value,
+        "lora_alpha":     lora_r.value * 2,
+        "lr":             10 ** lr_exp.value,
+        "max_length":     512,
+    }
+    mo.md(f"```json\n{__import__('json').dumps(CFG, indent=2)}\n```")
+    return (CFG,)
+
+
+# ---------------------------------------------------------------------------
+# Cell 5: load model & tokenizer via FastDiffusionModel
+# ---------------------------------------------------------------------------
+@app.cell
+def _(CFG, mo, torch):
+    from unturtle import FastDiffusionModel
+
+    mo.md("## Loading model…")
+
+    _model, _tokenizer = FastDiffusionModel.from_pretrained(
+        CFG["model_name"],
+        dtype=torch.bfloat16,
+        load_in_4bit=False,
+    )
+    model_base = _model
+    tokenizer  = _tokenizer
+
+    mo.md(f"Model loaded: `{CFG['model_name']}` — {sum(p.numel() for p in model_base.parameters()) / 1e9:.1f}B params")
+    return FastDiffusionModel, model_base, tokenizer
+
+
+# ---------------------------------------------------------------------------
+# Cell 6: apply LoRA
+# ---------------------------------------------------------------------------
+@app.cell
+def _(CFG, FastDiffusionModel, mo, model_base):
+    model = FastDiffusionModel.get_peft_model(
+        model_base,
+        r=CFG["lora_r"],
+        lora_alpha=CFG["lora_alpha"],
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                        "gate_proj", "up_proj", "down_proj"],
+        lora_dropout=0,
+        bias="none",
+    )
+
+    n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    n_total     = sum(p.numel() for p in model.parameters())
+
+    mo.md(f"""
+    ## LoRA applied
+
+    - Rank r = {CFG['lora_r']}, alpha = {CFG['lora_alpha']}
+    - Trainable: **{n_trainable / 1e6:.1f}M** / {n_total / 1e9:.1f}B ({n_trainable / n_total * 100:.2f}%)
+    """)
+    return (model,)
+
+
+# ---------------------------------------------------------------------------
+# Cell 7: load & preprocess dataset
+# ---------------------------------------------------------------------------
+@app.cell
+def _(CFG, mo, tokenizer):
+    from datasets import load_dataset
+
+    mo.md("## Loading dataset…")
+
+    raw = load_dataset(
+        "allenai/tulu-3-sft-mixture",
+        split={
+            "train": f"train[:{CFG['train_samples']}]",
+            "test":  f"train[10000:{10000 + CFG['eval_samples']}]",
+        },
+    )
+
+    # LLaDA tokenizer: mask_token_id is in model config, not tokenizer
+    _eos = tokenizer.eos_token or "<|endoftext|>"
+
+    def _preprocess(example):
+        msgs = example["messages"]
+        # Split: non-assistant turns → prompt, last assistant → completion
+        prompt_msgs     = [m for m in msgs if m["role"] != "assistant"]
+        completion_msgs = [m for m in msgs if m["role"] == "assistant"][-1:]
+
+        # apply_chat_template returns BatchEncoding when tokenize=True
+        _enc = tokenizer.apply_chat_template(
+            prompt_msgs,
+            tokenize=True,
+            add_generation_prompt=True,
+        )
+        prompt_ids = list(_enc["input_ids"]) if hasattr(_enc, "__getitem__") and not isinstance(_enc, list) else list(_enc)
+
+        completion_text = completion_msgs[0]["content"] if completion_msgs else ""
+        completion_ids  = tokenizer(
+            completion_text + _eos,
+            add_special_tokens=False,
+        )["input_ids"]
+
+        input_ids = prompt_ids + completion_ids
+        labels    = [-100] * len(prompt_ids) + completion_ids
+
+        # truncate
+        max_len   = CFG["max_length"]
+        input_ids = input_ids[:max_len]
+        labels    = labels[:max_len]
+
+        return {"input_ids": input_ids, "labels": labels}
+
+    dataset = raw.map(
+        _preprocess,
+        remove_columns=raw["train"].column_names,
+        desc="Tokenising",
+    )
+    # filter sequences that are too short (no completion tokens)
+    dataset = dataset.filter(lambda x: sum(1 for l in x["labels"] if l != -100) > 0)
+
+    mo.md(f"""
+    ## Dataset
+
+    | split | samples |
+    |-------|---------|
+    | train | {len(dataset['train'])} |
+    | test  | {len(dataset['test'])} |
+
+    Sample (first 10 input token ids): `{dataset['train'][0]['input_ids'][:10]}`
+    """)
+    return dataset, load_dataset
+
+
+# ---------------------------------------------------------------------------
+# Cell 8: training arguments & trainer
+# ---------------------------------------------------------------------------
+@app.cell
+def _(CFG, dataset, mo, model, tokenizer):
+    from unturtle.diffusion import DiffusionTrainer, DiffusionTrainingArguments
+
+    training_args = DiffusionTrainingArguments(
+        output_dir=CFG["output_dir"],
+        num_train_epochs=CFG["num_epochs"],
+        per_device_train_batch_size=CFG["batch_size"],
+        per_device_eval_batch_size=CFG["batch_size"],
+        learning_rate=CFG["lr"],
+        lr_scheduler_type="cosine",
+        warmup_ratio=0.05,
+        bf16=True,
+        logging_steps=10,
+        eval_strategy="epoch",
+        save_strategy="epoch",
+        disable_tqdm=True,
+        report_to="none",
+        loss_weight_type="uniform",
+        dataloader_num_workers=0,
+    )
+
+    trainer = DiffusionTrainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset["train"],
+        eval_dataset=dataset["test"],
+        processing_class=tokenizer,
+    )
+
+    mo.md(f"""
+    ## Trainer ready
+
+    - Output dir: `{CFG['output_dir']}`
+    - Epochs: {CFG['num_epochs']} / Batch: {CFG['batch_size']} / LR: {CFG['lr']:.0e}
+    - Loss weight: uniform / mask_prob: {CFG['mask_prob']}
+    """)
+    return DiffusionTrainer, DiffusionTrainingArguments, trainer, training_args
+
+
+# ---------------------------------------------------------------------------
+# Cell 9: run training (blocking — suits headless execution)
+# ---------------------------------------------------------------------------
+@app.cell
+def _(mo, time, trainer):
+    mo.md("## Training — running…")
+
+    _t0     = time.time()
+    _result = trainer.train()
+    _elapsed = time.time() - _t0
+
+    train_loss = _result.training_loss
+
+    mo.md(f"""
+    ## Training complete ✅
+
+    | | |
+    |---|---|
+    | Train loss | `{train_loss:.4f}` |
+    | Elapsed    | `{_elapsed/60:.1f} min` |
+    | Steps      | `{_result.global_step}` |
+    """)
+    return (train_loss,)
+
+
+# ---------------------------------------------------------------------------
+# Cell 10: loss curve visualisation
+# ---------------------------------------------------------------------------
+@app.cell
+def _(mo, trainer):
+    import altair as alt
+    import polars as pl
+
+    _log = trainer.state.log_history
+    _rows = [
+        {"step": e["step"], "loss": e["loss"]}
+        for e in _log
+        if "loss" in e
+    ]
+
+    if _rows:
+        _df = pl.DataFrame(_rows)
+        _chart = (
+            alt.Chart(_df.to_pandas())
+            .mark_line(point=True)
+            .encode(
+                x=alt.X("step:Q", title="Step"),
+                y=alt.Y("loss:Q", title="Train loss", scale=alt.Scale(zero=False)),
+            )
+            .properties(title="Training loss curve", width=700, height=300)
+        )
+        mo.md("## Loss curve"), _chart
+    else:
+        mo.md("No loss history recorded yet.")
+    return alt, pl
+
+
+# ---------------------------------------------------------------------------
+# Cell 11: inference demo (before/after)
+# ---------------------------------------------------------------------------
+@app.cell
+def _(CFG, mo, trainer):
+    import torch as _torch
+
+    mo.md("## Inference demo")
+
+    _tok    = trainer.processing_class
+    _prompt = "Please explain what a diffusion language model is in one sentence."
+    _msgs   = [{"role": "user", "content": _prompt}]
+    _enc    = _tok.apply_chat_template(_msgs, tokenize=True, add_generation_prompt=True)
+    _input_ids = _enc["input_ids"] if hasattr(_enc, "__getitem__") and not isinstance(_enc, list) else _enc
+    _ids    = _torch.tensor([_input_ids])
+
+    _model  = trainer.model
+    _device = next(_model.parameters()).device
+    _ids    = _ids.to(_device)
+
+    _model.eval()
+    with _torch.no_grad():
+        _out = _model.generate(
+            _ids,
+            max_new_tokens=128,
+            do_sample=False,
+        ) if hasattr(_model, "generate") else None
+
+    if _out is not None:
+        _gen_text = _tok.decode(_out[0][_ids.shape[1]:], skip_special_tokens=True)
+    else:
+        _gen_text = "(generate() not available on this model)"
+
+    mo.md(f"""
+    **Prompt**: {_prompt}
+
+    **Response**: {_gen_text}
+    """)
+    return (torch,)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# - Interactive:  marimo edit examples/demos/llada_sft_demo.py
+# - Headless:     python examples/training/run_training.py
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    app.run()

--- a/examples/grpo_diffu_train_smoke.py
+++ b/examples/grpo_diffu_train_smoke.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+"""Minimal GPU smoke: run :meth:`~unturtle.diffusion.DiffuGRPOTrainer.train` for a few steps.
+
+This verifies the full TRL + diffu-GRPO training loop (rollout → rewards → advantages →
+backward) on CUDA without downloading checkpoints.
+
+**Dependencies** (editable install with Hugging Face + GRPO extras)::
+
+    uv pip install --python .venv/bin/python -e ".[huggingface,grpo]"
+
+(or ``-e ".[huggingface]"`` then ``uv pip install trl mergekit tokenizers``).
+
+**Run** (single GPU)::
+
+    python examples/grpo_diffu_train_smoke.py
+
+Optional **wd1** objective (ratio-free weighted log-likelihood, ICLR 2026 wd1)::
+
+    python examples/grpo_diffu_train_smoke.py --wd1
+
+Optional **wd1++** (MC log-prob at denoise snapshots; see ``docs/wd1plusplus-design.md``)::
+
+    python examples/grpo_diffu_train_smoke.py --wd1++
+
+``import unsloth`` is executed before ``torch`` / ``transformers`` / TRL so Unsloth patches apply.
+Expects ``torch.cuda.is_available()``. For d1-aligned advantages (no per-group std scaling),
+we pass ``scale_rewards=\"none\"`` to :class:`~unturtle.diffusion.DiffuGRPOConfig` (TRL maps
+``False`` the same way). See ``docs/diffu-grpo-d1-notes.md``.
+
+The smoke uses ``num_iterations=2`` so the TRL rollout buffer and mask seeds are exercised
+across inner GRPO steps.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+
+import torch
+import unsloth  # noqa: F401 — must run before torch/transformers/trl (Unsloth + project convention).
+from datasets import Dataset
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from transformers import BertConfig, BertForMaskedLM, PreTrainedTokenizerFast
+
+
+def _stub_mod(name: str, **attrs: object) -> types.ModuleType:
+    m = types.ModuleType(name)
+    m.__package__ = name.rpartition(".")[0] or name
+    for k, v in attrs.items():
+        setattr(m, k, v)
+    return m
+
+
+def _patch_trl_if_broken_imports() -> None:
+    """Pre-load stubs so TRL can import without optional deps (see ``conftest.py``)."""
+    import importlib
+
+    trl_import_utils = importlib.import_module("trl.import_utils")
+    # ``_is_package_available("weave")`` can be true while ``import weave`` still fails in some envs.
+    try:
+        import weave  # noqa: F401
+    except ModuleNotFoundError:
+        trl_import_utils._weave_available = False  # type: ignore[attr-defined]
+
+    merge_missing = importlib.util.find_spec("mergekit") is None
+    blender_missing = importlib.util.find_spec("llm_blender") is None
+    if merge_missing and "trl.mergekit_utils" not in sys.modules:
+        sys.modules["trl.mergekit_utils"] = _stub_mod(
+            "trl.mergekit_utils",
+            MergeConfiguration=object,
+            MergeOptions=object,
+            MergeConfig=object,
+            run_merge=lambda *a, **kw: None,
+            merge_models=lambda *a, **kw: None,
+            upload_model_to_hub=lambda *a, **kw: None,
+        )
+    if blender_missing and "trl.trainer.judges" not in sys.modules:
+        sys.modules["trl.trainer.judges"] = _stub_mod(
+            "trl.trainer.judges",
+            BasePairRMJudge=object,
+            BaseJudge=object,
+            BasePairwiseJudge=object,
+            HfPairwiseJudge=object,
+            OpenAIPairwiseJudge=object,
+            AllTrueJudge=object,
+        )
+
+
+_patch_trl_if_broken_imports()
+
+from unturtle.diffusion import DiffuGRPOConfig, DiffuGRPOTrainer
+
+
+def _require_cuda() -> None:
+    if not torch.cuda.is_available():
+        print(
+            "This smoke test requires CUDA (DiffuGRPO generation uses CUDA autocast paths).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _make_tokenizer_and_model() -> tuple[PreTrainedTokenizerFast, BertForMaskedLM]:
+    pad, unk, bos, eos = "<|pad|>", "<|unk|>", "<|bos|>", "<|eos|>"
+    special = [pad, unk, "[MASK]", bos, eos]
+    vocab = special + [f"w{i}" for i in range(95)]
+    tok = Tokenizer(WordLevel(vocab={w: i for i, w in enumerate(vocab)}, unk_token=unk))
+    tok.pre_tokenizer = Whitespace()
+    tokenizer = PreTrainedTokenizerFast(tokenizer_object=tok)
+    tokenizer.add_special_tokens(
+        {
+            "pad_token": pad,
+            "unk_token": unk,
+            "mask_token": "[MASK]",
+            "bos_token": bos,
+            "eos_token": eos,
+        }
+    )
+    vocab_size = len(vocab)
+    cfg = BertConfig(
+        vocab_size=vocab_size,
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        intermediate_size=128,
+        max_position_embeddings=64,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+    model = BertForMaskedLM(cfg)
+    model.to(torch.device("cuda"))
+    model.train()
+    return tokenizer, model
+
+
+def _toy_reward(prompts, completions, **_kwargs):
+    # Vary rewards so group-relative advantages are non-degenerate.
+    out = []
+    for c in completions:
+        t = c if isinstance(c, str) else str(c)
+        out.append(1.0 if len(t) % 2 == 0 else 0.25)
+    return out
+
+
+def main() -> None:
+    _require_cuda()
+    use_wd1pp = "--wd1++" in sys.argv
+    use_wd1 = "--wd1" in sys.argv and not use_wd1pp
+
+    try:
+        import trl.trainer.grpo_trainer  # noqa: F401
+    except ModuleNotFoundError as e:
+        print(
+            "Missing optional GRPO dependencies. Install with:\n"
+            '  uv pip install --python .venv/bin/python -e ".[huggingface,grpo]"\n'
+            "  or: uv pip install trl mergekit tokenizers\n"
+            f"Import error: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    tokenizer, model = _make_tokenizer_and_model()
+    mask_id = tokenizer.mask_token_id
+    assert mask_id is not None
+
+    rows = [{"prompt": f"Repeat the tokens w{i} w{(i + 1) % 20}."} for i in range(8)]
+    train_ds = Dataset.from_list(rows)
+
+    out_dir = "/tmp/unturtle_grpo_smoke"
+    args = DiffuGRPOConfig(
+        output_dir=out_dir,
+        per_device_train_batch_size=1,
+        num_generations=2,
+        generation_batch_size=2,
+        max_steps=8,
+        max_completion_length=32,
+        max_prompt_length=48,
+        block_length=8,
+        diffusion_steps=8,
+        mask_id=int(mask_id),
+        p_mask_prompt=0.3,
+        beta=0.0,
+        scale_rewards="none",
+        logging_steps=1,
+        report_to="none",
+        save_strategy="no",
+        bf16=False,
+        fp16=False,
+        num_iterations=2,
+        diffu_policy_objective=("wd1++" if use_wd1pp else "wd1" if use_wd1 else "grpo"),
+        dataloader_num_workers=0,
+        remove_unused_columns=False,
+    )
+
+    trainer = DiffuGRPOTrainer(
+        model=model,
+        reward_funcs=_toy_reward,
+        args=args,
+        train_dataset=train_ds,
+        processing_class=tokenizer,
+    )
+
+    train_output = trainer.train()
+    mode = "wd1++" if use_wd1pp else "wd1" if use_wd1 else "grpo"
+    print(
+        "train() finished:", train_output.global_step, "steps", f"({mode})", flush=True
+    )
+    assert train_output.global_step >= 8, "expected max_steps to run"
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/training/run_training.py
+++ b/examples/training/run_training.py
@@ -1,0 +1,198 @@
+"""
+Headless training script — mirrors the logic of llada_sft_demo.py.
+
+Usage:
+    source .venv/bin/activate
+    nohup python examples/training/run_training.py > logs/llada_sft.log 2>&1 &
+
+Checkpoints saved to: outputs/llada_sft_demo/
+"""
+
+import json
+import logging
+import os
+import sys
+import time
+
+import peft  # noqa: F401
+import torch
+
+# transformers/trl/peft must be imported BEFORE unturtle
+import transformers
+import trl  # noqa: F401
+
+# Force transformers trainer to print loss to stdout (not swallowed by tqdm)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+    force=True,
+)
+transformers.logging.set_verbosity_info()
+transformers.logging.enable_default_handler()
+transformers.logging.enable_explicit_format()
+
+from datasets import load_dataset
+
+import unturtle  # noqa: F401 (triggers unsloth patching)
+from unturtle import FastDiffusionModel
+from unturtle.diffusion import DiffusionTrainer, DiffusionTrainingArguments
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+CFG = {
+    "model_name": "GSAI-ML/LLaDA-8B-Instruct",
+    "output_dir": "outputs/llada_sft_demo",
+    "train_samples": 2000,
+    "eval_samples": 200,
+    "num_epochs": 2,
+    "batch_size": 4,
+    "lora_r": 16,
+    "lora_alpha": 32,
+    "lr": 1e-5,
+    "max_length": 512,
+}
+print(json.dumps(CFG, indent=2), flush=True)
+
+# ---------------------------------------------------------------------------
+# Model & tokenizer
+# ---------------------------------------------------------------------------
+print(f"\n[1/5] Loading model: {CFG['model_name']} …", flush=True)
+model, tokenizer = FastDiffusionModel.from_pretrained(
+    CFG["model_name"],
+    dtype=torch.bfloat16,
+    load_in_4bit=False,
+)
+n_params = sum(p.numel() for p in model.parameters())
+print(f"  Loaded: {n_params / 1e9:.1f}B params", flush=True)
+
+# mask_token_id: tokenizer may not have it, fall back to model.config
+# Note: this is derived by DiffusionTrainer from processing_class=tokenizer,
+# so we only print it here for debug visibility.
+mask_token_id = tokenizer.mask_token_id or getattr(model.config, "mask_token_id", None)
+print(f"  mask_token_id: {mask_token_id}", flush=True)
+
+# ---------------------------------------------------------------------------
+# LoRA
+# ---------------------------------------------------------------------------
+print("\n[2/5] Applying LoRA …", flush=True)
+model = FastDiffusionModel.get_peft_model(
+    model,
+    r=CFG["lora_r"],
+    lora_alpha=CFG["lora_alpha"],
+    target_modules=[
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ],
+    lora_dropout=0,
+    bias="none",
+)
+n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+print(
+    f"  Trainable: {n_trainable / 1e6:.1f}M / {n_params / 1e9:.1f}B "
+    f"({n_trainable / n_params * 100:.2f}%)",
+    flush=True,
+)
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+print("\n[3/5] Loading dataset …", flush=True)
+raw = load_dataset(
+    "allenai/tulu-3-sft-mixture",
+    split={
+        "train": f"train[:{CFG['train_samples']}]",
+        "test": f"train[10000:{10000 + CFG['eval_samples']}]",
+    },
+)
+
+eos = tokenizer.eos_token or "<|endoftext|>"
+
+
+def preprocess(example):
+    msgs = example["messages"]
+    prompt_msgs = [m for m in msgs if m["role"] != "assistant"]
+    completion_msgs = [m for m in msgs if m["role"] == "assistant"][-1:]
+    enc = tokenizer.apply_chat_template(
+        prompt_msgs,
+        tokenize=True,
+        add_generation_prompt=True,
+    )
+    prompt_ids = (
+        list(enc["input_ids"])
+        if hasattr(enc, "__getitem__") and not isinstance(enc, list)
+        else list(enc)
+    )
+    completion_text = completion_msgs[0]["content"] if completion_msgs else ""
+    completion_ids = tokenizer(completion_text + eos, add_special_tokens=False)[
+        "input_ids"
+    ]
+    input_ids = (prompt_ids + completion_ids)[: CFG["max_length"]]
+    labels = ([-100] * len(prompt_ids) + completion_ids)[: CFG["max_length"]]
+    return {"input_ids": input_ids, "labels": labels}
+
+
+dataset = raw.map(
+    preprocess, remove_columns=raw["train"].column_names, desc="Tokenising"
+)
+dataset = dataset.filter(lambda x: sum(1 for l in x["labels"] if l != -100) > 0)
+print(f"  train: {len(dataset['train'])}  /  test: {len(dataset['test'])}", flush=True)
+
+# ---------------------------------------------------------------------------
+# Trainer
+# ---------------------------------------------------------------------------
+print("\n[4/5] Setting up trainer …", flush=True)
+os.makedirs(CFG["output_dir"], exist_ok=True)
+
+training_args = DiffusionTrainingArguments(
+    output_dir=CFG["output_dir"],
+    num_train_epochs=CFG["num_epochs"],
+    per_device_train_batch_size=CFG["batch_size"],
+    per_device_eval_batch_size=CFG["batch_size"],
+    learning_rate=CFG["lr"],
+    lr_scheduler_type="cosine",
+    warmup_ratio=0.05,
+    bf16=True,
+    logging_steps=10,
+    disable_tqdm=True,
+    eval_strategy="epoch",
+    save_strategy="epoch",
+    report_to="none",
+    loss_weight_type="uniform",
+    dataloader_num_workers=0,
+)
+
+trainer = DiffusionTrainer(
+    model=model,
+    args=training_args,
+    train_dataset=dataset["train"],
+    eval_dataset=dataset["test"],
+    processing_class=tokenizer,
+)
+
+# ---------------------------------------------------------------------------
+# Train
+# ---------------------------------------------------------------------------
+print("\n[5/5] Training …", flush=True)
+t0 = time.time()
+result = trainer.train()
+elapsed = time.time() - t0
+
+print(f"\n{'=' * 60}", flush=True)
+print("Training complete!", flush=True)
+print(f"  train_loss : {result.training_loss:.4f}", flush=True)
+print(f"  steps      : {result.global_step}", flush=True)
+print(f"  elapsed    : {elapsed / 60:.1f} min", flush=True)
+print(f"  checkpoint : {CFG['output_dir']}", flush=True)
+
+# Save loss history
+history = [e for e in trainer.state.log_history if "loss" in e]
+with open(os.path.join(CFG["output_dir"], "loss_history.json"), "w") as f:
+    json.dump(history, f, indent=2)
+print(f"  loss log   : {CFG['output_dir']}/loss_history.json", flush=True)

--- a/examples/validate_a2d_real_inference.py
+++ b/examples/validate_a2d_real_inference.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+CHECKPOINTS = {
+    "mdlm": "dllm-hub/Qwen3-0.6B-diffusion-mdlm-v0.1",
+    "bd3lm": "dllm-hub/Qwen3-0.6B-diffusion-bd3lm-v0.1",
+}
+
+BACKENDS = ("unturtle", "dllm")
+ENV_PATHS = {
+    "unturtle": ".venv",
+    "dllm": ".venvDllm",
+}
+UNTURTLE_MODEL_CACHE: dict[str, tuple[Any, Any]] = {}
+DLLM_MODEL_CACHE: dict[str, tuple[Any, Any]] = {}
+
+
+@dataclass(frozen=True)
+class PromptSpec:
+    name: str
+    text: str
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    backend: str
+    model_kind: str
+    prompt_name: str
+    prompt_text: str
+    settings: dict[str, Any]
+
+
+def build_unturtle_generation_kwargs(settings: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "max_new_tokens": settings["max_new_tokens"],
+        "steps": settings["steps"],
+        "temperature": settings["temperature"],
+        "use_cache": False,
+    }
+
+
+PROMPTS = {
+    "math": PromptSpec(
+        name="math",
+        text="Lily runs 12 km/h for 4 hours. How far in 8 hours?",
+    ),
+    "code": PromptSpec(
+        name="code",
+        text="Please write an educational python function.",
+    ),
+}
+
+SCENARIOS = {
+    "smoke": {
+        "mdlm": [{"steps": 64, "max_new_tokens": 64, "temperature": 0.0}],
+        "bd3lm": [
+            {"steps": 64, "max_new_tokens": 64, "temperature": 0.0, "block_size": 32}
+        ],
+    },
+    "stability": {
+        "mdlm": [
+            {"steps": 64, "max_new_tokens": 64, "temperature": 0.0},
+            {"steps": 128, "max_new_tokens": 128, "temperature": 0.0},
+        ],
+        "bd3lm": [
+            {"steps": 64, "max_new_tokens": 64, "temperature": 0.0, "block_size": 32},
+            {"steps": 128, "max_new_tokens": 128, "temperature": 0.0, "block_size": 32},
+        ],
+    },
+}
+
+
+def expand_runs(
+    backends: list[str], model_kinds: list[str], scenario_name: str
+) -> list[RunSpec]:
+    runs: list[RunSpec] = []
+    prompts = (
+        [PROMPTS["math"]]
+        if scenario_name == "smoke"
+        else [PROMPTS["math"], PROMPTS["code"]]
+    )
+    for backend in backends:
+        for model_kind in model_kinds:
+            for prompt in prompts:
+                for settings in SCENARIOS[scenario_name][model_kind]:
+                    runs.append(
+                        RunSpec(
+                            backend=backend,
+                            model_kind=model_kind,
+                            prompt_name=prompt.name,
+                            prompt_text=prompt.text,
+                            settings=dict(settings),
+                        )
+                    )
+    return runs
+
+
+def normalize_result_record(
+    *,
+    backend: str,
+    env_path: str,
+    checkpoint: str,
+    model_kind: str,
+    prompt_name: str,
+    prompt_text: str,
+    settings: dict[str, Any],
+    success: bool,
+    generated_text: str,
+    runtime_seconds: float,
+    output_tokens: int | None,
+    exception: Exception | None,
+    backend_metadata: dict[str, Any],
+    git_head: str,
+) -> dict[str, Any]:
+    return {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "git_head": git_head,
+        "backend": backend,
+        "environment_path": env_path,
+        "checkpoint": checkpoint,
+        "model_kind": model_kind,
+        "prompt_name": prompt_name,
+        "prompt_text": prompt_text,
+        "inference_settings": dict(settings),
+        "success": success,
+        "exception_type": None if exception is None else type(exception).__name__,
+        "exception_message": None if exception is None else str(exception),
+        "generated_text": generated_text,
+        "output_tokens": output_tokens,
+        "runtime_seconds": runtime_seconds,
+        "backend_metadata": dict(backend_metadata),
+    }
+
+
+def summarize_results(records: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for record in records:
+        header = (
+            f"{record['backend']} / {record['model_kind']}"
+            f" / {record.get('prompt_name', 'unknown')}"
+            f" / {record.get('inference_settings', {})}"
+        )
+        if record.get("success"):
+            generated_text = str(record.get("generated_text", "")).strip()
+            detail = generated_text[:80] if generated_text else "<empty>"
+            status = "ok"
+        else:
+            detail = record.get("exception_message") or "unknown failure"
+            status = "failed"
+        lines.append(f"- {header}: {status} - {detail}")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", choices=["unturtle", "dllm", "all"], default="all")
+    parser.add_argument("--model", choices=["mdlm", "bd3lm", "all"], default="all")
+    parser.add_argument("--scenario", choices=["smoke", "stability"], default="smoke")
+    parser.add_argument("--prompt", choices=["math", "code", "all"], default="all")
+    parser.add_argument("--steps", type=int)
+    parser.add_argument("--max-new-tokens", type=int)
+    parser.add_argument("--output-dir", default="outputs/real_inference_validation")
+    return parser.parse_args()
+
+
+def get_git_head() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def append_result_record(output_dir: Path, record: dict[str, Any]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "results.jsonl"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return path
+
+
+def load_unturtle_model(model_kind: str):
+    if model_kind in UNTURTLE_MODEL_CACHE:
+        return UNTURTLE_MODEL_CACHE[model_kind]
+
+    import torch
+
+    from unturtle.fast_diffusion_model import FastDiffusionModel
+    from unturtle.models.conversion.a2d.tiny_a2d.modeling_qwen3 import (
+        TinyA2DQwen3LMHeadModel,
+    )
+
+    checkpoint = CHECKPOINTS[model_kind]
+    model, tokenizer = FastDiffusionModel.from_pretrained(
+        checkpoint,
+        model_class=TinyA2DQwen3LMHeadModel,
+        dtype=torch.bfloat16,
+        load_in_4bit=False,
+        trust_remote_code=True,
+    )
+    model.eval()
+    UNTURTLE_MODEL_CACHE[model_kind] = (model, tokenizer)
+    return model, tokenizer
+
+
+def run_unturtle_once(run: RunSpec) -> tuple[str, dict[str, Any], int | None]:
+    from unturtle.models.generation.diffusion_generation_utils import (
+        MaskedDiffusionGenerationConfig,
+    )
+
+    model, tokenizer = load_unturtle_model(run.model_kind)
+    messages = [[{"role": "user", "content": run.prompt_text}]]
+    input_ids = tokenizer.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_tensors="pt",
+    )
+    input_ids = input_ids.to(model.device)
+    mask_token_id = tokenizer.mask_token_id
+    if mask_token_id is None:
+        mask_token_id = getattr(model.config, "mask_token_id", None)
+    if mask_token_id is None:
+        raise ValueError("mask_token_id is not available on tokenizer or model.config")
+
+    generation_kwargs = build_unturtle_generation_kwargs(run.settings)
+    generation_config = MaskedDiffusionGenerationConfig(
+        **generation_kwargs,
+        mask_token_id=mask_token_id,
+    )
+    outputs = model.diffusion_generate(
+        inputs=input_ids, generation_config=generation_config
+    )
+    text = tokenizer.batch_decode(
+        outputs[:, input_ids.shape[1] :], skip_special_tokens=True
+    )[0]
+    token_count = int(outputs.shape[1] - input_ids.shape[1])
+    return text, {"mask_token_id": mask_token_id}, token_count
+
+
+@dataclass(frozen=True)
+class _DllmModelArgs:
+    model_name_or_path: str
+
+
+def load_dllm_model(model_kind: str):
+    if model_kind in DLLM_MODEL_CACHE:
+        return DLLM_MODEL_CACHE[model_kind]
+
+    import torch
+    from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+    checkpoint = CHECKPOINTS[model_kind]
+    tokenizer = AutoTokenizer.from_pretrained(
+        checkpoint,
+        padding_side="right",
+        trust_remote_code=True,
+    )
+    if not tokenizer.pad_token:
+        tokenizer.pad_token = tokenizer.eos_token
+    if not tokenizer.eos_token:
+        tokenizer.eos_token = tokenizer.pad_token
+    if not tokenizer.bos_token:
+        tokenizer.bos_token = tokenizer.pad_token
+    tokenizer.add_special_tokens({"mask_token": "<|mask|>"})
+    tokenizer.eot_token = "<|im_end|>"
+    tokenizer.eot_token_id = tokenizer.convert_tokens_to_ids(tokenizer.eot_token)
+    _orig_apply_chat_template = tokenizer.apply_chat_template
+
+    def _apply_chat_template(*args, **kwargs):
+        if "enable_thinking" not in kwargs:
+            kwargs["enable_thinking"] = False
+        try:
+            return _orig_apply_chat_template(*args, **kwargs)
+        except TypeError:
+            kwargs.pop("enable_thinking", None)
+            return _orig_apply_chat_template(*args, **kwargs)
+
+    tokenizer.apply_chat_template = _apply_chat_template
+    model = AutoModelForMaskedLM.from_pretrained(
+        checkpoint,
+        dtype=torch.bfloat16,
+        trust_remote_code=True,
+    ).eval()
+    DLLM_MODEL_CACHE[model_kind] = (model, tokenizer)
+    return model, tokenizer
+
+
+def build_dllm_sampler_config(model_kind: str, settings: dict[str, Any]):
+    try:
+        from dllm.core.samplers import BD3LMSamplerConfig, MDLMSamplerConfig
+    except ModuleNotFoundError:
+        import dllm
+
+        BD3LMSamplerConfig = dllm.core.samplers.BD3LMSamplerConfig
+        MDLMSamplerConfig = dllm.core.samplers.MDLMSamplerConfig
+
+    sampler_kwargs = {
+        "steps": settings["steps"],
+        "max_new_tokens": settings["max_new_tokens"],
+        "temperature": settings["temperature"],
+        "remasking": "low_confidence",
+        "right_shift_logits": False,
+    }
+    if model_kind == "mdlm":
+        sampler_class = MDLMSamplerConfig
+    elif model_kind == "bd3lm":
+        sampler_class = BD3LMSamplerConfig
+        sampler_kwargs["block_size"] = settings.get("block_size", 32)
+    else:
+        raise ValueError(f"unsupported model kind: {model_kind}")
+    return sampler_class(**sampler_kwargs)
+
+
+def run_dllm_once(run: RunSpec) -> tuple[str, dict[str, Any], int | None]:
+    from dllm.core.samplers import BD3LMSampler, MDLMSampler
+    from dllm.utils.sampling import sample_trim
+
+    model, tokenizer = load_dllm_model(run.model_kind)
+    messages = [[{"role": "user", "content": run.prompt_text}]]
+    inputs = tokenizer.apply_chat_template(
+        messages, add_generation_prompt=True, tokenize=True
+    )
+    sampler_config = build_dllm_sampler_config(run.model_kind, run.settings)
+    if run.model_kind == "mdlm":
+        sampler = MDLMSampler(model=model, tokenizer=tokenizer)
+    elif run.model_kind == "bd3lm":
+        sampler = BD3LMSampler(model=model, tokenizer=tokenizer)
+    else:
+        raise ValueError(f"unsupported model kind: {run.model_kind}")
+    outputs = sampler.sample(inputs, sampler_config, return_dict=True)
+    text = sample_trim(tokenizer, outputs.sequences.tolist(), inputs)[0]
+    token_count = len(outputs.sequences[0]) - len(inputs[0])
+    return text, {"sampler": type(sampler).__name__}, token_count
+
+
+def main() -> None:
+    args = parse_args()
+    backends = ["unturtle", "dllm"] if args.backend == "all" else [args.backend]
+    model_kinds = ["mdlm", "bd3lm"] if args.model == "all" else [args.model]
+    runs = expand_runs(
+        backends=backends, model_kinds=model_kinds, scenario_name=args.scenario
+    )
+    if args.prompt != "all":
+        runs = [run for run in runs if run.prompt_name == args.prompt]
+    if args.steps is not None:
+        runs = [run for run in runs if run.settings.get("steps") == args.steps]
+    if args.max_new_tokens is not None:
+        runs = [
+            run
+            for run in runs
+            if run.settings.get("max_new_tokens") == args.max_new_tokens
+        ]
+    output_dir = Path(args.output_dir)
+    git_head = get_git_head()
+    records: list[dict[str, Any]] = []
+
+    for run in runs:
+        started = time.perf_counter()
+        error = None
+        generated_text = ""
+        output_tokens = None
+        metadata: dict[str, Any] = {}
+        try:
+            if run.backend == "unturtle":
+                generated_text, metadata, output_tokens = run_unturtle_once(run)
+            else:
+                generated_text, metadata, output_tokens = run_dllm_once(run)
+        except Exception as exc:
+            error = exc
+        runtime_seconds = time.perf_counter() - started
+        record = normalize_result_record(
+            backend=run.backend,
+            env_path=ENV_PATHS[run.backend],
+            checkpoint=CHECKPOINTS[run.model_kind],
+            model_kind=run.model_kind,
+            prompt_name=run.prompt_name,
+            prompt_text=run.prompt_text,
+            settings=run.settings,
+            success=error is None,
+            generated_text=generated_text,
+            runtime_seconds=runtime_seconds,
+            output_tokens=output_tokens,
+            exception=error,
+            backend_metadata=metadata,
+            git_head=git_head,
+        )
+        append_result_record(output_dir, record)
+        records.append(record)
+
+    print(summarize_results(records))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ markers = [
 [tool.ruff]
 target-version = "py311"
 force-exclude = true
+extend-exclude = [
+    "examples/demos/*.py",  # marimo notebooks: cell functions reference cross-cell names (F821 by design)
+]
 
 [tool.ruff.lint]
 select = [
@@ -104,6 +107,9 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = [
     "S101",   # assert is expected in tests
+]
+"examples/**" = [
+    "E402",   # deliberate import order: unsloth/unturtle patching must run before model imports
 ]
 
 [tool.ruff.format]

--- a/tests/examples/test_benchmark_a2d_aligned.py
+++ b/tests/examples/test_benchmark_a2d_aligned.py
@@ -1,0 +1,595 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import examples.benchmark_a2d_aligned as benchmark_a2d_aligned
+from examples.benchmark_a2d_aligned import (
+    BACKENDS,
+    BENCHMARK_MODES,
+    CHECKPOINT,
+    DEFAULT_MAX_NEW_TOKENS,
+    DEFAULT_STEPS,
+    DLLM_MODEL_CACHE,
+    ENV_PATHS,
+    PROMPTS,
+    UNTURTLE_MODEL_CACHE,
+    WORKER_MODE,
+    RunSpec,
+    build_aligned_generation_kwargs,
+    build_dllm_sampler_config,
+    describe_backend_path,
+    execute_cold_start_run,
+    expand_runs,
+    normalize_benchmark_record,
+    parse_args,
+    select_runner,
+    summarize_records,
+    write_summary,
+)
+
+
+def test_parse_args_defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["benchmark_a2d_aligned.py"])
+
+    args = parse_args()
+
+    assert args.mode == "aligned-warm"
+    assert args.backend == "all"
+    assert args.prompt == "all"
+    assert args.steps is None
+    assert args.max_new_tokens is None
+    assert args.output_dir == "outputs/a2d_aligned_benchmark"
+    assert args.warmup_iters == 2
+    assert args.measure_iters == 5
+
+
+def test_expand_runs_for_aligned_warm_uses_bd3lm_matrix_only():
+    runs = expand_runs(
+        backends=["unturtle", "dllm"],
+        mode="aligned-warm",
+        prompt_names=["math", "code"],
+        steps_values=[64, 128],
+        max_new_token_values=[64, 128],
+    )
+
+    assert all(isinstance(run, RunSpec) for run in runs)
+    assert {run.backend for run in runs} == {"unturtle", "dllm"}
+    assert {run.prompt_name for run in runs} == {"math", "code"}
+    assert {run.mode for run in runs} == {"aligned-warm"}
+    assert {run.prompt_text for run in runs} == {PROMPTS["math"], PROMPTS["code"]}
+    assert {run.settings["steps"] for run in runs} == {64, 128}
+    assert {run.settings["max_new_tokens"] for run in runs} == {64, 128}
+    assert all(run.settings["block_size"] == 32 for run in runs)
+    assert all(run.settings["temperature"] == 0.0 for run in runs)
+    assert all(run.settings["right_shift_logits"] is False for run in runs)
+
+
+def test_expand_runs_for_cold_start_keeps_same_parameter_matrix():
+    runs = expand_runs(
+        backends=["unturtle", "dllm"],
+        mode="cold-start",
+        prompt_names=["math", "code"],
+        steps_values=[64, 128],
+        max_new_token_values=[64, 128],
+    )
+
+    assert len(runs) == 16
+    assert all(isinstance(run, RunSpec) for run in runs)
+    assert {run.backend for run in runs} == {"unturtle", "dllm"}
+    assert {run.prompt_name for run in runs} == {"math", "code"}
+    assert {run.mode for run in runs} == {"cold-start"}
+    assert {run.prompt_text for run in runs} == {PROMPTS["math"], PROMPTS["code"]}
+    assert {run.settings["steps"] for run in runs} == {64, 128}
+    assert {run.settings["max_new_tokens"] for run in runs} == {64, 128}
+    assert all(run.settings["block_size"] == 32 for run in runs)
+    assert all(run.settings["temperature"] == 0.0 for run in runs)
+    assert all(run.settings["right_shift_logits"] is False for run in runs)
+
+
+def test_summarize_records_groups_by_mode_backend_prompt_and_settings():
+    records = [
+        {
+            "mode": "aligned-warm",
+            "backend": "unturtle",
+            "prompt_name": "math",
+            "benchmark_settings": {
+                "steps": 64,
+                "max_new_tokens": 64,
+                "block_size": 32,
+                "temperature": 0.0,
+                "right_shift_logits": False,
+            },
+            "runtime_seconds": 4.0,
+            "success": True,
+        },
+        {
+            "mode": "aligned-warm",
+            "backend": "unturtle",
+            "prompt_name": "math",
+            "benchmark_settings": {
+                "steps": 64,
+                "max_new_tokens": 64,
+                "block_size": 32,
+                "temperature": 0.0,
+                "right_shift_logits": False,
+            },
+            "runtime_seconds": 6.0,
+            "success": True,
+        },
+        {
+            "mode": "aligned-warm",
+            "backend": "unturtle",
+            "prompt_name": "math",
+            "benchmark_settings": {
+                "steps": 64,
+                "max_new_tokens": 64,
+                "block_size": 32,
+                "temperature": 0.0,
+                "right_shift_logits": False,
+            },
+            "runtime_seconds": 0.0,
+            "success": False,
+        },
+        {
+            "mode": "aligned-warm",
+            "backend": "unturtle",
+            "prompt_name": "math",
+            "benchmark_settings": {
+                "steps": 64,
+                "max_new_tokens": 128,
+                "block_size": 32,
+                "temperature": 0.0,
+                "right_shift_logits": False,
+            },
+            "runtime_seconds": 0.0,
+            "success": False,
+        },
+    ]
+
+    summary = summarize_records(records)
+
+    assert isinstance(summary, str)
+    assert summary == (
+        "# A2D aligned benchmark summary\n"
+        "aligned-warm / unturtle / math / steps=64 / max_new_tokens=64 / block_size=32 / temperature=0.0 / right_shift_logits=False | mean=5.00s | median=5.00s | p95=5.90s | success=2/3\n"
+        "aligned-warm / unturtle / math / steps=64 / max_new_tokens=128 / block_size=32 / temperature=0.0 / right_shift_logits=False | mean=n/a | median=n/a | p95=n/a | success=0/1\n"
+    )
+
+
+def test_write_summary_creates_summary_md(tmp_path: Path):
+    summary = (
+        "# A2D aligned benchmark summary\n"
+        "aligned-warm / unturtle / math / steps=64 / max_new_tokens=64 / block_size=32 / temperature=0.0 / right_shift_logits=False | mean=5.00s | median=5.00s | p95=6.00s | success=2/2\n"
+    )
+
+    path = write_summary(tmp_path, summary)
+
+    assert path == tmp_path / "summary.md"
+    assert path.read_text(encoding="utf-8") == summary
+
+
+def test_append_result_record_and_write_summary_create_output_files(tmp_path: Path):
+    result_path = benchmark_a2d_aligned.append_result_record(
+        tmp_path,
+        {"backend": "unturtle", "success": True},
+    )
+    summary_path = write_summary(
+        tmp_path, "- aligned-warm / unturtle / math: mean=1.00s"
+    )
+
+    assert result_path == tmp_path / "results.jsonl"
+    assert summary_path == tmp_path / "summary.md"
+    assert (
+        result_path.read_text(encoding="utf-8").strip()
+        == '{"backend": "unturtle", "success": true}'
+    )
+    assert "aligned-warm / unturtle / math" in summary_path.read_text(encoding="utf-8")
+
+
+def test_normalize_benchmark_record_keeps_mode_and_settings():
+    settings = {
+        "steps": 64,
+        "max_new_tokens": 64,
+        "block_size": 32,
+        "temperature": 0.0,
+        "right_shift_logits": False,
+    }
+    record = normalize_benchmark_record(
+        mode="aligned-warm",
+        backend="unturtle",
+        env_path=ENV_PATHS["unturtle"],
+        checkpoint=CHECKPOINT,
+        prompt_name="math",
+        prompt_text=PROMPTS["math"],
+        settings=settings,
+        success=True,
+        generated_text="96 km",
+        runtime_seconds=1.5,
+        output_tokens=2,
+        exception=None,
+        backend_metadata={"path": "block_diffusion_generator"},
+        git_head="deadbeef",
+    )
+
+    assert record["git_head"] == "deadbeef"
+    assert record["mode"] == "aligned-warm"
+    assert record["backend"] == "unturtle"
+    assert record["environment_path"] == ENV_PATHS["unturtle"]
+    assert record["checkpoint"] == CHECKPOINT
+    assert record["prompt_name"] == "math"
+    assert record["prompt_text"] == PROMPTS["math"]
+    assert record["benchmark_settings"] == settings
+    assert record["benchmark_settings"]["block_size"] == 32
+    assert record["benchmark_settings"]["right_shift_logits"] is False
+    assert record["success"] is True
+    assert record["generated_text"] == "96 km"
+    assert record["runtime_seconds"] == 1.5
+    assert record["output_tokens"] == 2
+    assert record["backend_metadata"] == {"path": "block_diffusion_generator"}
+    assert record["exception_type"] is None
+    assert record["exception_message"] is None
+
+
+def test_build_aligned_generation_kwargs_returns_only_task3_contract_keys():
+    settings = {
+        "steps": 128,
+        "max_new_tokens": 64,
+        "block_size": 32,
+        "temperature": 0.0,
+        "right_shift_logits": False,
+    }
+
+    kwargs = build_aligned_generation_kwargs(settings)
+
+    assert kwargs == {
+        "max_new_tokens": 64,
+        "steps": 128,
+        "block_size": 32,
+        "temperature": 0.0,
+        "right_shift_logits": False,
+    }
+
+
+def test_build_dllm_sampler_config_matches_task4_bd3lm_contract():
+    settings = {
+        "steps": 128,
+        "max_new_tokens": 64,
+        "block_size": 32,
+        "temperature": 0.0,
+        "right_shift_logits": False,
+    }
+
+    config = build_dllm_sampler_config(settings)
+
+    assert config == {
+        "steps": 128,
+        "max_new_tokens": 64,
+        "temperature": 0.0,
+        "block_size": 32,
+        "remasking": "low_confidence",
+        "right_shift_logits": False,
+    }
+
+
+def test_select_runner_routes_unturtle_cold_start_to_aligned_runner():
+    run = RunSpec(
+        mode="cold-start",
+        backend="unturtle",
+        prompt_name="math",
+        prompt_text=PROMPTS["math"],
+        settings={
+            "steps": 128,
+            "max_new_tokens": 64,
+            "block_size": 32,
+            "temperature": 0.0,
+            "right_shift_logits": False,
+        },
+    )
+
+    assert select_runner(run) is benchmark_a2d_aligned.run_unturtle_aligned_once
+
+
+def test_execute_cold_start_run_records_separate_load_and_first_generation_timings(
+    monkeypatch,
+):
+    run = RunSpec(
+        mode="cold-start",
+        backend="unturtle",
+        prompt_name="math",
+        prompt_text=PROMPTS["math"],
+        settings={
+            "steps": 128,
+            "max_new_tokens": 64,
+            "block_size": 32,
+            "temperature": 0.0,
+            "right_shift_logits": False,
+        },
+    )
+
+    expected = benchmark_a2d_aligned.ExecutionResult(
+        generated_text="generated",
+        backend_metadata={
+            "path": "block_diffusion_generator",
+            "cold_start": True,
+            "load_seconds": 1.5,
+            "first_generation_seconds": 4.25,
+        },
+        output_tokens=7,
+        runtime_seconds=5.75,
+    )
+
+    monkeypatch.setattr(
+        benchmark_a2d_aligned, "_run_in_backend_env", lambda inner_run: expected
+    )
+
+    result = execute_cold_start_run(run)
+
+    assert result == expected
+
+
+def test_execute_cold_start_run_in_process_records_separate_load_and_first_generation_timings(
+    monkeypatch,
+):
+    run = RunSpec(
+        mode="cold-start",
+        backend="unturtle",
+        prompt_name="math",
+        prompt_text=PROMPTS["math"],
+        settings={
+            "steps": 128,
+            "max_new_tokens": 64,
+            "block_size": 32,
+            "temperature": 0.0,
+            "right_shift_logits": False,
+        },
+    )
+    clear_calls: list[str] = []
+    perf_values = iter([10.0, 11.5, 20.0, 24.25])
+
+    def fake_clear_backend_state(backend: str) -> None:
+        clear_calls.append(backend)
+
+    def fake_load_unturtle_model():
+        return object(), object()
+
+    def fake_run_unturtle_aligned_once(inner_run: RunSpec):
+        assert inner_run is run
+        return "generated", {"path": "block_diffusion_generator"}, 7
+
+    monkeypatch.setattr(
+        benchmark_a2d_aligned, "_clear_backend_state", fake_clear_backend_state
+    )
+    monkeypatch.setattr(
+        benchmark_a2d_aligned, "load_unturtle_model", fake_load_unturtle_model
+    )
+    monkeypatch.setattr(
+        benchmark_a2d_aligned,
+        "run_unturtle_aligned_once",
+        fake_run_unturtle_aligned_once,
+    )
+    monkeypatch.setattr(
+        benchmark_a2d_aligned.time, "perf_counter", lambda: next(perf_values)
+    )
+
+    result = benchmark_a2d_aligned._execute_cold_start_run_in_process(run)
+
+    assert clear_calls == ["unturtle"]
+    assert result.generated_text == "generated"
+    assert result.output_tokens == 7
+    assert result.runtime_seconds == 5.75
+    assert result.backend_metadata == {
+        "path": "block_diffusion_generator",
+        "cold_start": True,
+        "load_seconds": 1.5,
+        "first_generation_seconds": 4.25,
+    }
+
+
+def test_main_preserves_successful_warm_measurements_when_later_iteration_fails(
+    monkeypatch, tmp_path: Path
+):
+    run = RunSpec(
+        mode="aligned-warm",
+        backend="unturtle",
+        prompt_name="math",
+        prompt_text=PROMPTS["math"],
+        settings={
+            "steps": 64,
+            "max_new_tokens": 64,
+            "block_size": 32,
+            "temperature": 0.0,
+            "right_shift_logits": False,
+        },
+    )
+    first = benchmark_a2d_aligned.ExecutionResult(
+        generated_text="first",
+        backend_metadata={"path": "block_diffusion_generator"},
+        output_tokens=2,
+        runtime_seconds=1.25,
+    )
+    second_error = RuntimeError("second measurement failed")
+    outcomes = iter([first, second_error])
+    recorded: list[dict[str, object]] = []
+    summaries: list[str] = []
+
+    monkeypatch.setattr(
+        benchmark_a2d_aligned,
+        "parse_args",
+        lambda: type(
+            "Args",
+            (),
+            {
+                "mode": "aligned-warm",
+                "backend": "unturtle",
+                "prompt": "math",
+                "steps": 64,
+                "max_new_tokens": 64,
+                "output_dir": str(tmp_path),
+                "warmup_iters": 0,
+                "measure_iters": 2,
+            },
+        )(),
+    )
+    monkeypatch.setattr(benchmark_a2d_aligned, "expand_runs", lambda **kwargs: [run])
+    monkeypatch.setattr(benchmark_a2d_aligned, "get_git_head", lambda: "deadbeef")
+
+    def fake_run_warm_batch_in_backend_env(
+        inner_run: RunSpec, *, warmup_iters: int, measure_iters: int
+    ):
+        assert inner_run is run
+        assert warmup_iters == 0
+        assert measure_iters == 2
+        return [next(outcomes), next(outcomes)]
+
+    def fake_append_result_record(output_dir: Path, record: dict[str, object]) -> Path:
+        path = output_dir / "results.jsonl"
+        recorded.append(record)
+        return path
+
+    def fake_write_summary(output_dir: Path, summary: str) -> Path:
+        summaries.append(summary)
+        return output_dir / "summary.md"
+
+    monkeypatch.setattr(
+        benchmark_a2d_aligned,
+        "_run_warm_batch_in_backend_env",
+        fake_run_warm_batch_in_backend_env,
+    )
+    monkeypatch.setattr(
+        benchmark_a2d_aligned, "append_result_record", fake_append_result_record
+    )
+    monkeypatch.setattr(benchmark_a2d_aligned, "write_summary", fake_write_summary)
+
+    benchmark_a2d_aligned.main()
+
+    assert len(recorded) == 2
+    assert recorded[0]["success"] is True
+    assert recorded[0]["generated_text"] == "first"
+    assert recorded[0]["runtime_seconds"] == 1.25
+    assert recorded[1]["success"] is False
+    assert recorded[1]["exception_type"] == "RuntimeError"
+    assert recorded[1]["exception_message"] == "second measurement failed"
+    assert "success=1/2" in summaries[0]
+
+
+def test_execute_warm_runs_uses_single_backend_env_batch(monkeypatch):
+    run = RunSpec(
+        mode="aligned-warm",
+        backend="unturtle",
+        prompt_name="math",
+        prompt_text=PROMPTS["math"],
+        settings={
+            "steps": 64,
+            "max_new_tokens": 64,
+            "block_size": 32,
+            "temperature": 0.0,
+            "right_shift_logits": False,
+        },
+    )
+    calls: list[tuple[RunSpec, int, int]] = []
+    outcomes = [
+        benchmark_a2d_aligned.ExecutionResult(
+            generated_text="one",
+            backend_metadata={"path": "block_diffusion_generator"},
+            output_tokens=3,
+            runtime_seconds=1.0,
+        ),
+        benchmark_a2d_aligned.ExecutionResult(
+            generated_text="two",
+            backend_metadata={"path": "block_diffusion_generator"},
+            output_tokens=4,
+            runtime_seconds=1.1,
+        ),
+        RuntimeError("third measurement failed"),
+    ]
+
+    monkeypatch.setattr(
+        benchmark_a2d_aligned,
+        "_run_warm_batch_in_backend_env",
+        lambda inner_run, *, warmup_iters, measure_iters: (
+            calls.append((inner_run, warmup_iters, measure_iters)) or outcomes
+        ),
+    )
+
+    records = benchmark_a2d_aligned.execute_warm_runs(
+        run,
+        warmup_iters=2,
+        measure_iters=3,
+        env_path=ENV_PATHS["unturtle"],
+        checkpoint=CHECKPOINT,
+        git_head="deadbeef",
+    )
+
+    assert calls == [(run, 2, 3)]
+    assert len(records) == 3
+    assert records[0]["success"] is True
+    assert records[1]["success"] is True
+    assert records[2]["success"] is False
+    assert records[2]["exception_message"] == "third measurement failed"
+
+
+def test_describe_backend_path_returns_approved_task3_labels():
+    assert (
+        describe_backend_path("aligned-warm", "unturtle") == "block_diffusion_generator"
+    )
+    assert describe_backend_path("validator-warm", "unturtle") == "diffusion_generate"
+    assert describe_backend_path("aligned-warm", "dllm") == "bd3lm_sampler"
+    assert describe_backend_path("validator-warm", "dllm") == "bd3lm_sampler"
+
+
+def test_run_in_backend_env_uses_configured_worker_python(monkeypatch):
+    run = RunSpec(
+        mode="aligned-warm",
+        backend="dllm",
+        prompt_name="math",
+        prompt_text=PROMPTS["math"],
+        settings={
+            "steps": 64,
+            "max_new_tokens": 64,
+            "block_size": 32,
+            "temperature": 0.0,
+            "right_shift_logits": False,
+        },
+    )
+    captured: dict[str, object] = {}
+
+    class Completed:
+        stdout = '{"generated_text": "ok", "backend_metadata": {"path": "bd3lm_sampler"}, "output_tokens": 2, "runtime_seconds": 1.5}'
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        return Completed()
+
+    monkeypatch.setattr(benchmark_a2d_aligned.subprocess, "run", fake_run)
+
+    result = benchmark_a2d_aligned._run_in_backend_env(run)
+
+    assert captured["command"] == [
+        str(
+            benchmark_a2d_aligned.get_env_root() / ENV_PATHS["dllm"] / "bin" / "python"
+        ),
+        str(Path(benchmark_a2d_aligned.__file__).resolve()),
+    ]
+    assert WORKER_MODE in captured["env"]
+    assert result.generated_text == "ok"
+    assert result.backend_metadata == {"path": "bd3lm_sampler"}
+    assert result.output_tokens == 2
+    assert result.runtime_seconds == 1.5
+
+
+def test_missing_grpo_dependency_placeholder_raises_module_not_found():
+    module_path = (
+        Path(benchmark_a2d_aligned.__file__).resolve().parent.parent
+        / "unturtle"
+        / "diffusion"
+        / "__init__.py"
+    )
+    code = module_path.read_text(encoding="utf-8")
+    assert "from missing_exc" in code
+
+
+def test_model_caches_start_empty():
+    assert UNTURTLE_MODEL_CACHE == {}
+    assert DLLM_MODEL_CACHE == {}

--- a/tests/examples/test_validate_a2d_real_inference.py
+++ b/tests/examples/test_validate_a2d_real_inference.py
@@ -1,0 +1,168 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from examples.validate_a2d_real_inference import (
+    append_result_record,
+    build_dllm_sampler_config,
+    build_unturtle_generation_kwargs,
+    expand_runs,
+    normalize_result_record,
+    parse_args,
+    summarize_results,
+)
+
+
+def test_expand_runs_smoke_for_all_backends_and_models():
+    runs = expand_runs(
+        backends=["unturtle", "dllm"],
+        model_kinds=["mdlm", "bd3lm"],
+        scenario_name="smoke",
+    )
+
+    pairs = {(run.backend, run.model_kind) for run in runs}
+    assert pairs == {
+        ("unturtle", "mdlm"),
+        ("unturtle", "bd3lm"),
+        ("dllm", "mdlm"),
+        ("dllm", "bd3lm"),
+    }
+    assert all(run.prompt_name for run in runs)
+    assert all(run.settings for run in runs)
+
+
+def test_normalize_result_record_keeps_shared_fields():
+    record = normalize_result_record(
+        backend="unturtle",
+        env_path="./.venv",
+        checkpoint="dllm-hub/Qwen3-0.6B-diffusion-mdlm-v0.1",
+        model_kind="mdlm",
+        prompt_name="math",
+        prompt_text="What is 2+2?",
+        settings={"steps": 64, "max_new_tokens": 32},
+        success=True,
+        generated_text="4",
+        runtime_seconds=1.25,
+        output_tokens=1,
+        exception=None,
+        backend_metadata={"mask_token_id": 151643},
+        git_head="deadbeef",
+    )
+
+    assert record["backend"] == "unturtle"
+    assert record["model_kind"] == "mdlm"
+    assert record["success"] is True
+    assert record["generated_text"] == "4"
+    assert record["inference_settings"] == {"steps": 64, "max_new_tokens": 32}
+    assert record["backend_metadata"] == {"mask_token_id": 151643}
+
+
+def test_build_unturtle_generation_kwargs_uses_shared_keys():
+    kwargs = build_unturtle_generation_kwargs(
+        {"steps": 64, "max_new_tokens": 32, "temperature": 0.0}
+    )
+
+    assert kwargs == {
+        "steps": 64,
+        "max_new_tokens": 32,
+        "temperature": 0.0,
+        "use_cache": False,
+    }
+
+
+def test_parse_args_defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["validate_a2d_real_inference.py"])
+
+    args = parse_args()
+
+    assert args.backend == "all"
+    assert args.model == "all"
+    assert args.scenario == "smoke"
+    assert args.prompt == "all"
+    assert args.steps is None
+    assert args.max_new_tokens is None
+    assert args.output_dir == "outputs/real_inference_validation"
+
+
+def test_summarize_results_mentions_failures():
+    text = summarize_results(
+        [
+            {
+                "backend": "unturtle",
+                "model_kind": "mdlm",
+                "success": True,
+                "generated_text": "hello",
+                "exception_type": None,
+                "exception_message": None,
+            },
+            {
+                "backend": "dllm",
+                "model_kind": "mdlm",
+                "success": False,
+                "generated_text": "",
+                "exception_type": "RuntimeError",
+                "exception_message": "decode failed",
+            },
+        ]
+    )
+
+    assert "unturtle / mdlm" in text
+    assert "dllm / mdlm" in text
+    assert "decode failed" in text
+
+
+def test_append_result_record_creates_jsonl(tmp_path: Path):
+    path = append_result_record(tmp_path, {"backend": "unturtle", "success": True})
+
+    assert path == tmp_path / "results.jsonl"
+    assert path.exists()
+    assert (
+        path.read_text(encoding="utf-8").strip()
+        == '{"backend": "unturtle", "success": true}'
+    )
+
+
+def test_build_dllm_sampler_config_selects_bd3lm_and_keeps_block_size(monkeypatch):
+    class _MdlmConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class _Bd3lmConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    fake_dllm = SimpleNamespace(
+        core=SimpleNamespace(
+            samplers=SimpleNamespace(
+                MDLMSamplerConfig=_MdlmConfig,
+                BD3LMSamplerConfig=_Bd3lmConfig,
+            )
+        )
+    )
+    monkeypatch.setitem(sys.modules, "dllm", fake_dllm)
+
+    default_config = build_dllm_sampler_config(
+        "bd3lm",
+        {"steps": 128, "max_new_tokens": 64, "temperature": 0.0},
+    )
+    explicit_config = build_dllm_sampler_config(
+        "bd3lm",
+        {"steps": 128, "max_new_tokens": 64, "temperature": 0.0, "block_size": 16},
+    )
+    mdlm_config = build_dllm_sampler_config(
+        "mdlm",
+        {"steps": 64, "max_new_tokens": 32, "temperature": 0.0},
+    )
+
+    assert isinstance(default_config, _Bd3lmConfig)
+    assert default_config.kwargs["block_size"] == 32
+    assert default_config.kwargs["remasking"] == "low_confidence"
+    assert default_config.kwargs["right_shift_logits"] is False
+    assert isinstance(explicit_config, _Bd3lmConfig)
+    assert explicit_config.kwargs["block_size"] == 16
+    assert explicit_config.kwargs["remasking"] == "low_confidence"
+    assert explicit_config.kwargs["right_shift_logits"] is False
+    assert isinstance(mdlm_config, _MdlmConfig)
+    assert "block_size" not in mdlm_config.kwargs
+    assert mdlm_config.kwargs["remasking"] == "low_confidence"
+    assert mdlm_config.kwargs["right_shift_logits"] is False

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,217 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from datasets import Dataset
+from transformers import BertTokenizerFast
+from typer import Exit
+
+from unturtle.cli.commands.eval import _prepare_eval_dataset
+from unturtle.cli.commands.export import list_checkpoints
+from unturtle.cli.commands.train import _resolve_model_class, train
+from unturtle.cli.config import load_config
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "examples" / "configs"
+EXAMPLE_CONFIGS = [
+    "llada_sft.yaml",
+    "a2d_llama_sft.yaml",
+    "dream_sft.yaml",
+    "llada_grpo.yaml",
+]
+
+
+@pytest.fixture
+def tokenizer(tmp_path):
+    vocab_path = tmp_path / "vocab.txt"
+    vocab_path.write_text(
+        "\n".join(
+            [
+                "[PAD]",
+                "[UNK]",
+                "[CLS]",
+                "[SEP]",
+                "[MASK]",
+                "hello",
+                "world",
+                "Question",
+                ":",
+                "Answer",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return BertTokenizerFast(vocab_file=str(vocab_path))
+
+
+def test_prepare_eval_dataset_tokenizes_raw_text_for_diffusion(tokenizer):
+    dataset = Dataset.from_list([{"text": "hello world"}])
+
+    prepared = _prepare_eval_dataset(
+        dataset,
+        tokenizer=tokenizer,
+        dataset_text_field="text",
+        eval_type="diffusion",
+    )
+
+    row = prepared[0]
+    assert set(prepared.column_names) == {"input_ids", "attention_mask", "labels"}
+    assert row["input_ids"] == row["labels"]
+    assert len(row["attention_mask"]) == len(row["input_ids"])
+
+
+def test_prepare_eval_dataset_builds_generation_labels_from_prompt_and_completion(
+    tokenizer,
+):
+    dataset = Dataset.from_list(
+        [
+            {"prompt": "Question:", "completion": " Answer"},
+        ]
+    )
+
+    prepared = _prepare_eval_dataset(
+        dataset,
+        tokenizer=tokenizer,
+        dataset_text_field="text",
+        eval_type="generation",
+    )
+
+    row = prepared[0]
+    prompt_ids = tokenizer("Question:", add_special_tokens=False)["input_ids"]
+    completion_ids = tokenizer(" Answer", add_special_tokens=False)["input_ids"]
+
+    assert row["input_ids"] == prompt_ids + completion_ids
+    assert row["labels"] == ([-100] * len(prompt_ids)) + completion_ids
+    assert row["attention_mask"] == [1] * len(row["input_ids"])
+
+
+def test_prepare_eval_dataset_preserves_generation_labels_for_both_mode(tokenizer):
+    dataset = Dataset.from_list(
+        [
+            {"prompt": "Question:", "completion": " Answer"},
+        ]
+    )
+
+    prepared = _prepare_eval_dataset(
+        dataset,
+        tokenizer=tokenizer,
+        dataset_text_field="text",
+        eval_type="both",
+    )
+
+    row = prepared[0]
+    prompt_ids = tokenizer("Question:", add_special_tokens=False)["input_ids"]
+    completion_ids = tokenizer(" Answer", add_special_tokens=False)["input_ids"]
+
+    assert row["input_ids"] == prompt_ids + completion_ids
+    assert row["labels"] == ([-100] * len(prompt_ids)) + completion_ids
+
+
+def test_resolve_model_class_returns_none_for_auto():
+    assert _resolve_model_class("auto") is None
+
+
+@pytest.mark.parametrize(
+    "model_type,expected_name",
+    [
+        ("a2d", "TinyA2DLlamaLMHeadModel"),
+        ("llada", "LLaDAModelLM"),
+        ("dream", "DreamModel"),
+    ],
+)
+def test_resolve_model_class_returns_correct_class(model_type, expected_name):
+    from unittest.mock import MagicMock, patch
+
+    fake_a2d = MagicMock(__name__="TinyA2DLlamaLMHeadModel")
+    fake_llada = MagicMock(__name__="LLaDAModelLM")
+    fake_dream = MagicMock(__name__="DreamModel")
+    fake_module = MagicMock(
+        TinyA2DLlamaLMHeadModel=fake_a2d,
+        LLaDAModelLM=fake_llada,
+        DreamModel=fake_dream,
+    )
+    with patch.dict("sys.modules", {"unturtle": fake_module}):
+        cls = _resolve_model_class(model_type)
+    assert cls.__name__ == expected_name
+
+
+def test_resolve_model_class_raises_on_unknown_type():
+    from unittest.mock import MagicMock, patch
+
+    fake_module = MagicMock(
+        TinyA2DLlamaLMHeadModel=MagicMock(),
+        LLaDAModelLM=MagicMock(),
+        DreamModel=MagicMock(),
+    )
+    with patch.dict("sys.modules", {"unturtle": fake_module}), pytest.raises(KeyError):
+        _resolve_model_class("unknown")
+
+
+@pytest.mark.parametrize("config_name", EXAMPLE_CONFIGS)
+def test_example_yaml_configs_load_with_current_schema(config_name):
+    cfg = load_config(CONFIG_DIR / config_name)
+    assert cfg.model.model is not None
+    assert cfg.data.dataset is not None
+    assert cfg.training.output_dir
+
+
+def test_llada_grpo_yaml_sets_task_and_builds_diffu_config():
+    cfg = load_config(CONFIG_DIR / "llada_grpo.yaml")
+    assert cfg.training.task == "grpo"
+    args = cfg.build_diffu_grpo_config(mask_token_id=126336, report_to="none")
+    assert args.num_generations == 8
+    assert args.diffu_policy_objective == "grpo"
+    assert args.mask_id == 126336
+    assert args.generation_batch_size == 8
+
+
+def test_build_diffu_grpo_config_scales_generation_batch_with_world_size(monkeypatch):
+    # Do not set WORLD_SIZE: DiffuGRPOConfig.__post_init__ loads Accelerate and
+    # would require a full distributed env.  Scale is computed in config only.
+    monkeypatch.setattr(
+        "unturtle.cli.config._grpo_effective_world_size",
+        lambda: 2,
+    )
+    cfg = load_config(CONFIG_DIR / "llada_grpo.yaml")
+    args = cfg.build_diffu_grpo_config(mask_token_id=126336, report_to="none")
+    assert args.generation_batch_size == 16
+
+
+@pytest.mark.parametrize("config_name", EXAMPLE_CONFIGS)
+def test_example_yaml_configs_work_with_train_dry_run(config_name, capsys):
+    config_path = CONFIG_DIR / config_name
+
+    with pytest.raises(Exit) as exc_info:
+        train(config=config_path, dry_run=True, config_overrides={})
+
+    assert exc_info.value.exit_code == 0
+    captured = capsys.readouterr()
+    assert "model:" in captured.out
+    assert "training:" in captured.out
+
+
+def test_list_checkpoints_reports_unreadable_trainer_state(tmp_path, capsys):
+    ckpt_dir = tmp_path / "run-1" / "checkpoint-10"
+    ckpt_dir.mkdir(parents=True)
+    (ckpt_dir / "trainer_state.json").write_text("{not-json", encoding="utf-8")
+
+    list_checkpoints(outputs_dir=tmp_path)
+
+    captured = capsys.readouterr()
+    assert "unreadable trainer_state.json" in captured.out
+    assert "Warning: failed to read loss" in captured.err

--- a/unturtle/cli/__init__.py
+++ b/unturtle/cli/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typer
+
+from unturtle.cli.commands.eval import eval_cmd
+from unturtle.cli.commands.export import export, list_checkpoints
+from unturtle.cli.commands.generate import generate
+from unturtle.cli.commands.train import train
+
+app = typer.Typer(
+    help="Unturtle CLI — dLLM training, generation, and evaluation.",
+    context_settings={"help_option_names": ["-h", "--help"]},
+    no_args_is_help=True,
+)
+
+app.command()(train)
+app.command()(generate)
+app.command()(export)
+app.command("list-checkpoints")(list_checkpoints)
+app.command("eval")(eval_cmd)

--- a/unturtle/cli/commands/eval.py
+++ b/unturtle/cli/commands/eval.py
@@ -1,0 +1,322 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle eval — evaluate a dLLM on masked diffusion loss or generation metrics."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from unturtle.cli.config import DataConfig
+
+EVAL_TYPES = ["diffusion", "generation", "both"]
+ALG_CHOICES = ["origin", "maskgit_plus", "topk_margin", "entropy"]
+
+
+def _tokenize_for_diffusion(tokenizer, dataset, dataset_text_field: str):
+    def _map(example):
+        text = example.get(dataset_text_field)
+        if text is None:
+            raise ValueError(
+                f"Dataset example is missing text field '{dataset_text_field}' required for diffusion eval."
+            )
+        encoded = tokenizer(str(text), add_special_tokens=True, truncation=True)
+        input_ids = encoded["input_ids"]
+        attention_mask = encoded.get("attention_mask", [1] * len(input_ids))
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "labels": input_ids.copy(),
+        }
+
+    return dataset.map(
+        _map,
+        remove_columns=getattr(dataset, "column_names", None),
+    )
+
+
+def _tokenize_for_generation(tokenizer, dataset, dataset_text_field: str):
+    def _map(example):
+        prompt_text = example.get("prompt")
+        completion_text = example.get("completion")
+        if prompt_text is not None and completion_text is not None:
+            prompt_ids = tokenizer(
+                str(prompt_text), add_special_tokens=False, truncation=True
+            )["input_ids"]
+            completion_ids = tokenizer(
+                str(completion_text), add_special_tokens=False, truncation=True
+            )["input_ids"]
+            input_ids = prompt_ids + completion_ids
+            attention_mask = [1] * len(input_ids)
+            labels = ([-100] * len(prompt_ids)) + completion_ids
+            return {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "labels": labels,
+            }
+
+        text = example.get(dataset_text_field)
+        if text is None:
+            raise ValueError(
+                "Generation eval requires either prompt/completion columns or "
+                f"a text field '{dataset_text_field}'."
+            )
+        encoded = tokenizer(str(text), add_special_tokens=True, truncation=True)
+        input_ids = encoded["input_ids"]
+        attention_mask = encoded.get("attention_mask", [1] * len(input_ids))
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "labels": input_ids.copy(),
+        }
+
+    return dataset.map(
+        _map,
+        remove_columns=getattr(dataset, "column_names", None),
+    )
+
+
+def _prepare_eval_dataset(dataset, tokenizer, dataset_text_field: str, eval_type: str):
+    column_names = set(getattr(dataset, "column_names", []))
+    has_diffusion_schema = {"input_ids", "labels"}.issubset(column_names)
+    has_generation_schema = "input_ids" in column_names and (
+        "references" in column_names or "labels" in column_names
+    )
+
+    if eval_type == "both":
+        if not has_generation_schema:
+            dataset = _tokenize_for_generation(tokenizer, dataset, dataset_text_field)
+            column_names = set(getattr(dataset, "column_names", []))
+        has_diffusion_schema = {"input_ids", "labels"}.issubset(column_names)
+        if not has_diffusion_schema:
+            dataset = _tokenize_for_diffusion(tokenizer, dataset, dataset_text_field)
+        return dataset
+
+    if eval_type == "diffusion" and not has_diffusion_schema:
+        return _tokenize_for_diffusion(tokenizer, dataset, dataset_text_field)
+
+    if eval_type == "generation" and not has_generation_schema:
+        return _tokenize_for_generation(tokenizer, dataset, dataset_text_field)
+
+    return dataset
+
+
+def eval_cmd(
+    model: str = typer.Argument(..., help="HuggingFace model ID or local path."),
+    dataset: str = typer.Option(..., "--dataset", help="HuggingFace dataset ID."),
+    dataset_text_field: str = typer.Option(
+        DataConfig.model_fields["dataset_text_field"].default,
+        "--dataset-text-field",
+        help=DataConfig.model_fields["dataset_text_field"].description,
+    ),
+    eval_type: str = typer.Option(
+        "diffusion",
+        "--eval-type",
+        help=f"Evaluation type: {', '.join(EVAL_TYPES)}.",
+    ),
+    hf_token: Optional[str] = typer.Option(
+        None, "--hf-token", envvar="HF_TOKEN", help="HuggingFace token."
+    ),
+    max_seq_length: int = typer.Option(2048, "--max-seq-length"),
+    load_in_4bit: bool = typer.Option(True, "--load-in-4bit/--no-load-in-4bit"),
+    batch_size: int = typer.Option(1, "--batch-size", help="Eval batch size."),
+    max_batches: Optional[int] = typer.Option(
+        None,
+        "--max-batches",
+        help="Limit number of batches for diffusion eval (default: all).",
+    ),
+    max_examples: Optional[int] = typer.Option(
+        None,
+        "--max-examples",
+        help="Limit number of examples for generation eval (default: all).",
+    ),
+    num_steps: int = typer.Option(
+        128, "--num-steps", help="Denoising steps for generation eval."
+    ),
+    mask_token_id: Optional[int] = typer.Option(
+        None, "--mask-token-id", help="Mask token ID override."
+    ),
+    alg: str = typer.Option(
+        "origin",
+        "--alg",
+        help=f"Sampling algorithm for generation eval: {', '.join(ALG_CHOICES)}.",
+    ),
+    temperature: float = typer.Option(
+        0.0, "--temperature", help="Sampling temperature for generation eval."
+    ),
+    alpha_scheduler: str = typer.Option(
+        "linear",
+        "--alpha-scheduler",
+        help="Alpha scheduler for diffusion eval: 'linear' or 'cosine'.",
+    ),
+    loss_weight_type: str = typer.Option(
+        "uniform",
+        "--loss-weight-type",
+        help="Loss weighting for diffusion eval: uniform|timestep|scheduler.",
+    ),
+    completion_only: bool = typer.Option(
+        True,
+        "--completion-only/--no-completion-only",
+        help="For diffusion eval, only mask completion tokens (not the prompt).",
+    ),
+    output_file: Optional[Path] = typer.Option(
+        None, "--output-file", help="Write metrics to this JSON file."
+    ),
+):
+    """Evaluate a dLLM using masked diffusion loss or generation metrics."""
+    if eval_type not in EVAL_TYPES:
+        typer.echo(
+            f"Error: --eval-type must be one of {EVAL_TYPES}, got '{eval_type}'",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    try:
+        from unturtle import FastDiffusionModel
+        from unturtle.diffusion import MaskedDiffusionDataCollator
+        from unturtle.eval import GenerationEvaluator, MaskedDiffusionEvaluator
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+    except ImportError as e:
+        typer.echo(f"Error: failed to import unturtle — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    # --- Load model ---
+    typer.echo(f"Loading model: {model}", err=True)
+    try:
+        loaded_model, tokenizer = FastDiffusionModel.from_pretrained(
+            model_name=model,
+            max_seq_length=max_seq_length,
+            load_in_4bit=load_in_4bit,
+            token=hf_token,
+        )
+    except Exception as e:
+        typer.echo(f"Error: model load failed — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    FastDiffusionModel.for_inference(loaded_model)
+
+    # --- Load dataset ---
+    typer.echo(f"Loading dataset: {dataset}", err=True)
+    try:
+        from datasets import load_dataset as hf_load_dataset
+
+        ds = hf_load_dataset(dataset, token=hf_token)
+        if hasattr(ds, "keys"):
+            split_name = next(
+                (name for name in ("validation", "test", "train") if name in ds),
+                None,
+            )
+            if split_name is None:
+                raise ValueError("Dataset has no validation, test, or train split.")
+            eval_ds = ds[split_name]
+        else:
+            eval_ds = ds
+        eval_ds = _prepare_eval_dataset(
+            eval_ds,
+            tokenizer=tokenizer,
+            dataset_text_field=dataset_text_field,
+            eval_type=eval_type,
+        )
+    except Exception as e:
+        typer.echo(f"Error: dataset load failed — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    all_metrics: dict = {}
+    failures: list[str] = []
+
+    # --- Diffusion eval ---
+    if eval_type in ("diffusion", "both"):
+        typer.echo("Running diffusion eval...", err=True)
+        try:
+            collator = MaskedDiffusionDataCollator(
+                tokenizer=tokenizer,
+                completion_only=completion_only,
+            )
+            evaluator = MaskedDiffusionEvaluator(
+                model=loaded_model,
+                tokenizer=tokenizer,
+                data_collator=collator,
+                loss_weight_type=loss_weight_type,
+                alpha_scheduler=alpha_scheduler,
+                completion_only=completion_only,
+            )
+            diff_metrics = evaluator.evaluate(
+                eval_ds,
+                batch_size=batch_size,
+                max_batches=max_batches,
+            )
+            all_metrics.update(diff_metrics)
+        except Exception as e:
+            typer.echo(f"Error: diffusion eval failed — {e}", err=True)
+            failures.append("diffusion")
+
+    # --- Generation eval ---
+    if eval_type in ("generation", "both"):
+        typer.echo("Running generation eval...", err=True)
+
+        # Resolve mask token ID
+        resolved_mask_id = mask_token_id
+        if resolved_mask_id is None:
+            resolved_mask_id = getattr(tokenizer, "mask_token_id", None)
+        if resolved_mask_id is None:
+            resolved_mask_id = getattr(loaded_model.config, "mask_token_id", None)
+        if resolved_mask_id is None:
+            typer.echo(
+                "Error: cannot resolve mask_token_id for generation eval.",
+                err=True,
+            )
+            failures.append("generation")
+        else:
+            try:
+                gen_config = MaskedDiffusionGenerationConfig(
+                    steps=num_steps,
+                    mask_token_id=resolved_mask_id,
+                    temperature=temperature,
+                    alg=alg,
+                )
+                gen_evaluator = GenerationEvaluator(
+                    model=loaded_model,
+                    tokenizer=tokenizer,
+                )
+                gen_metrics = gen_evaluator.evaluate(
+                    eval_ds,
+                    generation_config=gen_config,
+                    max_examples=max_examples,
+                )
+                all_metrics.update(gen_metrics)
+            except Exception as e:
+                typer.echo(f"Error: generation eval failed — {e}", err=True)
+                failures.append("generation")
+
+    if failures:
+        raise typer.Exit(code=1)
+
+    if not all_metrics:
+        typer.echo("No metrics collected.", err=True)
+        raise typer.Exit(code=1)
+
+    # --- Print metrics ---
+    import yaml
+
+    typer.echo("\n" + yaml.dump(all_metrics, default_flow_style=False, sort_keys=True))
+
+    # --- Write output file ---
+    if output_file:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(json.dumps(all_metrics, indent=2), encoding="utf-8")
+        typer.echo(f"Metrics written to {output_file}", err=True)

--- a/unturtle/cli/commands/export.py
+++ b/unturtle/cli/commands/export.py
@@ -1,0 +1,218 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle export / list-checkpoints — checkpoint management commands."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+EXPORT_FORMATS = ["merged-16bit", "lora", "gguf"]
+GGUF_QUANTS = ["q4_k_m", "q5_k_m", "q8_0", "f16"]
+
+
+def list_checkpoints(
+    outputs_dir: Path = typer.Option(
+        Path("./outputs"),
+        "--outputs-dir",
+        help="Directory that holds training runs.",
+    ),
+):
+    """List checkpoints detected in the outputs directory."""
+    outputs_path = Path(outputs_dir)
+    if not outputs_path.exists():
+        typer.echo("No checkpoints found.")
+        raise typer.Exit()
+
+    # Group checkpoint dirs by their parent
+    checkpoints: dict[Path, list[tuple[str, Path, Optional[float], str | None]]] = {}
+    for ckpt_dir in sorted(outputs_path.rglob("checkpoint-*")):
+        if not ckpt_dir.is_dir():
+            continue
+        parent = ckpt_dir.parent
+
+        loss: Optional[float] = None
+        status: str | None = "no trainer_state.json"
+        state_file = ckpt_dir / "trainer_state.json"
+        if state_file.exists():
+            status = None
+            try:
+                state = json.loads(state_file.read_text(encoding="utf-8"))
+                log_history = state.get("log_history", [])
+                # Find the last entry that has a loss or eval_loss value
+                for entry in reversed(log_history):
+                    if "loss" in entry:
+                        loss = float(entry["loss"])
+                        break
+                    if "eval_loss" in entry:
+                        loss = float(entry["eval_loss"])
+                        break
+                if loss is None:
+                    status = "trainer_state.json has no loss"
+            except (OSError, json.JSONDecodeError, TypeError, ValueError) as exc:
+                status = "unreadable trainer_state.json"
+                typer.echo(
+                    f"Warning: failed to read loss from {state_file}: {exc}",
+                    err=True,
+                )
+
+        checkpoints.setdefault(parent, []).append(
+            (ckpt_dir.name, ckpt_dir, loss, status)
+        )
+
+    if not checkpoints:
+        typer.echo("No checkpoints found.")
+        raise typer.Exit()
+
+    for parent, ckpt_list in sorted(checkpoints.items()):
+        typer.echo(f"\n{parent}:")
+        for name, path, loss, status in ckpt_list:
+            if loss is not None:
+                typer.echo(f"  {name:<30} loss={loss:.4f}  {path}")
+            else:
+                typer.echo(f"  {name:<30} ({status})  {path}")
+
+
+def export(
+    checkpoint: Path = typer.Argument(..., help="Path to checkpoint directory."),
+    output_dir: Path = typer.Argument(..., help="Directory to save exported model."),
+    format: str = typer.Option(
+        "merged-16bit",
+        "--format",
+        "-f",
+        help=f"Export format: {', '.join(EXPORT_FORMATS)}.",
+    ),
+    quantization: str = typer.Option(
+        "q4_k_m",
+        "--quantization",
+        "-q",
+        help=f"GGUF quantization method (gguf format only): {', '.join(GGUF_QUANTS)}.",
+    ),
+    push_to_hub: bool = typer.Option(
+        False, "--push-to-hub", help="Push exported model to HuggingFace Hub."
+    ),
+    repo_id: Optional[str] = typer.Option(
+        None, "--repo-id", help="HuggingFace repo ID (username/model-name)."
+    ),
+    hf_token: Optional[str] = typer.Option(
+        None, "--hf-token", envvar="HF_TOKEN", help="HuggingFace token."
+    ),
+    private: bool = typer.Option(
+        False, "--private", help="Make the HuggingFace repo private."
+    ),
+    max_seq_length: int = typer.Option(2048, "--max-seq-length"),
+    load_in_4bit: bool = typer.Option(True, "--load-in-4bit/--no-load-in-4bit"),
+):
+    """Export a checkpoint to various formats (merged-16bit, lora, gguf)."""
+    if format not in EXPORT_FORMATS:
+        typer.echo(
+            f"Error: Invalid format '{format}'. "
+            f"Choose from: {', '.join(EXPORT_FORMATS)}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    if format == "gguf" and quantization not in GGUF_QUANTS:
+        typer.echo(
+            f"Error: Invalid quantization '{quantization}'. "
+            f"Choose from: {', '.join(GGUF_QUANTS)}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    if push_to_hub and not repo_id:
+        typer.echo("Error: --repo-id is required when using --push-to-hub", err=True)
+        raise typer.Exit(code=2)
+
+    try:
+        from unturtle import FastDiffusionModel
+    except ImportError as e:
+        typer.echo(f"Error: failed to import unturtle — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    # --- Load checkpoint ---
+    typer.echo(f"Loading checkpoint: {checkpoint}")
+    try:
+        model, tokenizer = FastDiffusionModel.from_pretrained(
+            model_name=str(checkpoint),
+            max_seq_length=max_seq_length,
+            load_in_4bit=load_in_4bit,
+            token=hf_token,
+        )
+    except Exception as e:
+        typer.echo(f"Error: checkpoint load failed — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Export ---
+    typer.echo(f"Exporting as {format} to {output_dir} ...")
+    try:
+        if format == "merged-16bit":
+            if push_to_hub:
+                if repo_id is None:
+                    raise typer.Exit(code=2)
+                FastDiffusionModel.push_to_hub_merged(
+                    model,
+                    repo_id,
+                    tokenizer,
+                    token=hf_token,
+                    private=private,
+                )
+                typer.echo(f"Pushed merged model to Hub: {repo_id}")
+            else:
+                FastDiffusionModel.save_pretrained_merged(
+                    model, str(output_dir), tokenizer
+                )
+                typer.echo(f"Saved merged model to {output_dir}")
+
+        elif format == "lora":
+            FastDiffusionModel.save_lora_adapter(model, str(output_dir), tokenizer)
+            if push_to_hub and repo_id:
+                model.push_to_hub(repo_id, token=hf_token, private=private)
+                tokenizer.push_to_hub(repo_id, token=hf_token, private=private)
+                typer.echo(f"Pushed LoRA adapter to Hub: {repo_id}")
+            else:
+                typer.echo(f"Saved LoRA adapter to {output_dir}")
+
+        elif format == "gguf":
+            FastDiffusionModel.save_pretrained_gguf(
+                model,
+                str(output_dir),
+                tokenizer,
+                quantization_method=quantization,
+            )
+            if push_to_hub and repo_id:
+                from huggingface_hub import HfApi
+
+                api = HfApi(token=hf_token)
+                api.create_repo(
+                    repo_id=repo_id,
+                    private=private,
+                    exist_ok=True,
+                )
+                api.upload_folder(
+                    folder_path=str(output_dir),
+                    repo_id=repo_id,
+                    token=hf_token,
+                )
+                typer.echo(f"Pushed GGUF to Hub: {repo_id}")
+            else:
+                typer.echo(f"Saved GGUF to {output_dir}")
+
+    except Exception as e:
+        typer.echo(f"Error: export failed — {e}", err=True)
+        raise typer.Exit(code=1)

--- a/unturtle/cli/commands/generate.py
+++ b/unturtle/cli/commands/generate.py
@@ -1,0 +1,194 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle generate — iterative denoising inference for dLLMs.
+
+Unlike autoregressive LMs, dLLMs denoise a fully-masked sequence over
+multiple steps.  There is no token-by-token streaming; the output is the
+full decoded sequence after all denoising steps complete.
+"""
+
+from typing import Optional
+
+import typer
+
+ALG_CHOICES = ["origin", "maskgit_plus", "topk_margin", "entropy"]
+
+
+def generate(
+    model: str = typer.Argument(..., help="HuggingFace model ID or local path."),
+    prompt: str = typer.Argument(..., help="Text prompt to condition generation on."),
+    hf_token: Optional[str] = typer.Option(
+        None, "--hf-token", envvar="HF_TOKEN", help="HuggingFace token."
+    ),
+    max_seq_length: int = typer.Option(2048, "--max-seq-length"),
+    load_in_4bit: bool = typer.Option(
+        True, "--load-in-4bit/--no-load-in-4bit", help="Load model in 4-bit."
+    ),
+    num_steps: int = typer.Option(
+        128, "--num-steps", help="Number of denoising steps."
+    ),
+    mask_token_id: Optional[int] = typer.Option(
+        None,
+        "--mask-token-id",
+        help="Mask token ID override. Resolved from tokenizer if not set.",
+    ),
+    temperature: float = typer.Option(
+        0.0, "--temperature", help="Sampling temperature (0 = greedy)."
+    ),
+    top_p: Optional[float] = typer.Option(
+        None, "--top-p", help="Top-p (nucleus) sampling probability."
+    ),
+    top_k: Optional[int] = typer.Option(None, "--top-k", help="Top-k sampling cutoff."),
+    alg: str = typer.Option(
+        "origin",
+        "--alg",
+        help=f"Denoising sampling algorithm: {', '.join(ALG_CHOICES)}.",
+    ),
+    alg_temp: Optional[float] = typer.Option(
+        None, "--alg-temp", help="Temperature for the sampling algorithm."
+    ),
+    max_new_tokens: int = typer.Option(
+        256, "--max-new-tokens", help="Maximum number of new tokens to generate."
+    ),
+    use_cache: bool = typer.Option(
+        False,
+        "--use-cache/--no-use-cache",
+        help="Enable KV-cache (block-decode fast path).",
+    ),
+    block_length: Optional[int] = typer.Option(
+        None, "--block-length", help="Block length for block-decode cache mode."
+    ),
+    output_history: bool = typer.Option(
+        False,
+        "--output-history/--no-output-history",
+        help="Return per-step denoising history.",
+    ),
+    show_steps: bool = typer.Option(
+        False,
+        "--show-steps/--no-show-steps",
+        help="Print each denoising step (requires --output-history).",
+    ),
+):
+    """Run dLLM iterative denoising generation on a prompt."""
+    if alg not in ALG_CHOICES:
+        typer.echo(f"Error: --alg must be one of {ALG_CHOICES}, got '{alg}'", err=True)
+        raise typer.Exit(code=2)
+
+    try:
+        from unturtle import FastDiffusionModel
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+    except ImportError as e:
+        typer.echo(f"Error: failed to import unturtle — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    # --- Load model ---
+    typer.echo(f"Loading model: {model}", err=True)
+    try:
+        loaded_model, tokenizer = FastDiffusionModel.from_pretrained(
+            model_name=model,
+            max_seq_length=max_seq_length,
+            load_in_4bit=load_in_4bit,
+            token=hf_token,
+        )
+    except Exception as e:
+        typer.echo(f"Error: model load failed — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    FastDiffusionModel.for_inference(loaded_model)
+
+    # --- Resolve mask token ID ---
+    resolved_mask_id = mask_token_id
+    if resolved_mask_id is None:
+        resolved_mask_id = getattr(tokenizer, "mask_token_id", None)
+    if resolved_mask_id is None:
+        resolved_mask_id = getattr(loaded_model.config, "mask_token_id", None)
+    if resolved_mask_id is None:
+        typer.echo(
+            "Error: could not resolve mask_token_id. "
+            "Provide --mask-token-id or use a tokenizer/model with mask_token_id set.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    # --- Tokenize ---
+    import torch
+
+    inputs = tokenizer(prompt, return_tensors="pt")
+    input_ids = inputs["input_ids"]
+    model_device = next(loaded_model.parameters()).device
+    input_ids = input_ids.to(model_device)
+
+    # --- Build generation config ---
+    gen_config_kwargs = dict(
+        steps=num_steps,
+        mask_token_id=resolved_mask_id,
+        temperature=temperature,
+        alg=alg,
+        use_cache=use_cache,
+        output_history=output_history,
+        max_new_tokens=max_new_tokens,
+    )
+    if top_p is not None:
+        gen_config_kwargs["top_p"] = top_p
+    if top_k is not None:
+        gen_config_kwargs["top_k"] = top_k
+    if alg_temp is not None:
+        gen_config_kwargs["alg_temp"] = alg_temp
+    if block_length is not None:
+        gen_config_kwargs["block_length"] = block_length
+
+    try:
+        gen_config = MaskedDiffusionGenerationConfig(**gen_config_kwargs)
+    except Exception as e:
+        typer.echo(f"Error: invalid generation config — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    # --- Generate ---
+    typer.echo("Generating...", err=True)
+    try:
+        output = loaded_model.diffusion_generate(
+            input_ids, generation_config=gen_config
+        )
+    except Exception as e:
+        typer.echo(f"Error: generation failed — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    # Extract token IDs: output may be a tensor or a model output object
+    out_ids = output.sequences if hasattr(output, "sequences") else output
+
+    # Decode only the generated portion (beyond the prompt)
+    prompt_len = input_ids.shape[-1]
+    gen_ids = out_ids[0, prompt_len:]
+    result_text = tokenizer.decode(gen_ids, skip_special_tokens=True)
+
+    # --- Show per-step trace if requested ---
+    if show_steps and output_history and hasattr(output, "history"):
+        typer.echo("\n--- Denoising trace ---", err=True)
+        for step_idx, step_ids in enumerate(output.history):
+            step_tokens = step_ids[0] if step_ids.dim() > 1 else step_ids
+            decoded_tokens = []
+            for tok_id in step_tokens[prompt_len:].tolist():
+                if tok_id == resolved_mask_id:
+                    decoded_tokens.append("_")
+                else:
+                    decoded_tokens.append(
+                        tokenizer.decode([tok_id], skip_special_tokens=True)
+                    )
+            typer.echo(f"Step {step_idx + 1:3d}: {''.join(decoded_tokens)}", err=True)
+        typer.echo("--- End trace ---", err=True)
+
+    typer.echo(result_text)

--- a/unturtle/cli/commands/train.py
+++ b/unturtle/cli/commands/train.py
@@ -1,0 +1,308 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""unturtle train — masked diffusion language model training."""
+
+from pathlib import Path
+from typing import Callable, List, Optional
+
+import typer
+
+from unturtle.cli.config import Config, load_config
+from unturtle.cli.options import add_options_from_config
+
+
+def _builtin_grpo_reward(name: str) -> Callable[..., List[float]]:
+    if name == "length":
+
+        def _fn(prompts, completions, **kw):  # noqa: ANN001
+            return [float(len(str(c))) for c in completions]
+
+        return _fn
+    if name == "constant_one":
+
+        def _fn(prompts, completions, **kw):  # noqa: ANN001
+            return [1.0] * len(completions)
+
+        return _fn
+    raise ValueError(f"Unknown grpo.builtin_reward: {name!r}")
+
+
+def _dataset_for_grpo(train_dataset, dataset_text_field: str):
+    """Each row must expose a ``prompt`` string for TRL GRPO (or map from *dataset_text_field*)."""
+    cols = train_dataset.column_names
+    if "prompt" in cols:
+        to_drop = [c for c in cols if c != "prompt"]
+        return train_dataset.remove_columns(to_drop) if to_drop else train_dataset
+    if dataset_text_field not in cols:
+        typer.echo(
+            f"Error: dataset has no 'prompt' column and no {dataset_text_field!r} "
+            f"(columns: {cols})",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    def _row(ex):
+        return {"prompt": ex[dataset_text_field]}
+
+    return train_dataset.map(_row, remove_columns=cols)
+
+
+def _resolve_model_class(model_type: str):
+    if model_type == "auto":
+        return None
+
+    from unturtle import DreamModel, LLaDAModelLM, TinyA2DLlamaLMHeadModel
+
+    model_classes = {
+        "a2d": TinyA2DLlamaLMHeadModel,
+        "dream": DreamModel,
+        "llada": LLaDAModelLM,
+    }
+    return model_classes[model_type]
+
+
+@add_options_from_config(Config)
+def train(
+    config: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to YAML/JSON config file. CLI flags override config values.",
+    ),
+    hf_token: Optional[str] = typer.Option(
+        None,
+        "--hf-token",
+        envvar="HF_TOKEN",
+        help="HuggingFace token.",
+    ),
+    wandb_token: Optional[str] = typer.Option(
+        None,
+        "--wandb-token",
+        envvar="WANDB_API_KEY",
+        help="Weights & Biases API key.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print resolved config as YAML and exit without training.",
+    ),
+    config_overrides: dict = None,
+):
+    """Launch dLLM training (SFT via DiffusionTrainer or RL via DiffuGRPOTrainer)."""
+    try:
+        cfg = load_config(config)
+    except FileNotFoundError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=2)
+
+    cfg.apply_overrides(**config_overrides)
+
+    # CLI/env tokens override config file values
+    from typer.models import OptionInfo
+
+    if isinstance(hf_token, OptionInfo):
+        hf_token = None
+    if isinstance(wandb_token, OptionInfo):
+        wandb_token = None
+    hf_token = hf_token or cfg.logging.hf_token
+    wandb_token = wandb_token or cfg.logging.wandb_token
+
+    if dry_run:
+        import yaml
+
+        data = cfg.model_dump()
+        typer.echo(yaml.dump(data, default_flow_style=False, sort_keys=False))
+        raise typer.Exit(code=0)
+
+    if not cfg.model.model:
+        typer.echo("Error: provide --model or set model.model in --config", err=True)
+        raise typer.Exit(code=2)
+
+    if not cfg.data.dataset and not cfg.data.local_dataset:
+        typer.echo(
+            "Error: provide --dataset or --local-dataset (or via --config)",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    use_lora = cfg.training.training_type.lower() == "lora"
+    task = cfg.training.task.lower()
+
+    # Import here to avoid slow startup when only --help is requested
+    try:
+        from unturtle import FastDiffusionModel
+        from unturtle.diffusion import DiffusionTrainer, DiffusionTrainingArguments
+    except ImportError as e:
+        typer.echo(f"Error: failed to import unturtle — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    if task == "grpo":
+        try:
+            import trl.trainer.grpo_trainer  # noqa: F401
+        except ImportError as e:
+            typer.echo(
+                "Error: GRPO requires optional dependencies — "
+                'install with `uv pip install -e ".[huggingface,grpo]"` '
+                f"(import failed: {e})",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        try:
+            from unturtle.diffusion import DiffuGRPOTrainer
+        except ImportError as e:
+            typer.echo(f"Error: failed to import DiffuGRPOTrainer — {e}", err=True)
+            raise typer.Exit(code=1)
+
+    model_class = _resolve_model_class(cfg.model.model_type)
+
+    # --- Load model ---
+    typer.echo(f"Loading model: {cfg.model.model}")
+    try:
+        model, tokenizer = FastDiffusionModel.from_pretrained(
+            model_name=cfg.model.model,
+            max_seq_length=cfg.model.max_seq_length,
+            load_in_4bit=cfg.model.load_in_4bit if use_lora else False,
+            model_class=model_class,
+            token=hf_token,
+        )
+    except Exception as e:
+        typer.echo(f"Error: model load failed — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    # --- Apply LoRA ---
+    if use_lora:
+        typer.echo("Applying LoRA adapter...")
+        try:
+            model = FastDiffusionModel.get_peft_model(
+                model,
+                use_gradient_checkpointing=cfg.training.gradient_checkpointing,
+                **cfg.lora_kwargs(),
+            )
+        except Exception as e:
+            typer.echo(f"Error: LoRA setup failed — {e}", err=True)
+            raise typer.Exit(code=1)
+
+    # --- Load dataset ---
+    typer.echo("Loading dataset...")
+    try:
+        if cfg.data.dataset:
+            from datasets import load_dataset
+
+            dataset = load_dataset(cfg.data.dataset, token=hf_token)
+            train_dataset = dataset.get("train", dataset)
+        else:
+            import json
+
+            from datasets import Dataset
+
+            rows = []
+            for path in cfg.data.local_dataset or []:
+                with open(path, encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line:
+                            rows.append(json.loads(line))
+            train_dataset = Dataset.from_list(rows)
+    except Exception as e:
+        typer.echo(f"Error: dataset load failed — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    if cfg.logging.enable_wandb:
+        report_to = "wandb"
+    elif cfg.logging.enable_tensorboard:
+        report_to = "tensorboard"
+    else:
+        report_to = "none"
+    tb_dir = cfg.logging.tensorboard_dir if cfg.logging.enable_tensorboard else None
+
+    # --- Train ---
+    typer.echo("Starting training...")
+    try:
+        if cfg.logging.enable_wandb and wandb_token:
+            import os
+
+            os.environ.setdefault("WANDB_API_KEY", wandb_token)
+        if cfg.logging.enable_wandb and cfg.logging.wandb_project:
+            import os
+
+            os.environ.setdefault("WANDB_PROJECT", cfg.logging.wandb_project)
+
+        if task == "grpo":
+            train_dataset = _dataset_for_grpo(
+                train_dataset, cfg.data.dataset_text_field
+            )
+            tok_mask = tokenizer.mask_token_id
+            if tok_mask is None and cfg.grpo.mask_id is None:
+                typer.echo(
+                    "Error: tokenizer has no mask_token_id — set grpo.mask_id in config",
+                    err=True,
+                )
+                raise typer.Exit(code=2)
+            mask_token_id = (
+                int(cfg.grpo.mask_id) if cfg.grpo.mask_id is not None else int(tok_mask)
+            )
+            grpo_args = cfg.build_diffu_grpo_config(
+                mask_token_id=mask_token_id,
+                report_to=report_to,
+                logging_dir=tb_dir,
+            )
+            reward_fn = _builtin_grpo_reward(cfg.grpo.builtin_reward)
+            typer.echo(
+                f"Diffu-GRPO: objective={grpo_args.diffu_policy_objective}, "
+                f"reward={cfg.grpo.builtin_reward}"
+            )
+            trainer = DiffuGRPOTrainer(
+                model=model,
+                reward_funcs=reward_fn,
+                args=grpo_args,
+                train_dataset=train_dataset,
+                processing_class=tokenizer,
+            )
+            trainer.train()
+        else:
+            args_kwargs = cfg.training_args_kwargs()
+            args_kwargs["report_to"] = report_to
+            if report_to == "tensorboard" and tb_dir:
+                args_kwargs["logging_dir"] = tb_dir
+            try:
+                training_args = DiffusionTrainingArguments(**args_kwargs)
+            except Exception as e:
+                typer.echo(f"Error: invalid training arguments — {e}", err=True)
+                raise typer.Exit(code=1)
+
+            from unturtle.diffusion import MaskedDiffusionDataCollator
+
+            collator = MaskedDiffusionDataCollator(
+                tokenizer=tokenizer,
+                completion_only=cfg.diffusion.completion_only,
+            )
+            trainer = DiffusionTrainer(
+                model=model,
+                args=training_args,
+                train_dataset=train_dataset,
+                data_collator=collator,
+                processing_class=tokenizer,
+            )
+            trainer.train()
+    except KeyboardInterrupt:
+        typer.echo("\nTraining interrupted.")
+        raise typer.Exit(code=0)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        typer.echo(f"Error: training failed — {e}", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo("Training complete.")

--- a/unturtle/cli/config.py
+++ b/unturtle/cli/config.py
@@ -1,0 +1,450 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pydantic configuration models for unturtle.cli.
+
+Relationship to ``dev/repos/unsloth`` ``unsloth_cli``:
+
+- Upstream uses a flatter root config (e.g. ``model: str``, ``training.max_seq_length``).
+- Unturtle nests model loading under ``model:`` (``model.model``, ``model_type``, …) for
+  :class:`~unturtle.fast_diffusion_model.FastDiffusionModel`, adds ``diffusion:`` for dLLM
+  SFT, and may include GRPO-oriented sections in example YAMLs under ``examples/configs/``.
+- ``unturtle train`` uses ``FastDiffusionModel`` / ``DiffusionTrainer`` (and optionally
+  ``DiffuGRPOTrainer``); it does **not** call Studio's ``UnslothTrainer`` from upstream CLI.
+
+Config hierarchy::
+
+    Config
+    ├── model:    ModelConfig      — model loading / quantization
+    ├── data:     DataConfig       — dataset sources
+    ├── training: TrainingConfig   — task (sft/grpo), LR, batch, checkpoints
+    ├── diffusion: DiffusionConfig — dLLM-specific training options
+    ├── lora:     LoraConfig       — LoRA adapter settings
+    ├── logging:  LoggingConfig    — W&B / TensorBoard / HF tokens
+    └── grpo:     GRPOConfig       — DiffuGRPO settings (optional)
+
+YAML/JSON config files use the nested key names (e.g. ``training.num_epochs``).
+CLI flags are auto-generated from the flattened field names by
+:func:`~unturtle.cli.options.add_options_from_config`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from pathlib import Path
+from typing import List, Literal, Optional
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+def _grpo_effective_world_size() -> int:
+    """Process count for TRL ``generation_batch_size`` (per-rank batch × world)."""
+    try:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            return max(1, dist.get_world_size())
+    except Exception:
+        pass
+    for key in ("WORLD_SIZE", "SLURM_NTASKS", "OMPI_COMM_WORLD_SIZE"):
+        v = os.environ.get(key)
+        if v:
+            try:
+                w = int(v)
+                if w >= 1:
+                    return w
+            except ValueError:
+                continue
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Sub-config sections
+# ---------------------------------------------------------------------------
+
+
+class ModelConfig(BaseModel):
+    model: Optional[str] = Field(
+        default=None,
+        description="HuggingFace model ID or local path.",
+    )
+    model_type: Literal["auto", "a2d", "llada", "dream"] = Field(
+        default="auto",
+        description=(
+            "Hint for FastDiffusionModel auto-detection: "
+            "'auto' uses HF AutoConfig; 'a2d'/'llada'/'dream' are explicit."
+        ),
+    )
+    max_seq_length: int = Field(default=2048, description="Maximum sequence length.")
+    load_in_4bit: bool = Field(
+        default=True, description="Load model in 4-bit quantisation."
+    )
+
+
+class DataConfig(BaseModel):
+    dataset: Optional[str] = Field(default=None, description="HuggingFace dataset ID.")
+    local_dataset: Optional[List[str]] = Field(
+        default=None, description="Paths to local JSONL/JSON dataset files."
+    )
+    dataset_text_field: str = Field(
+        default="text", description="Column name that holds the training text."
+    )
+
+
+class TrainingConfig(BaseModel):
+    task: Literal["sft", "grpo"] = Field(
+        default="sft",
+        description="Training task: masked diffusion SFT or Diffu-GRPO / wd1 RL.",
+    )
+    training_type: Literal["lora", "full"] = Field(
+        default="lora", description="Training mode: 'lora' (adapter) or 'full'."
+    )
+    output_dir: str = Field(
+        default="./outputs", description="Directory to save checkpoints."
+    )
+    num_epochs: int = Field(default=3, description="Number of training epochs.")
+    learning_rate: float = Field(default=2e-4, description="Peak learning rate.")
+    batch_size: int = Field(default=2, description="Per-device training batch size.")
+    gradient_accumulation_steps: int = Field(
+        default=4, description="Gradient accumulation steps."
+    )
+    warmup_steps: int = Field(
+        default=5, description="Number of warmup steps for the LR scheduler."
+    )
+    max_steps: int = Field(
+        default=0, description="Maximum training steps; 0 means use num_epochs."
+    )
+    save_steps: int = Field(
+        default=0, description="Save checkpoint every N steps; 0 to disable."
+    )
+    weight_decay: float = Field(default=0.01, description="AdamW weight decay.")
+    random_seed: int = Field(default=3407, description="Random seed.")
+    packing: bool = Field(
+        default=False, description="Enable sample packing for efficiency."
+    )
+    gradient_checkpointing: Literal["unsloth", "true", "none"] = Field(
+        default="unsloth",
+        description="Gradient checkpointing mode ('unsloth' recommended).",
+    )
+
+
+class DiffusionConfig(BaseModel):
+    """dLLM-specific training options — maps to DiffusionTrainingArguments."""
+
+    alpha_scheduler: Literal["linear", "cosine"] = Field(
+        default="linear",
+        description="Alpha scheduler for masked diffusion noise: 'linear' or 'cosine'.",
+    )
+    time_epsilon: float = Field(
+        default=1e-3,
+        description="Minimum sampled timestep (avoids t→0 degenerate case).",
+    )
+    loss_weight_type: Literal["uniform", "timestep", "scheduler"] = Field(
+        default="uniform",
+        description=(
+            "Per-token loss weighting: "
+            "'uniform' (LLaDA/MDLM default), "
+            "'timestep' (d1 SFT 1/t weighting), "
+            "'scheduler' (MDLM paper w(t))."
+        ),
+    )
+    completion_only: bool = Field(
+        default=True,
+        description="Only mask completion tokens; skip the prompt.",
+    )
+
+
+class LoraConfig(BaseModel):
+    lora_r: int = Field(default=64, description="LoRA rank.")
+    lora_alpha: int = Field(default=16, description="LoRA alpha scaling factor.")
+    lora_dropout: float = Field(default=0.0, description="LoRA dropout probability.")
+    target_modules: str = Field(
+        default="q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj",
+        description="Comma-separated list of module names to apply LoRA to.",
+    )
+    use_rslora: bool = Field(
+        default=False, description="Use Rank-Stabilised LoRA (rsLoRA)."
+    )
+
+
+class LoggingConfig(BaseModel):
+    enable_wandb: bool = Field(
+        default=False, description="Enable Weights & Biases logging."
+    )
+    wandb_project: str = Field(
+        default="unturtle-training", description="W&B project name."
+    )
+    wandb_token: Optional[str] = Field(
+        default=None,
+        description="W&B API key (overrides WANDB_API_KEY env var).",
+    )
+    enable_tensorboard: bool = Field(
+        default=False, description="Enable TensorBoard logging."
+    )
+    tensorboard_dir: str = Field(
+        default="runs", description="TensorBoard log directory."
+    )
+    hf_token: Optional[str] = Field(
+        default=None,
+        description="HuggingFace token (overrides HF_TOKEN env var).",
+    )
+
+
+class GRPOConfig(BaseModel):
+    """DiffuGRPO / wd1 settings — used when ``training.task == \"grpo\"``."""
+
+    diffusion_steps: int = Field(
+        default=128, description="Number of diffusion denoising steps during rollout."
+    )
+    block_length: int = Field(
+        default=32, description="Block decode length for DiffuGRPO rollouts."
+    )
+    mask_id: Optional[int] = Field(
+        default=None,
+        description="Mask token ID override; resolved from tokenizer if None.",
+    )
+    cfg_scale: float = Field(
+        default=0.0,
+        description="Classifier-free guidance scale (0 = disabled).",
+    )
+    remasking: Literal["random", "low_confidence"] = Field(
+        default="random",
+        description="Remasking strategy for DiffuGRPO rollouts.",
+    )
+    num_generations: int = Field(
+        default=8,
+        ge=2,
+        description="GRPO group size (completions per prompt).",
+    )
+    max_completion_length: int = Field(
+        default=128,
+        description="Maximum generated completion length (tokens).",
+    )
+    max_prompt_length: Optional[int] = Field(
+        default=None,
+        description="Trim prompts to this many tokens from the left; None = no trim.",
+    )
+    num_iterations: int = Field(
+        default=1,
+        ge=1,
+        description="Inner GRPO iterations (μ); >1 reuses rollouts with TRL buffering.",
+    )
+    beta: float = Field(
+        default=0.0,
+        description="KL coefficient vs reference policy (0 disables).",
+    )
+    p_mask_prompt: float = Field(
+        default=0.3,
+        description="Probability of masking prompt tokens in log-prob computation.",
+    )
+    random_masking: bool = Field(
+        default=True,
+        description="Random mask seeds per GRPO iteration.",
+    )
+    diffu_policy_objective: Literal["grpo", "wd1", "wd1++"] = Field(
+        default="grpo",
+        description="Loss: grpo, wd1 (Eq. 8–9), or wd1++ (Eq. 10 MC at denoise snapshots).",
+    )
+    wd1_psi: float = Field(
+        default=1.0, description="ψ for wd1 softmax weights (Eq. 9)."
+    )
+    scale_rewards: bool = Field(
+        default=False,
+        description="If True, scale advantages by per-group std (TRL 'group'); False = d1-style unscaled.",
+    )
+    generation_batch_size: Optional[int] = Field(
+        default=None,
+        description="Rollout micro-batch size; None = derive from batch size and grad accumulation (TRL).",
+    )
+    builtin_reward: Literal["length", "constant_one"] = Field(
+        default="length",
+        description="Built-in reward for CLI runs (no custom Python reward).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Root config
+# ---------------------------------------------------------------------------
+
+
+class Config(BaseModel):
+    model: ModelConfig = Field(default_factory=ModelConfig)
+    data: DataConfig = Field(default_factory=DataConfig)
+    training: TrainingConfig = Field(default_factory=TrainingConfig)
+    diffusion: DiffusionConfig = Field(default_factory=DiffusionConfig)
+    lora: LoraConfig = Field(default_factory=LoraConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    grpo: GRPOConfig = Field(default_factory=GRPOConfig)
+
+    def apply_overrides(self, **kwargs) -> None:
+        """Merge CLI flag overrides into the config.
+
+        Each key is matched against the config sections in order.
+        Values that are ``None`` are skipped (flag not provided).
+        """
+        sections = [
+            self.model,
+            self.data,
+            self.training,
+            self.diffusion,
+            self.lora,
+            self.logging,
+            self.grpo,
+        ]
+
+        for key, value in kwargs.items():
+            if value is None:
+                continue
+            for section in sections:
+                if hasattr(section, key):
+                    setattr(section, key, value)
+                    break
+
+    def training_args_kwargs(self) -> dict:
+        """Return kwargs suitable for DiffusionTrainingArguments."""
+        return {
+            "output_dir": self.training.output_dir,
+            "num_train_epochs": self.training.num_epochs,
+            "learning_rate": self.training.learning_rate,
+            "per_device_train_batch_size": self.training.batch_size,
+            "gradient_accumulation_steps": self.training.gradient_accumulation_steps,
+            "warmup_steps": self.training.warmup_steps,
+            "max_steps": self.training.max_steps if self.training.max_steps > 0 else -1,
+            "save_steps": self.training.save_steps
+            if self.training.save_steps > 0
+            else 500,
+            "weight_decay": self.training.weight_decay,
+            "seed": self.training.random_seed,
+            "gradient_checkpointing": self.training.gradient_checkpointing != "none",
+            # dLLM-specific
+            "alpha_scheduler": self.diffusion.alpha_scheduler,
+            "time_epsilon": self.diffusion.time_epsilon,
+            "loss_weight_type": self.diffusion.loss_weight_type,
+            "completion_only": self.diffusion.completion_only,
+        }
+
+    def lora_kwargs(self) -> dict:
+        """Return kwargs for FastDiffusionModel.get_peft_model()."""
+        target_modules = [
+            m.strip() for m in str(self.lora.target_modules).split(",") if m.strip()
+        ]
+        return {
+            "r": self.lora.lora_r,
+            "lora_alpha": self.lora.lora_alpha,
+            "lora_dropout": self.lora.lora_dropout,
+            "target_modules": target_modules,
+            "use_rslora": self.lora.use_rslora,
+        }
+
+    def build_diffu_grpo_config(
+        self,
+        *,
+        mask_token_id: int,
+        report_to: str,
+        logging_dir: Optional[str] = None,
+    ):
+        """Instantiate :class:`~unturtle.diffusion.DiffuGRPOConfig` from this file + tokenizer mask id.
+
+        When ``grpo.generation_batch_size`` is omitted, derives a TRL-valid batch from
+        ``training.batch_size × world_size × gradient_accumulation_steps`` (rounded up to
+        a multiple of ``num_generations``). ``world_size`` comes from an initialized
+        ``torch.distributed`` process group if available, else ``WORLD_SIZE`` /
+        ``SLURM_NTASKS`` / ``OMPI_COMM_WORLD_SIZE``, else ``1``.
+        """
+        from unturtle.diffusion import DiffuGRPOConfig
+
+        t, g = self.training, self.grpo
+        save_strategy = "steps" if t.save_steps > 0 else "no"
+        save_steps_val = t.save_steps if t.save_steps > 0 else 500
+        max_steps = t.max_steps if t.max_steps > 0 else -1
+        logging_steps = max(1, min(50, save_steps_val // 2)) if t.save_steps > 0 else 10
+
+        kwargs: dict = {
+            "output_dir": t.output_dir,
+            "num_train_epochs": t.num_epochs,
+            "max_steps": max_steps,
+            "learning_rate": t.learning_rate,
+            "per_device_train_batch_size": t.batch_size,
+            "gradient_accumulation_steps": t.gradient_accumulation_steps,
+            "warmup_steps": t.warmup_steps,
+            "save_strategy": save_strategy,
+            "save_steps": save_steps_val,
+            "weight_decay": t.weight_decay,
+            "seed": t.random_seed,
+            "logging_steps": logging_steps,
+            "report_to": report_to,
+            "bf16": False,
+            "fp16": False,
+            "gradient_checkpointing": t.gradient_checkpointing != "none",
+            "remove_unused_columns": False,
+            "dataloader_num_workers": 0,
+            "num_generations": g.num_generations,
+            "max_completion_length": g.max_completion_length,
+            "block_length": g.block_length,
+            "diffusion_steps": g.diffusion_steps,
+            "cfg_scale": g.cfg_scale,
+            "remasking": g.remasking,
+            "mask_id": int(g.mask_id) if g.mask_id is not None else int(mask_token_id),
+            "p_mask_prompt": g.p_mask_prompt,
+            "beta": g.beta,
+            "num_iterations": g.num_iterations,
+            "scale_rewards": g.scale_rewards,
+            "diffu_policy_objective": g.diffu_policy_objective,
+            "wd1_psi": g.wd1_psi,
+            "random_masking": g.random_masking,
+        }
+        if g.max_prompt_length is not None:
+            kwargs["max_prompt_length"] = g.max_prompt_length
+        if g.generation_batch_size is not None:
+            kwargs["generation_batch_size"] = g.generation_batch_size
+        else:
+            # Pre-buffer enough rollouts for all grad-accum microbatches in one round
+            # (per-device batch × world × gradient_accumulation_steps), then round up to
+            # a multiple of num_generations. Not the same as TRL's steps_per_generation.
+            raw = (
+                t.batch_size
+                * _grpo_effective_world_size()
+                * t.gradient_accumulation_steps
+            )
+            gmul = g.num_generations
+            kwargs["generation_batch_size"] = max(gmul, math.ceil(raw / gmul) * gmul)
+        if logging_dir and report_to == "tensorboard":
+            kwargs["logging_dir"] = logging_dir
+        return DiffuGRPOConfig(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+
+
+def load_config(path: Optional[Path]) -> Config:
+    """Load Config from a YAML or JSON file; return defaults if path is None."""
+    if not path:
+        return Config()
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        data = yaml.safe_load(text) or {}
+    else:
+        data = json.loads(text or "{}")
+
+    return Config(**data)

--- a/unturtle/cli/options.py
+++ b/unturtle/cli/options.py
@@ -1,0 +1,184 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate Typer CLI options from Pydantic models.
+
+The :func:`add_options_from_config` decorator introspects a Pydantic
+:class:`~pydantic.BaseModel` and dynamically adds corresponding Typer
+``Option`` parameters for supported fields, flattening nested sub-models into
+top-level flags. The decorated function receives a ``config_overrides`` dict
+containing only the flags the user explicitly provided on the command line.
+"""
+
+import functools
+import inspect
+from pathlib import Path
+from typing import Any, Callable, Optional, get_args, get_origin
+
+import typer
+from pydantic import BaseModel
+
+
+def _python_name_to_cli_flag(name: str) -> str:
+    """Convert python_name to --cli-flag."""
+    return "--" + name.replace("_", "-")
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    """Unwrap Optional[X] to X."""
+    origin = get_origin(annotation)
+    if origin is not None:
+        args = get_args(annotation)
+        if type(None) in args:
+            non_none = [a for a in args if a is not type(None)]
+            if non_none:
+                return non_none[0]
+    return annotation
+
+
+def _is_bool_field(annotation: Any) -> bool:
+    """Check if field is a boolean (including Optional[bool])."""
+    return _unwrap_optional(annotation) is bool
+
+
+def _is_list_type(annotation: Any) -> bool:
+    """Check if type is a List (including Optional[List[T]])."""
+    return get_origin(_unwrap_optional(annotation)) is list
+
+
+def _get_python_type(annotation: Any) -> type:
+    """Get the Python type for scalar annotations."""
+    unwrapped = _unwrap_optional(annotation)
+    if unwrapped in (str, int, float, bool, Path):
+        return unwrapped
+    return str
+
+
+def _get_list_item_type(annotation: Any) -> type:
+    """Get the Python item type for List[T] / Optional[List[T]]."""
+    unwrapped = _unwrap_optional(annotation)
+    args = get_args(unwrapped)
+    if args:
+        item = _unwrap_optional(args[0])
+        if item in (str, int, float, bool, Path):
+            return item
+    return str
+
+
+def _collect_config_fields(config_class: type[BaseModel]) -> list[tuple[str, Any]]:
+    """Collect all fields from a config class, flattening nested models.
+
+    Returns list of (name, field_info) tuples.
+    Raises ValueError on duplicate field names.
+    """
+    fields = []
+    seen_names: set[str] = set()
+
+    for name, field_info in config_class.model_fields.items():
+        annotation = field_info.annotation
+        # Recurse into nested Pydantic models, skip Optional[NestedModel]
+        inner = _unwrap_optional(annotation)
+        if isinstance(inner, type) and issubclass(inner, BaseModel):
+            for nested_name, nested_field in inner.model_fields.items():
+                if nested_name in seen_names:
+                    raise ValueError(f"Duplicate field name '{nested_name}' in config")
+                seen_names.add(nested_name)
+                fields.append((nested_name, nested_field))
+        else:
+            if name in seen_names:
+                raise ValueError(f"Duplicate field name '{name}' in config")
+            seen_names.add(name)
+            fields.append((name, field_info))
+    return fields
+
+
+def add_options_from_config(config_class: type[BaseModel]) -> Callable:
+    """Decorator that adds CLI options for all fields in a Pydantic config model.
+
+    The decorated function should declare a ``config_overrides: dict = None``
+    parameter which will receive a dict of all CLI-provided config values.
+    """
+    fields = _collect_config_fields(config_class)
+    field_names = {name for name, _field_info in fields}
+
+    def decorator(func: Callable) -> Callable:
+        sig = inspect.signature(func)
+        original_params = list(sig.parameters.values())
+        original_param_names = {p.name for p in original_params}
+
+        new_params = []
+
+        for field_name, field_info in fields:
+            if field_name in original_param_names:
+                continue
+            annotation = field_info.annotation
+
+            flag_name = _python_name_to_cli_flag(field_name)
+            help_text = field_info.description or ""
+
+            if _is_list_type(annotation):
+                item_type = _get_list_item_type(annotation)
+                default = typer.Option(None, flag_name, help=help_text)
+                param = inspect.Parameter(
+                    field_name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=default,
+                    annotation=list[item_type] | None,
+                )
+            elif _is_bool_field(annotation):
+                default = typer.Option(
+                    None,
+                    f"{flag_name}/--no-{field_name.replace('_', '-')}",
+                    help=help_text,
+                )
+                param = inspect.Parameter(
+                    field_name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=default,
+                    annotation=Optional[bool],
+                )
+            else:
+                py_type = _get_python_type(annotation)
+                default = typer.Option(None, flag_name, help=help_text)
+                param = inspect.Parameter(
+                    field_name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=default,
+                    annotation=Optional[py_type],
+                )
+            new_params.append(param)
+
+        for param in original_params:
+            if param.name != "config_overrides":
+                new_params.append(param)
+
+        new_sig = sig.replace(parameters=new_params)
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            config_overrides = {}
+            for key in list(kwargs.keys()):
+                if key in field_names:
+                    if kwargs[key] is not None:
+                        config_overrides[key] = kwargs[key]
+                    if key not in original_param_names:
+                        del kwargs[key]
+
+            kwargs["config_overrides"] = config_overrides
+            return func(*args, **kwargs)
+
+        wrapper.__signature__ = new_sig
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
Closes #20

## 概要
クリーン移植の最終 Task 9。

- **CLI 統合**: `unturtle_cli` → `unturtle/cli/`（studio コマンド除去、import 全置換）。`unturtle --help` で train/generate/export/eval を確認、studio なし
- **benchmarks/ + examples/** 移植（validate_studio_mdlm_chat 除外）。legacy CI が lint 対象外だった examples/ の潜在 lint 10件を解消（SIM 系修正、marimo demos は exclude、E402 は意図的 import 順として per-file-ignore）
- **docs**: dllm-gap-map.md に DiffusionGemma（P1 候補）/ Nemotron-Labs-Diffusion（評価候補）行と移植後ロードマップを追加。CLAUDE.md を新構成（冒頭に transformers/TRL/unsloth/unturtle の Layering 節、install.sh を環境構築の正、studio/lighteval/エイリアス/a2d-compat 言及を全削除、gotchas は全維持）でスリム化。AGENTS.md 同方針

## テスト
- cli_smoke + examples: 44 passed / 全量 not-slow: **538 passed, 1 skipped**
- **GPU チェック③（全量 slow+gpu）: 542 passed, 1 failed, 1 skipped** — 失敗は既知 #16（bf16 reload、legacy 同一 venv でも再現する環境起因）のみ
- **ベンチマーク比較**: block-decode cache speedup smoke を新旧両環境で実行 — legacy+旧スタック 23.8s / 新+新スタック 20.6s、**性能退行なし**（gsm8k フル比較は checkpoint DL+長時間 eval のため未実施、代理指標で確認）
- ruff グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)