### PR TITLE
♻️ refactor(generation): unify dLLM inference entry on generate(), remove diffusion_generate (#22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,8 @@ Two tiers, different guarantees:
 - **Smoke / in-loop** (`unturtle.eval` — `GSM8KEvaluator`, `MaskedDiffusionEvaluator`,
   `GenerationEvaluator`): fast local sanity checks during training/CI. NOT authoritative.
 - **Canonical benchmark** (`unturtle.eval.harness`, lm-evaluation-harness): the
-  authoritative, paper-comparable path. Routes through `FastDiffusionModel` +
-  `diffusion_generate`. Every run pins an explicit per-(model_family, task)
+  authoritative, paper-comparable path. Routes through `model.generate` (via
+  `FastDiffusionModel.generate` forwarder). Every run pins an explicit per-(model_family, task)
   `DecodingConfig` and records it with the score (dLLM scores are highly sensitive to
   decoding hyperparameters such as max_new_tokens, eos-suppression, steps, temperature).
 
@@ -170,13 +170,17 @@ must not require it (the adapter/runner import `lm_eval` lazily).
 
 ## High-level generation
 
-`FastDiffusionModel.generate(model, inputs, algorithm="auto", **kwargs)` is the high-level
-inference entry. `algorithm` is explicit: `"auto"` (default — fastest discrete path the model
-supports: block-decode when available, else MDLM; BD3LM when requested), or force
-`"mdlm"` / `"block_decode"` / `"bd3lm"`. It delegates to `model.diffusion_generate(...)` with
-the flag set the named algorithm implies, so output is identical to the equivalent
-`diffusion_generate` call; the low-level `diffusion_generate` entry stays for existing callers.
-Decoding algorithms are registered in `unturtle/models/generation/sampler.py`
+`model.generate(inputs, algorithm="auto", **kwargs)` is the unified dLLM inference entry
+(transformers-standard name; diffusion is the default behavior). `algorithm` is explicit:
+`"auto"` (default — fastest discrete path the model supports: BD3LM when requested via
+`use_block_diffusion=True`, else block-decode when available, else MDLM), or force
+`"mdlm"` / `"block_decode"` / `"bd3lm"`. The resolved algorithm's flags
+(`use_cache` / `use_block_diffusion`) are injected into kwargs and override
+`generation_config` fields — pin `algorithm="mdlm"` explicitly when the no-cache MDLM
+path is the intent on a block-decode-capable model. `FastDiffusionModel.generate(model,
+inputs, algorithm=..., **kwargs)` remains as a thin forwarder (unsloth-style facade,
+behaviorally identical to calling `model.generate` directly). Decoding algorithms are
+registered in `unturtle/models/generation/sampler.py`
 (discrete-masked-only today; the registry is open for future continuous-diffusion algorithms).
 
 ## Issue, branch, commit, PR workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,10 +160,11 @@ Two tiers, different guarantees:
 - **Smoke / in-loop** (`unturtle.eval` — `GSM8KEvaluator`, `MaskedDiffusionEvaluator`,
   `GenerationEvaluator`): fast local sanity checks during training/CI. NOT authoritative.
 - **Canonical benchmark** (`unturtle.eval.harness`, lm-evaluation-harness): the
-  authoritative, paper-comparable path. Routes through `model.generate` (via
-  `FastDiffusionModel.generate` forwarder). Every run pins an explicit per-(model_family, task)
-  `DecodingConfig` and records it with the score (dLLM scores are highly sensitive to
-  decoding hyperparameters such as max_new_tokens, eos-suppression, steps, temperature).
+  authoritative, paper-comparable path. Uses `FastDiffusionModel.from_pretrained` then calls
+  `model.generate(..., algorithm="mdlm")` directly in the adapter (no forwarder). Every run
+  pins an explicit per-(model_family, task) `DecodingConfig` and records it with the score
+  (dLLM scores are highly sensitive to decoding hyperparameters such as max_new_tokens,
+  eos-suppression, steps, temperature).
 
 `lm_eval` is an optional dependency (`./install.sh --eval`); `import unturtle.eval`
 must not require it (the adapter/runner import `lm_eval` lazily).
@@ -172,15 +173,18 @@ must not require it (the adapter/runner import `lm_eval` lazily).
 
 `model.generate(inputs, algorithm="auto", **kwargs)` is the unified dLLM inference entry
 (transformers-standard name; diffusion is the default behavior). `algorithm` is explicit:
-`"auto"` (default — fastest discrete path the model supports: BD3LM when requested via
-`use_block_diffusion=True`, else block-decode when available, else MDLM), or force
+`"auto"` (default — fastest discrete path the model supports: BD3LM when requested via the
+`use_block_diffusion=True` KWARG, else block-decode when available, else MDLM), or force
 `"mdlm"` / `"block_decode"` / `"bd3lm"`. The resolved algorithm's flags
 (`use_cache` / `use_block_diffusion`) are injected into kwargs and override
 `generation_config` fields — pin `algorithm="mdlm"` explicitly when the no-cache MDLM
-path is the intent on a block-decode-capable model. `FastDiffusionModel.generate(model,
-inputs, algorithm=..., **kwargs)` remains as a thin forwarder (unsloth-style facade,
-behaviorally identical to calling `model.generate` directly). Decoding algorithms are
-registered in `unturtle/models/generation/sampler.py`
+path is the intent on a block-decode-capable model. Explicit algorithm choices are
+capability-checked and raise `ValueError` immediately for unsupported combinations:
+`"bd3lm"` requires the model to implement `_sample_block_diffusion` (TinyA2D family today;
+Dream and LLaDA raise). `FastDiffusionModel.generate(model, inputs, algorithm=..., **kwargs)`
+remains as a thin forwarder (unsloth-style facade, behaviorally identical to calling
+`model.generate` directly). Decoding algorithms are registered in
+`unturtle/models/generation/sampler.py`
 (discrete-masked-only today; the registry is open for future continuous-diffusion algorithms).
 
 ## Issue, branch, commit, PR workflow

--- a/benchmarks/a2d/benchmark_block_decode.py
+++ b/benchmarks/a2d/benchmark_block_decode.py
@@ -25,16 +25,22 @@ from unturtle.models.generation.diffusion_generation_utils import (
 def benchmark_generation(model, input_ids, gen_config, warmup=3, iters=10):
     """Benchmark generation with warmup."""
     # Warmup
+    use_cache = gen_config.use_cache if hasattr(gen_config, "use_cache") else False
+    algorithm = "block_decode" if use_cache else "mdlm"
     for _ in range(warmup):
         with torch.no_grad():
-            _ = model.generate(inputs=input_ids, generation_config=gen_config)
+            _ = model.generate(
+                inputs=input_ids, generation_config=gen_config, algorithm=algorithm
+            )
 
     # Benchmark
     torch.cuda.synchronize() if torch.cuda.is_available() else None
     start = time.perf_counter()
     for _ in range(iters):
         with torch.no_grad():
-            _ = model.generate(inputs=input_ids, generation_config=gen_config)
+            _ = model.generate(
+                inputs=input_ids, generation_config=gen_config, algorithm=algorithm
+            )
     torch.cuda.synchronize() if torch.cuda.is_available() else None
     elapsed = time.perf_counter() - start
 

--- a/benchmarks/a2d/benchmark_block_decode.py
+++ b/benchmarks/a2d/benchmark_block_decode.py
@@ -27,14 +27,14 @@ def benchmark_generation(model, input_ids, gen_config, warmup=3, iters=10):
     # Warmup
     for _ in range(warmup):
         with torch.no_grad():
-            _ = model.diffusion_generate(inputs=input_ids, generation_config=gen_config)
+            _ = model.generate(inputs=input_ids, generation_config=gen_config)
 
     # Benchmark
     torch.cuda.synchronize() if torch.cuda.is_available() else None
     start = time.perf_counter()
     for _ in range(iters):
         with torch.no_grad():
-            _ = model.diffusion_generate(inputs=input_ids, generation_config=gen_config)
+            _ = model.generate(inputs=input_ids, generation_config=gen_config)
     torch.cuda.synchronize() if torch.cuda.is_available() else None
     elapsed = time.perf_counter() - start
 

--- a/benchmarks/gsm8k.py
+++ b/benchmarks/gsm8k.py
@@ -84,8 +84,8 @@ def _load_model_and_tokenizer(model_id: str, load_in_4bit: bool):
 
         warnings.warn(
             "unsloth is not installed; falling back to AutoModelForCausalLM. "
-            "diffusion_generate will not be available — benchmark results will use "
-            "model.generate and are NOT comparable to diffusion-model baselines.",
+            "the unified generate() path will not be available — benchmark results will use "
+            "AutoModelForCausalLM.generate and are NOT comparable to diffusion-model baselines.",
             stacklevel=2,
         )
     # Only ImportError triggers the fallback. All other errors (OOM, bad model

--- a/benchmarks/gsm8k.py
+++ b/benchmarks/gsm8k.py
@@ -80,26 +80,13 @@ def _load_model_and_tokenizer(model_id: str, load_in_4bit: bool):
         FastLanguageModel.for_inference(model)
         return model, tokenizer
     except ImportError:
-        import warnings
-
-        warnings.warn(
-            "unsloth is not installed; falling back to AutoModelForCausalLM. "
-            "the unified generate() path will not be available — benchmark results will use "
-            "AutoModelForCausalLM.generate and are NOT comparable to diffusion-model baselines.",
-            stacklevel=2,
+        raise SystemExit(
+            "unsloth (and the dLLM generate path) is required for this benchmark — "
+            "run ./install.sh to set up the environment. "
+            "Plain AutoModelForCausalLM cannot run the diffusion evaluator: "
+            "GSM8KEvaluator passes diffusion-specific kwargs (steps=, temperature=) "
+            "to model.generate() which raises on a plain AR model."
         )
-    # Only ImportError triggers the fallback. All other errors (OOM, bad model
-    # ID, for_inference failures) propagate so they are not silently swallowed.
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
-    tokenizer = AutoTokenizer.from_pretrained(model_id)
-    model = AutoModelForCausalLM.from_pretrained(
-        model_id,
-        load_in_4bit=load_in_4bit,
-        device_map="auto",
-    )
-    model.eval()
-    return model, tokenizer
 
 
 def _model_slug(model_id: str) -> str:

--- a/docs/superpowers/plans/2026-06-11-generate-api-unification.md
+++ b/docs/superpowers/plans/2026-06-11-generate-api-unification.md
@@ -4,6 +4,13 @@
 
 **Goal:** Remove `diffusion_generate` entirely and unify the dLLM inference entry on transformers-standard `model.generate()`, with diffusion as the default behavior and TinyA2D retaining AR via `algorithm="ar"`.
 
+> **Amendment 2026-06-12 (issue #22):** `algorithm="ar"` / `_supports_ar` are **dropped**
+> (see the design spec amendment). Deltas: Task 1 ships only the sampler test coverage +
+> docstring update (no `_supports_ar`, no `"ar"` branch); Task 3 adds **no** `generate`
+> override — only an MRO regression test that TinyA2D `generate` runs diffusion by default;
+> Task 5's "ar raises" test asserts the unknown-algorithm `ValueError` instead; Tasks 6/11
+> do not document an `"ar"` algorithm choice.
+
 **Architecture:** The algorithm→flags resolution moves out of the `FastDiffusionModel.generate` facade and down into the model's `generate()` method (renamed from `diffusion_generate`). `MaskedDiffusionGenerationMixin.generate` handles diffusion-only paths; `MaskedDiffusionBlockGenerationMixin` (TinyA2D-only) overrides `generate` to add an `algorithm="ar"` branch that delegates to transformers' AR generate. `sampler.py` gains `_supports_ar` and an `"ar"` concept in `resolve_algorithm`. No backward-compat alias is kept (repository is being rebuilt).
 
 **Tech Stack:** Python 3.12, PyTorch, transformers 5.11, pytest. Venv at `.venv/`, run tests with `.venv/bin/python -m pytest`.

--- a/docs/superpowers/plans/2026-06-11-generate-api-unification.md
+++ b/docs/superpowers/plans/2026-06-11-generate-api-unification.md
@@ -1,0 +1,1034 @@
+# Generate API Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `diffusion_generate` entirely and unify the dLLM inference entry on transformers-standard `model.generate()`, with diffusion as the default behavior and TinyA2D retaining AR via `algorithm="ar"`.
+
+**Architecture:** The algorithm→flags resolution moves out of the `FastDiffusionModel.generate` facade and down into the model's `generate()` method (renamed from `diffusion_generate`). `MaskedDiffusionGenerationMixin.generate` handles diffusion-only paths; `MaskedDiffusionBlockGenerationMixin` (TinyA2D-only) overrides `generate` to add an `algorithm="ar"` branch that delegates to transformers' AR generate. `sampler.py` gains `_supports_ar` and an `"ar"` concept in `resolve_algorithm`. No backward-compat alias is kept (repository is being rebuilt).
+
+**Tech Stack:** Python 3.12, PyTorch, transformers 5.11, pytest. Venv at `.venv/`, run tests with `.venv/bin/python -m pytest`.
+
+---
+
+## File Structure
+
+**Modified:**
+- `unturtle/models/generation/sampler.py` — add `"ar"` handling + `_supports_ar`; update module docstring (drop `diffusion_generate` mention)
+- `unturtle/models/generation/diffusion_generation_utils.py` — rename `diffusion_generate` → `generate`, accept `algorithm`, resolve flags internally
+- `unturtle/models/generation/masked_diffusion_block_mixin.py` — override `generate` with `algorithm="ar"` branch
+- `unturtle/models/backbones/dream/generation_utils.py` — rename `diffusion_generate` → `generate`, accept `algorithm`
+- `unturtle/models/backbones/llada/modeling_llada.py` — remove the `generate`→`diffusion_generate` redirect (inherit mixin `generate`)
+- `unturtle/fast_diffusion_model.py` — simplify `FastDiffusionModel.generate` to a thin forwarder
+- `unturtle/eval/generation.py` — call `model.generate` directly
+- `unturtle/eval/gsm8k.py` — call `model.generate` directly
+- `unturtle/eval/harness/model_adapter.py` — call `model.generate` directly
+
+**Test files (rewrite `diffusion_generate` → `generate`, assertions unchanged unless noted):**
+- `tests/test_fast_diffusion_generate.py` — **redesigned** (facade no longer resolves flags; flag-resolution tests move to model `generate`)
+- `tests/models/test_llada.py`, `tests/models/test_a2d.py`, `tests/models/test_dream.py`
+- `tests/models/test_block_decode.py`, `tests/models/test_parallel_decode.py`, `tests/models/test_block_decode_benchmark.py`
+- `tests/diffusion/test_block_diffusion_generator.py`
+- `tests/eval/test_evaluators.py`, `tests/eval/test_gsm8k.py`, `tests/eval/test_harness_adapter.py`
+- `tests/examples/test_benchmark_a2d_aligned.py`
+- **New:** AR regression test for TinyA2D + `ValueError` for pure dLLM (placed in `tests/models/test_a2d.py` and `tests/models/test_llada.py`)
+
+---
+
+## Task 1: Add `"ar"` support and `_supports_ar` to sampler.py
+
+**Files:**
+- Modify: `unturtle/models/generation/sampler.py`
+- Test: `tests/models/test_sampler.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/models/test_sampler.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from unturtle.models.generation.sampler import (
+    _supports_ar,
+    algorithm_to_flags,
+    resolve_algorithm,
+)
+
+
+class _BlockCapable:
+    """Stub exposing the block-decode cache hook."""
+
+    def _model_forward_with_cache(self, *a, **k): ...
+
+
+class _PlainDiffusion:
+    """Stub without the cache hook."""
+
+
+class _FakeConfig:
+    def __init__(self, model_type):
+        self.model_type = model_type
+
+
+class _ARModel:
+    """Stub whose config model_type marks it AR-capable (TinyA2D family)."""
+
+    def __init__(self, model_type):
+        self.config = _FakeConfig(model_type)
+
+
+@pytest.mark.parametrize(
+    "model_type,expected",
+    [
+        ("tiny-a2d-llama", True),
+        ("tiny-a2d-qwen2", True),
+        ("tiny-a2d-qwen3", True),
+        ("llada", False),
+        ("dream", False),
+        ("modernbert-diffusion", False),
+    ],
+)
+def test_supports_ar_by_model_type(model_type, expected):
+    assert _supports_ar(_ARModel(model_type)) is expected
+
+
+def test_supports_ar_missing_config_is_false():
+    assert _supports_ar(_PlainDiffusion()) is False
+
+
+def test_resolve_ar_for_ar_capable_returns_ar():
+    model = _ARModel("tiny-a2d-llama")
+    assert resolve_algorithm("ar", model, bd3lm_requested=False) == "ar"
+
+
+def test_resolve_ar_for_non_ar_capable_raises():
+    model = _ARModel("llada")
+    with pytest.raises(ValueError, match="autoregressive"):
+        resolve_algorithm("ar", model, bd3lm_requested=False)
+
+
+def test_resolve_auto_block_decode_still_works():
+    assert (
+        resolve_algorithm("auto", _BlockCapable(), bd3lm_requested=False)
+        == "block_decode"
+    )
+
+
+def test_resolve_auto_mdlm_fallback_still_works():
+    assert (
+        resolve_algorithm("auto", _PlainDiffusion(), bd3lm_requested=False) == "mdlm"
+    )
+
+
+def test_algorithm_to_flags_unchanged():
+    assert algorithm_to_flags("mdlm") == {
+        "use_cache": False,
+        "use_block_diffusion": False,
+    }
+    assert algorithm_to_flags("block_decode") == {
+        "use_cache": True,
+        "use_block_diffusion": False,
+    }
+    assert algorithm_to_flags("bd3lm") == {
+        "use_cache": False,
+        "use_block_diffusion": True,
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/models/test_sampler.py -v`
+Expected: FAIL — `ImportError: cannot import name '_supports_ar'`
+
+- [ ] **Step 3: Implement `_supports_ar` and `"ar"` handling in `resolve_algorithm`**
+
+In `unturtle/models/generation/sampler.py`, add the AR-capable model_type set near the top (after `DISCRETE_ALGORITHMS`):
+
+```python
+#: model_types whose backbone retains a usable transformers autoregressive generate.
+_AR_CAPABLE_MODEL_TYPES: frozenset[str] = frozenset(
+    {"tiny-a2d-llama", "tiny-a2d-qwen2", "tiny-a2d-qwen3"}
+)
+
+
+def _supports_ar(model: Any) -> bool:
+    """True if the model exposes a usable autoregressive ``generate`` (TinyA2D family)."""
+    config = getattr(model, "config", None)
+    model_type = getattr(config, "model_type", None)
+    return model_type in _AR_CAPABLE_MODEL_TYPES
+```
+
+Update `resolve_algorithm` to accept and validate `"ar"`:
+
+```python
+def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> str:
+    """Resolve ``algorithm`` to a concrete algorithm name.
+
+    ``auto`` picks the fastest discrete path the model supports:
+      - BD3LM if requested,
+      - else block-decode (Fast-dLLM) when the model supports the cache hook,
+      - else plain MDLM.
+    ``ar`` is returned verbatim for AR-capable models and raises for others.
+    An explicit discrete algorithm name is validated and returned as-is.
+    """
+    if algorithm == "auto":
+        if bd3lm_requested:
+            return "bd3lm"
+        if _supports_block_decode(model):
+            return "block_decode"
+        return "mdlm"
+    if algorithm == "ar":
+        if not _supports_ar(model):
+            raise ValueError(
+                f"{type(model).__name__} does not support autoregressive "
+                "generation (algorithm='ar'); it is a pure diffusion model."
+            )
+        return "ar"
+    if algorithm not in DISCRETE_ALGORITHMS:
+        raise ValueError(
+            f"Unknown decoding algorithm {algorithm!r}. "
+            f"Supported: {sorted(DISCRETE_ALGORITHMS)} (or 'auto'/'ar')."
+        )
+    return algorithm
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/models/test_sampler.py -v`
+Expected: PASS (all 11 cases)
+
+- [ ] **Step 5: Update the module docstring**
+
+In `unturtle/models/generation/sampler.py`, change the docstring line that references `diffusion_generate`:
+
+```python
+flag set that the model's ``generate`` dispatch understands — so this is
+```
+
+(was: "the existing ``diffusion_generate`` dispatch already understands")
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add unturtle/models/generation/sampler.py tests/models/test_sampler.py
+git commit -m "✨ feat(generation): add ar algorithm + _supports_ar to sampler"
+```
+
+---
+
+## Task 2: Rename `MaskedDiffusionGenerationMixin.diffusion_generate` → `generate` with algorithm dispatch
+
+**Files:**
+- Modify: `unturtle/models/generation/diffusion_generation_utils.py:815-879`
+- Test: `tests/models/test_a2d.py` (existing diffusion tests exercise this path)
+
+- [ ] **Step 1: Write the failing test**
+
+Add these methods **inside the `TestA2DGeneration` class** in `tests/models/test_a2d.py` (it has `MASK_TOKEN_ID = 999` and fixtures `llama_config` / `llama_model`). The class is at line ~454; insert after `test_has_diffusion_generate`:
+
+```python
+    def test_generate_accepts_algorithm_kwarg(self, llama_model):
+        B, L_prompt, L_new = 1, 4, 4
+        L_total = L_prompt + L_new
+        prompt_ids = torch.tensor([[1, 2, 3, 4]])
+        mask_fill = torch.full((B, L_new), self.MASK_TOKEN_ID, dtype=torch.long)
+        input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
+        with torch.no_grad():
+            out = llama_model.generate(
+                input_ids_full,
+                algorithm="mdlm",
+                steps=3,
+                mask_token_id=self.MASK_TOKEN_ID,
+                max_length=L_total + 1,
+            )
+        seq = out.sequences if hasattr(out, "sequences") else out
+        assert seq.shape == (B, L_total + 1)
+
+    def test_generate_auto_matches_block_decode(self, llama_model):
+        B, L_prompt, L_new = 1, 4, 4
+        L_total = L_prompt + L_new
+        prompt_ids = torch.tensor([[1, 2, 3, 4]])
+        mask_fill = torch.full((B, L_new), self.MASK_TOKEN_ID, dtype=torch.long)
+        input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
+        gen = dict(steps=3, mask_token_id=self.MASK_TOKEN_ID, max_length=L_total + 1)
+
+        torch.manual_seed(0)
+        out_auto = llama_model.generate(input_ids_full, **gen)
+        torch.manual_seed(0)
+        out_block = llama_model.generate(input_ids_full, algorithm="block_decode", **gen)
+
+        s_auto = out_auto.sequences if hasattr(out_auto, "sequences") else out_auto
+        s_block = out_block.sequences if hasattr(out_block, "sequences") else out_block
+        assert torch.equal(s_auto, s_block)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest "tests/models/test_a2d.py::TestA2DGeneration::test_generate_accepts_algorithm_kwarg" -v`
+Expected: FAIL — `TinyA2DLlamaLMHeadModel` inherits transformers' AR `generate`, which does not accept the `algorithm` kwarg (TypeError) / does not run the diffusion loop.
+
+- [ ] **Step 3: Rename and add algorithm dispatch in the base mixin**
+
+In `unturtle/models/generation/diffusion_generation_utils.py`, change the method (line ~815):
+
+```python
+    @torch.no_grad()
+    def generate(
+        self,
+        inputs: Optional[torch.Tensor] = None,
+        *,
+        algorithm: str = "auto",
+        generation_config: Optional[MaskedDiffusionGenerationConfig] = None,
+        **kwargs,
+    ) -> Union[MaskedDiffusionModelOutput, torch.LongTensor]:
+        """Generate sequences via masked diffusion.
+
+        ``algorithm`` selects the discrete decoding path ("auto"|"mdlm"|
+        "block_decode"|"bd3lm"). The resolved algorithm's flags
+        (``use_cache`` / ``use_block_diffusion``) are injected before the
+        denoising loop runs. Pure-diffusion backbones do not support
+        ``algorithm="ar"`` and will raise ``ValueError`` via ``resolve_algorithm``.
+        """
+        from unturtle.models.generation.sampler import (
+            algorithm_to_flags,
+            resolve_algorithm,
+        )
+
+        bd3lm_requested = bool(kwargs.get("use_block_diffusion", False)) or (
+            algorithm == "bd3lm"
+        )
+        resolved = resolve_algorithm(algorithm, self, bd3lm_requested=bd3lm_requested)
+        # "ar" never reaches this mixin for pure dLLM (resolve_algorithm raises);
+        # TinyA2D short-circuits "ar" in its own override before delegating here.
+        flags = algorithm_to_flags(resolved)
+        kwargs = {**kwargs, **flags}
+
+        generation_config = self._prepare_generation_config(generation_config, **kwargs)
+
+        assert inputs is not None, "`inputs` (input_ids) must be provided"
+        input_ids = inputs
+        attention_mask = kwargs.pop("attention_mask", None)
+
+        input_ids_length = input_ids.shape[-1]
+        has_default_max_length = (
+            kwargs.get("max_length") is None
+            and generation_config.max_length is not None
+        )
+        generation_config = self._prepare_generated_length(
+            generation_config=generation_config,
+            has_default_max_length=has_default_max_length,
+            input_ids_length=input_ids_length,
+        )
+        self._validate_generated_length(
+            generation_config, input_ids_length, has_default_max_length
+        )
+
+        if not is_torchdynamo_compiling() and self.device.type != input_ids.device.type:
+            warnings.warn(
+                "You are calling .generate() with `input_ids` on a different device type than the model."
+                f" `input_ids` is on {input_ids.device.type}, model is on {self.device.type}.",
+                UserWarning,
+            )
+
+        input_ids, attention_mask = self._expand_inputs_for_generation(
+            expand_size=generation_config.num_return_sequences,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+        )
+
+        return self._sample(
+            input_ids,
+            attention_mask=attention_mask,
+            generation_config=generation_config,
+        )
+```
+
+> The `_prepare_generation_config` call already consumes `use_cache`/`use_block_diffusion` from kwargs (they are config fields), so injecting flags into kwargs before it runs is correct and mirrors what the facade previously did.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest "tests/models/test_a2d.py::TestA2DGeneration::test_generate_accepts_algorithm_kwarg" "tests/models/test_a2d.py::TestA2DGeneration::test_generate_auto_matches_block_decode" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add unturtle/models/generation/diffusion_generation_utils.py tests/models/test_a2d.py
+git commit -m "♻️ refactor(generation): rename base mixin diffusion_generate to generate with algorithm dispatch"
+```
+
+---
+
+## Task 3: TinyA2D `generate` override with `algorithm="ar"` branch
+
+**Files:**
+- Modify: `unturtle/models/generation/masked_diffusion_block_mixin.py:68-81` (add `generate` override to the class)
+- Test: `tests/models/test_a2d.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this method **inside the `TestA2DGeneration` class** in `tests/models/test_a2d.py`:
+
+```python
+    def test_generate_ar_delegates_to_transformers(self, llama_model):
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        # AR path produces input + up to max_new_tokens via transformers GenerationMixin.
+        out = llama_model.generate(prompt, algorithm="ar", max_new_tokens=3, do_sample=False)
+        seq = out.sequences if hasattr(out, "sequences") else out
+        assert seq.shape[-1] >= prompt.shape[-1]
+        assert seq.shape[-1] <= prompt.shape[-1] + 3
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest "tests/models/test_a2d.py::TestA2DGeneration::test_generate_ar_delegates_to_transformers" -v`
+Expected: FAIL — without the `ar` branch yet, `algorithm="ar"` reaches the base diffusion mixin's `generate`, whose `resolve_algorithm("ar", ...)` raises `ValueError` ("does not support autoregressive").
+
+- [ ] **Step 3: Add `generate` override to the TinyA2D block mixin**
+
+In `unturtle/models/generation/masked_diffusion_block_mixin.py`, add a `generate` method to `MaskedDiffusionBlockGenerationMixin` (after the class docstring, before `_model_forward_with_cache`). Also add the import at the top of the file:
+
+```python
+from unturtle.models.generation.diffusion_generation_utils import (
+    MaskedDiffusionGenerationMixin,
+)
+```
+
+```python
+    def generate(
+        self,
+        inputs=None,
+        *,
+        algorithm: str = "auto",
+        generation_config=None,
+        **kwargs,
+    ):
+        """Generate via diffusion (default) or transformers AR (``algorithm="ar"``).
+
+        TinyA2D backbones inherit a usable autoregressive ``generate`` from
+        ``transformers.*ForCausalLM``. ``algorithm="ar"`` short-circuits to it
+        via ``super().generate()`` (which walks the MRO down to
+        ``transformers.GenerationMixin.generate``). All diffusion algorithms are
+        routed explicitly to :meth:`MaskedDiffusionGenerationMixin.generate`.
+        """
+        if algorithm == "ar":
+            return super().generate(
+                inputs, generation_config=generation_config, **kwargs
+            )
+        return MaskedDiffusionGenerationMixin.generate(
+            self,
+            inputs,
+            algorithm=algorithm,
+            generation_config=generation_config,
+            **kwargs,
+        )
+```
+
+> `super().generate(...)` here resolves through the MRO past `BlockDecodeMixin`, `MaskedDiffusionGenerationMixin`, and `LlamaForCausalLM` (none define `generate`) to `transformers.GenerationMixin.generate`. Verified MRO order during design.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest "tests/models/test_a2d.py::TestA2DGeneration::test_generate_ar_delegates_to_transformers" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full TinyA2D test file**
+
+Run: `.venv/bin/python -m pytest tests/models/test_a2d.py -v`
+Expected: FAIL only on the not-yet-rewritten `diffusion_generate` calls (handled in Task 8). The new `generate`/`ar` tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add unturtle/models/generation/masked_diffusion_block_mixin.py tests/models/test_a2d.py
+git commit -m "✨ feat(generation): TinyA2D generate override with algorithm=ar AR fallback"
+```
+
+---
+
+## Task 4: Rename Dream `diffusion_generate` → `generate` with algorithm dispatch
+
+**Files:**
+- Modify: `unturtle/models/backbones/dream/generation_utils.py:364-370`
+- Test: `tests/models/test_dream.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this method **inside the `TestDreamGenerationUtils` class** in `tests/models/test_dream.py` (it has a `config` fixture and builds `DreamModel(config)` inline per test — mirror that pattern):
+
+```python
+    def test_dream_generate_accepts_algorithm(self, config):
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            block_length=2,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            out = model.generate(
+                inputs=inputs, algorithm="mdlm", generation_config=generation_config
+            )
+        seq = out.sequences if hasattr(out, "sequences") else out
+        assert seq.shape == (1, 8)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest "tests/models/test_dream.py::TestDreamGenerationUtils::test_dream_generate_accepts_algorithm" -v`
+Expected: FAIL — `DreamModel.generate` is the transformers AR `generate` (Dream defines only `diffusion_generate`), which does not accept the `algorithm` kwarg (TypeError) and does not run the diffusion loop.
+
+- [ ] **Step 3: Rename Dream method and add algorithm dispatch**
+
+In `unturtle/models/backbones/dream/generation_utils.py`, change the method signature (line ~364) from `diffusion_generate` to `generate` and inject flags. Add the `algorithm` parameter and resolution at the top of the body:
+
+```python
+    @torch.no_grad()
+    def generate(
+        self,
+        inputs: Optional[torch.Tensor] = None,
+        *,
+        algorithm: str = "auto",
+        generation_config: Optional[DreamGenerationConfig] = None,
+        **kwargs,
+    ) -> Union[DreamModelOutput, torch.LongTensor]:
+        from unturtle.models.generation.sampler import (
+            algorithm_to_flags,
+            resolve_algorithm,
+        )
+
+        bd3lm_requested = bool(kwargs.get("use_block_diffusion", False)) or (
+            algorithm == "bd3lm"
+        )
+        resolved = resolve_algorithm(algorithm, self, bd3lm_requested=bd3lm_requested)
+        kwargs = {**kwargs, **algorithm_to_flags(resolved)}
+
+        # 1. Handle `generation_config` and kwargs that might update it, and validate the `.generate()` call
+        generation_config = self._prepare_generation_config(generation_config, **kwargs)
+        ...  # REST OF THE EXISTING METHOD BODY UNCHANGED
+```
+
+> Keep the entire remaining body identical (from `generation_tokens_hook_func = ...` onward). Only the signature and the inserted algorithm-resolution block at the top change. Dream is a pure dLLM (not AR-capable), so `algorithm="ar"` raises in `resolve_algorithm`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest "tests/models/test_dream.py::TestDreamGenerationUtils::test_dream_generate_accepts_algorithm" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add unturtle/models/backbones/dream/generation_utils.py tests/models/test_dream.py
+git commit -m "♻️ refactor(dream): rename diffusion_generate to generate with algorithm dispatch"
+```
+
+---
+
+## Task 5: Remove LLaDA `generate`→`diffusion_generate` redirect
+
+**Files:**
+- Modify: `unturtle/models/backbones/llada/modeling_llada.py:1963-1977`
+- Test: `tests/models/test_llada.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add these methods **inside the `TestLLaDAGeneration` class** in `tests/models/test_llada.py` (it has a `model` fixture and `TINY_MASK_ID = 511`; the config uses `mask_token_id=511`):
+
+```python
+    def test_llada_generate_runs_diffusion(self, model):
+        B, L_prompt, L_new = 1, 4, 4
+        L_total = L_prompt + L_new
+        prompt_ids = torch.tensor([[1, 2, 3, 4]])
+        mask_fill = torch.full((B, L_new), self.TINY_MASK_ID, dtype=torch.long)
+        input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
+        with torch.no_grad():
+            out = model.generate(
+                input_ids_full,
+                algorithm="mdlm",
+                steps=3,
+                mask_token_id=self.TINY_MASK_ID,
+                max_length=L_total + 1,
+            )
+        seq = out.sequences if hasattr(out, "sequences") else out
+        assert seq.shape == (B, L_total + 1)
+
+    def test_llada_generate_ar_raises(self, model):
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        with pytest.raises(ValueError, match="autoregressive"):
+            model.generate(prompt, algorithm="ar", max_new_tokens=4)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest "tests/models/test_llada.py::TestLLaDAGeneration::test_llada_generate_runs_diffusion" "tests/models/test_llada.py::TestLLaDAGeneration::test_llada_generate_ar_raises" -v`
+Expected: FAIL — the current `LLaDAModelLM.generate` redirect forwards to `diffusion_generate` (no `algorithm` param), so `algorithm="mdlm"` is an unexpected kwarg and `algorithm="ar"` does not raise the expected `ValueError`.
+
+- [ ] **Step 3: Remove the redirect method**
+
+In `unturtle/models/backbones/llada/modeling_llada.py`, delete the entire `generate` override (lines ~1963-1977):
+
+```python
+    def generate(self, inputs=None, generation_config=None, **kwargs):
+        """Redirect HF autoregressive ``generate()`` to ``diffusion_generate()``.
+        ...
+        """
+        return self.diffusion_generate(
+            inputs, generation_config=generation_config, **kwargs
+        )
+```
+
+After removal, `LLaDAModelLM` inherits `generate` from `MaskedDiffusionGenerationMixin` (via `LLaDAGenerationMixin`), which now handles `algorithm` and raises `ValueError` for `"ar"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest "tests/models/test_llada.py::TestLLaDAGeneration::test_llada_generate_runs_diffusion" "tests/models/test_llada.py::TestLLaDAGeneration::test_llada_generate_ar_raises" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add unturtle/models/backbones/llada/modeling_llada.py tests/models/test_llada.py
+git commit -m "♻️ refactor(llada): drop generate->diffusion_generate redirect, inherit mixin generate"
+```
+
+---
+
+## Task 6: Simplify `FastDiffusionModel.generate` to a thin forwarder
+
+**Files:**
+- Modify: `unturtle/fast_diffusion_model.py:1211-1258`
+- Test: `tests/test_fast_diffusion_generate.py` (redesigned in Task 7)
+
+- [ ] **Step 1: Replace the facade body**
+
+In `unturtle/fast_diffusion_model.py`, replace the `generate` staticmethod (lines ~1211-1258) with:
+
+```python
+    @staticmethod
+    def generate(
+        model: Any,
+        inputs: Any = None,
+        *,
+        algorithm: str = "auto",
+        **kwargs: Any,
+    ) -> Any:
+        """Generate from a dLLM via its unified ``generate`` entry point.
+
+        Thin facade that forwards to ``model.generate(inputs, algorithm=...)``.
+        Algorithm resolution (auto/mdlm/block_decode/bd3lm/ar) happens inside the
+        model's ``generate``. Output is whatever ``model.generate`` returns.
+
+        Args:
+            model: A dLLM model exposing ``generate`` (e.g. from
+                ``FastDiffusionModel.from_pretrained``).
+            inputs: Prompt token IDs (``[B, L]``).
+            algorithm: ``"auto"`` | ``"mdlm"`` | ``"block_decode"`` | ``"bd3lm"`` | ``"ar"``.
+            **kwargs: Forwarded to ``model.generate`` / the generation config.
+
+        Returns:
+            Whatever ``model.generate`` returns (token IDs or model output).
+        """
+        if not callable(getattr(model, "generate", None)):
+            raise TypeError(
+                f"{type(model).__name__} has no `generate` method; "
+                "FastDiffusionModel.generate requires a dLLM model."
+            )
+        return model.generate(inputs, algorithm=algorithm, **kwargs)
+```
+
+- [ ] **Step 2: Remove now-unused imports**
+
+In `unturtle/fast_diffusion_model.py`, remove the `resolve_algorithm` / `algorithm_to_flags` imports if they are no longer referenced anywhere else in the file. Verify with:
+
+Run: `grep -n "resolve_algorithm\|algorithm_to_flags" unturtle/fast_diffusion_model.py`
+Expected: no matches after the edit (remove the import line if present).
+
+- [ ] **Step 3: Run lint to confirm no unused imports**
+
+Run: `.venv/bin/python -m ruff check unturtle/fast_diffusion_model.py`
+Expected: PASS (no F401)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add unturtle/fast_diffusion_model.py
+git commit -m "♻️ refactor(fast-diffusion): simplify FastDiffusionModel.generate to thin forwarder"
+```
+
+---
+
+## Task 7: Redesign `tests/test_fast_diffusion_generate.py`
+
+**Files:**
+- Modify: `tests/test_fast_diffusion_generate.py` (full rewrite)
+
+The facade no longer resolves flags, so the old stub-records-flags tests are invalid. The facade's contract is now: "forward `inputs` + `algorithm` + kwargs to `model.generate`, and raise `TypeError` if the model has no `generate`." Flag-resolution parity is covered by the model-level tests (Tasks 2-5).
+
+- [ ] **Step 1: Rewrite the test file**
+
+Replace the entire contents of `tests/test_fast_diffusion_generate.py` with:
+
+```python
+from __future__ import annotations
+
+import pytest
+import torch
+
+from unturtle.fast_diffusion_model import FastDiffusionModel
+
+
+class _RecordingModel:
+    """Stub dLLM model: records the args its generate() receives."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def generate(self, inputs=None, *, algorithm="auto", **kwargs):  # noqa: ANN001, ANN003
+        self.calls.append({"inputs": inputs, "algorithm": algorithm, **kwargs})
+        return "GENERATED"
+
+
+def test_facade_forwards_inputs_and_algorithm() -> None:
+    model = _RecordingModel()
+    out = FastDiffusionModel.generate(model, inputs="X", algorithm="mdlm", steps=8)
+    assert out == "GENERATED"
+    call = model.calls[-1]
+    assert call["inputs"] == "X"
+    assert call["algorithm"] == "mdlm"
+    assert call["steps"] == 8
+
+
+def test_facade_default_algorithm_is_auto() -> None:
+    model = _RecordingModel()
+    FastDiffusionModel.generate(model, inputs="X")
+    assert model.calls[-1]["algorithm"] == "auto"
+
+
+def test_facade_passes_through_gen_kwargs() -> None:
+    model = _RecordingModel()
+    FastDiffusionModel.generate(
+        model, inputs="X", algorithm="block_decode", temperature=0.7, max_new_tokens=32
+    )
+    call = model.calls[-1]
+    assert call["temperature"] == 0.7
+    assert call["max_new_tokens"] == 32
+
+
+def test_facade_requires_generate() -> None:
+    class _NotADLLM:
+        pass
+
+    with pytest.raises(TypeError, match="generate"):
+        FastDiffusionModel.generate(_NotADLLM(), inputs="X")
+
+
+def _tiny_a2d_model():
+    from unturtle.models.conversion.a2d.tiny_a2d import (
+        TinyA2DLlamaConfig,
+        TinyA2DLlamaLMHeadModel,
+    )
+
+    config = TinyA2DLlamaConfig(
+        vocab_size=1000,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=128,
+        mask_token_id=999,
+    )
+    model = TinyA2DLlamaLMHeadModel(config)
+    model.eval()
+    return model
+
+
+@pytest.mark.parametrize("algorithm", ["mdlm", "block_decode"])
+def test_facade_parity_with_direct_generate(algorithm) -> None:
+    """Facade output equals calling model.generate directly with the same algorithm."""
+    model = _tiny_a2d_model()
+    prompt = torch.tensor([[1, 2, 3, 4]])
+    gen_kwargs = dict(
+        steps=4, max_new_tokens=4, temperature=0.0, mask_token_id=999, block_length=4
+    )
+
+    torch.manual_seed(0)
+    out_direct = model.generate(inputs=prompt, algorithm=algorithm, **gen_kwargs)
+
+    torch.manual_seed(0)
+    out_facade = FastDiffusionModel.generate(
+        model, inputs=prompt, algorithm=algorithm, **gen_kwargs
+    )
+
+    seq_direct = out_direct.sequences if hasattr(out_direct, "sequences") else out_direct
+    seq_facade = out_facade.sequences if hasattr(out_facade, "sequences") else out_facade
+    assert torch.equal(seq_direct, seq_facade)
+```
+
+- [ ] **Step 2: Run the redesigned test file**
+
+Run: `.venv/bin/python -m pytest tests/test_fast_diffusion_generate.py -v`
+Expected: PASS (all cases)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_fast_diffusion_generate.py
+git commit -m "✅ test(fast-diffusion): redesign facade tests for thin-forwarder contract"
+```
+
+---
+
+## Task 8: Rewrite model test files (`diffusion_generate` → `generate`)
+
+**Files:**
+- Modify: `tests/models/test_llada.py`, `tests/models/test_a2d.py`, `tests/models/test_dream.py`, `tests/models/test_block_decode.py`, `tests/models/test_parallel_decode.py`, `tests/models/test_block_decode_benchmark.py`, `tests/diffusion/test_block_diffusion_generator.py`
+
+These call `model.diffusion_generate(...)` directly. Replace the method name with `generate`. **Assertions are unchanged.** Where a call passes `use_cache=True` / `use_block_diffusion=True` flags directly, those still work (the model `generate` injects flags, and explicit flags in kwargs are honored by `_prepare_generation_config`). However, calls that pass `use_cache`/`use_block_diffusion` as the *only* selector and rely on default `algorithm="auto"` will still resolve correctly because auto picks block_decode for cache-capable models — verify each file's tests after replacement.
+
+- [ ] **Step 1: Replace `diffusion_generate` references with `generate` in each model test file**
+
+This replaces method-call sites, `callable(...)` assertions, and `hasattr(..., "diffusion_generate")` assertions (e.g. `test_generation_mixin_importable` in test_dream.py checks `hasattr(DreamGenerationMixin, "diffusion_generate")`).
+
+```bash
+.venv/bin/python - <<'PY'
+import pathlib
+files = [
+    "tests/models/test_llada.py",
+    "tests/models/test_a2d.py",
+    "tests/models/test_dream.py",
+    "tests/models/test_block_decode.py",
+    "tests/models/test_parallel_decode.py",
+    "tests/models/test_block_decode_benchmark.py",
+    "tests/diffusion/test_block_diffusion_generator.py",
+]
+for f in files:
+    p = pathlib.Path(f)
+    s = p.read_text()
+    s = s.replace(".diffusion_generate(", ".generate(")
+    s = s.replace("callable(model.diffusion_generate)", "callable(model.generate)")
+    s = s.replace("callable(llama_model.diffusion_generate)", "callable(llama_model.generate)")
+    # hasattr(...Mixin, "diffusion_generate") assertions
+    s = s.replace('"diffusion_generate"', '"generate"')
+    p.write_text(s)
+    print("rewrote", f)
+PY
+```
+
+- [ ] **Step 2: Fix `test_has_diffusion_generate` assertions**
+
+In `tests/models/test_llada.py` and `tests/models/test_a2d.py`, the existing `test_has_diffusion_generate` tests assert `callable(model.diffusion_generate)`. After the rewrite they assert `callable(model.generate)` (handled by Step 1's extra replacements). Rename these test functions for clarity:
+
+In `tests/models/test_llada.py`: rename `test_has_diffusion_generate` → `test_has_generate`.
+In `tests/models/test_a2d.py`: rename `test_has_diffusion_generate` → `test_has_generate`.
+
+Run to find them: `grep -rn "test_has_diffusion_generate" tests/models/`
+
+- [ ] **Step 3: Handle calls passing explicit `use_cache`/`use_block_diffusion`**
+
+Some tests (e.g. `test_block_decode.py`, `test_parallel_decode.py`) call `diffusion_generate(..., use_cache=True)`. After rename these become `generate(..., use_cache=True)`. The model `generate` resolves `algorithm="auto"` → for cache-capable models that yields `block_decode` (use_cache=True), and the explicit `use_cache=True` in kwargs is consistent. For BD3LM tests passing `use_block_diffusion=True`, `bd3lm_requested` is True so auto resolves to bd3lm. No assertion changes needed — verify in Step 4.
+
+- [ ] **Step 4: Run each rewritten file**
+
+Run: `.venv/bin/python -m pytest tests/models/test_llada.py tests/models/test_a2d.py tests/models/test_dream.py tests/models/test_block_decode.py tests/models/test_parallel_decode.py tests/diffusion/test_block_diffusion_generator.py -m "not slow" -v`
+Expected: PASS. If any FAIL on flag conflicts, the failing test passed `use_cache=False` while also relying on auto block_decode — set an explicit `algorithm=` in that call to match its original intent (document which in the commit).
+
+- [ ] **Step 5: Run the benchmark test file**
+
+Run: `.venv/bin/python -m pytest tests/models/test_block_decode_benchmark.py -m "not slow" -v`
+Expected: PASS (or skip if benchmark-gated)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/models/ tests/diffusion/test_block_diffusion_generator.py
+git commit -m "✅ test(models): route generation tests through unified generate()"
+```
+
+---
+
+## Task 9: Re-wire eval layer to `model.generate`
+
+**Files:**
+- Modify: `unturtle/eval/generation.py:108-113`, `unturtle/eval/gsm8k.py:98-110`, `unturtle/eval/harness/model_adapter.py:115-127`
+- Test: `tests/eval/test_evaluators.py`, `tests/eval/test_gsm8k.py`, `tests/eval/test_harness_adapter.py`
+
+- [ ] **Step 1: Update `eval/generation.py`**
+
+Replace the `getattr`-guarded block (lines ~108-113):
+
+```python
+        sequences = self.model.generate(prompt_ids, **generation_kwargs)
+```
+
+(removes the `diffusion_generate` getattr and the else-branch; all dLLMs now expose `generate`).
+
+- [ ] **Step 2: Update `eval/gsm8k.py`**
+
+Replace the `getattr`-guarded block (lines ~98 onward) with:
+
+```python
+        max_length = prompt_len + self.max_new_tokens
+        sequences = self.model.generate(
+            input_ids,
+            max_length=max_length,
+            steps=self.num_steps,
+            temperature=self.temperature,
+        )
+```
+
+(removes the `diffusion_generate` getattr, the `if callable` guard, and the warning else-branch).
+
+- [ ] **Step 3: Update `eval/harness/model_adapter.py`**
+
+Replace the `getattr`-guarded block (lines ~115-127). Change the docstring on line 77 from "through ``diffusion_generate``" to "through ``generate``", and the dispatch:
+
+```python
+            sequences = self._model.generate(
+                ...  # same kwargs as before, formerly passed to diffusion_generate
+            )
+```
+
+Keep the exact kwargs that were passed to `diffusion_generate` (read lines 117-125 and preserve them verbatim, only changing the method name to `generate`). Remove the `if callable(...)` guard and its `else` (the TypeError-raising branch on lines ~126).
+
+- [ ] **Step 4: Run eval tests**
+
+Run: `.venv/bin/python -m pytest tests/eval/ -m "not slow" -v`
+Expected: Some tests still reference `diffusion_generate` in stubs (handled next step). Production-code-driven tests PASS.
+
+- [ ] **Step 5: Rewrite eval test stubs**
+
+In `tests/eval/test_evaluators.py`, `tests/eval/test_gsm8k.py`, `tests/eval/test_harness_adapter.py`, any stub model that defines `diffusion_generate` must define `generate` instead. Replace:
+
+```bash
+.venv/bin/python - <<'PY'
+import pathlib
+files = [
+    "tests/eval/test_evaluators.py",
+    "tests/eval/test_gsm8k.py",
+    "tests/eval/test_harness_adapter.py",
+]
+for f in files:
+    p = pathlib.Path(f)
+    s = p.read_text()
+    s = s.replace("def diffusion_generate(", "def generate(")
+    s = s.replace(".diffusion_generate(", ".generate(")
+    p.write_text(s)
+    print("rewrote", f)
+PY
+```
+
+> If a stub's `generate` signature must accept `algorithm` (because the production code now passes it), check whether the eval call sites pass `algorithm`. The eval code in Steps 1-3 does NOT pass `algorithm` (defaults to auto inside the model), so stub `generate(self, inputs=None, **kwargs)` is sufficient. Verify after rewrite.
+
+- [ ] **Step 6: Run eval tests again**
+
+Run: `.venv/bin/python -m pytest tests/eval/ -m "not slow" -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add unturtle/eval/ tests/eval/
+git commit -m "♻️ refactor(eval): route generation/gsm8k/harness through unified generate()"
+```
+
+---
+
+## Task 10: Rewrite remaining example test + full-suite verification
+
+**Files:**
+- Modify: `tests/examples/test_benchmark_a2d_aligned.py`
+- Verify: whole not-slow suite
+
+- [ ] **Step 1: Rewrite the example test**
+
+Replace `.diffusion_generate(` with `.generate(` in `tests/examples/test_benchmark_a2d_aligned.py`:
+
+```bash
+.venv/bin/python - <<'PY'
+import pathlib
+p = pathlib.Path("tests/examples/test_benchmark_a2d_aligned.py")
+s = p.read_text()
+s = s.replace(".diffusion_generate(", ".generate(")
+p.write_text(s)
+print("rewrote", p)
+PY
+```
+
+- [ ] **Step 2: Confirm no `diffusion_generate` references remain anywhere**
+
+Run: `grep -rn "diffusion_generate" unturtle/ tests/ examples/ benchmarks/`
+Expected: NO matches. If any remain (e.g. in docstrings or benchmark scripts), update them to `generate`.
+
+- [ ] **Step 3: Run the focused fast suite**
+
+Run: `.venv/bin/python -m pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py tests/test_fast_diffusion_generate.py tests/test_e2e_integration.py tests/eval/ -m "not slow" -v`
+Expected: PASS
+
+- [ ] **Step 4: Run the full not-slow suite**
+
+Run: `.venv/bin/python -m pytest tests/ -m "not slow" -q`
+Expected: PASS (≥ 424 + new tests)
+
+- [ ] **Step 5: Lint and format**
+
+Run: `.venv/bin/python -m ruff check . && .venv/bin/python -m ruff format --check .`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/examples/test_benchmark_a2d_aligned.py
+git commit -m "✅ test(examples): route benchmark test through unified generate()"
+```
+
+---
+
+## Task 11: Update docs and CLAUDE.md references
+
+**Files:**
+- Modify: `CLAUDE.md`, `docs/dllm-gap-map.md` (if they reference `diffusion_generate`)
+
+- [ ] **Step 1: Find doc references**
+
+Run: `grep -rn "diffusion_generate" CLAUDE.md AGENTS.md docs/ README.md 2>/dev/null`
+
+- [ ] **Step 2: Update each reference**
+
+For each match, change `diffusion_generate` to `generate`. In `CLAUDE.md`, the "High-level generation" section describes `FastDiffusionModel.generate` delegating to `model.diffusion_generate(...)` — update it to say it delegates to `model.generate(..., algorithm=...)`. Update the gotcha line "Loss normalization should align with..." region if it mentions `diffusion_generate` (it does not, but verify). Update the algorithm list to include `"ar"`.
+
+Specifically, in `CLAUDE.md` replace:
+
+> It delegates to `model.diffusion_generate(...)` with the flag set the named algorithm implies
+
+with:
+
+> It delegates to `model.generate(..., algorithm=...)`, which resolves the named
+> algorithm to its decoding flags internally
+
+And add `"ar"` (TinyA2D autoregressive fallback) to the documented algorithm choices.
+
+- [ ] **Step 3: Verify no stale references**
+
+Run: `grep -rn "diffusion_generate" CLAUDE.md AGENTS.md docs/ README.md 2>/dev/null`
+Expected: NO matches (except possibly the design/plan specs themselves, which are historical records — leave those).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md docs/ README.md AGENTS.md 2>/dev/null
+git commit -m "📚 docs: update generation references to unified generate() API"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Section 2 (signature/dispatch) → Tasks 2, 6. Section 3 (TinyA2D AR + MRO) → Tasks 1, 3. Section 4 (eval/facade/tests rewiring) → Tasks 6, 8, 9, 10. Section 5 (stages/tests/risks) → all tasks; AR regression + ValueError tests → Tasks 3, 5. `_supports_ar` → Task 1.
+- **`ar` dispatch single-source-of-truth:** TinyA2D short-circuits `ar` before `resolve_algorithm` (Task 3); pure dLLM reaches `resolve_algorithm` which raises (Tasks 2, 5). Matches spec.
+- **No backward-compat alias:** `diffusion_generate` fully removed; Task 10 Step 2 asserts zero remaining references.
+- **Type consistency:** `generate(inputs, *, algorithm="auto", generation_config=None, **kwargs)` used identically in base mixin (Task 2), TinyA2D override (Task 3), Dream (Task 4), and facade forwarder (Task 6).

--- a/docs/superpowers/specs/2026-06-11-generate-api-unification-design.md
+++ b/docs/superpowers/specs/2026-06-11-generate-api-unification-design.md
@@ -1,0 +1,247 @@
+# Generate API Unification — Design
+
+**Date:** 2026-06-11
+**Status:** Approved (design)
+**Scope:** Single PR. Precursor sub-project to the DiffusionGemma backbone addition.
+
+## Goal
+
+Unify the dLLM inference entry point on the transformers-standard `model.generate()`.
+`diffusion_generate` is **removed entirely** (the repository is being rebuilt, so no
+backward-compatibility alias is kept). Diffusion generation becomes the default behavior
+of `generate()`.
+
+This aligns Unturtle with the HF ecosystem and matches the convention DiffusionGemma adopts
+upstream (`model.generate()` returns diffusion output), making the subsequent DiffusionGemma
+backbone addition clean.
+
+## Current structure
+
+```
+FastDiffusionModel.generate(model, inputs, algorithm="auto", **kw)   # static helper
+  └─ resolve_algorithm() → algorithm_to_flags() → model.diffusion_generate(**flags)
+
+MaskedDiffusionGenerationMixin.diffusion_generate(...)   # shared infra (LLaDA / TinyA2D)
+DreamGenerationMixin.diffusion_generate(...)             # Dream-specific
+LLaDAModelLM.generate(...) → self.diffusion_generate(...)  # already redirects
+```
+
+Inheritance:
+
+```
+MaskedDiffusionGenerationMixin (defines diffusion_generate)
+  ├─ LLaDAGenerationMixin (+ BlockDecodeMixin) → LLaDAModelLM (generate→diffusion_generate redirect)
+  ├─ MaskedDiffusionBlockGenerationMixin → TinyA2DGenerationMixin → TinyA2D{Llama,Qwen2,Qwen3}
+  └─ DreamGenerationMixin (BlockDecodeMixin only, own diffusion_generate)
+```
+
+TinyA2D additionally inherits `transformers.{Llama,Qwen}ForCausalLM`, so it has a working
+**AR `generate()`** — this is why `diffusion_generate` historically existed under a separate
+name.
+
+## Target structure
+
+```
+model.generate(inputs, algorithm="auto", **kw)          # sole generation entry (diffusion default)
+  ├─ pure dLLM (LLaDA/Dream): generate = diffusion dispatch
+  └─ TinyA2D: generate = diffusion default; algorithm="ar" → transformers AR generate
+
+FastDiffusionModel.generate(model, inputs, algorithm=...)  # thin facade → model.generate
+```
+
+`diffusion_generate` disappears from infra, backbones, eval, and tests.
+
+## Section 2 — `generate()` signature and algorithm dispatch
+
+The shared infra method `diffusion_generate` on `MaskedDiffusionGenerationMixin` is
+**renamed to `generate`** and accepts `algorithm` as a first-class keyword-only parameter.
+This base `generate` handles only diffusion paths — it has **no `ar` branch**, because the
+pure-dLLM backbones that inherit it (LLaDA/Dream) do not have a `transformers.GenerationMixin`
+in their MRO (verified: `LLaDAModelLM.__mro__` reaches `PreTrainedModel` directly, no
+`GenerationMixin`), so `super().generate()` would `AttributeError`. The `ar` branch lives
+only on the TinyA2D mixin (Section 3).
+
+```python
+def generate(
+    self,
+    inputs=None,
+    *,
+    algorithm="auto",          # "auto"|"mdlm"|"block_decode"|"bd3lm"
+    generation_config=None,
+    **kwargs,
+):
+    resolved = resolve_algorithm(algorithm, self, bd3lm_requested=...)
+    # resolve_algorithm raises ValueError if algorithm=="ar" and the model is
+    # not AR-capable, so "ar" never reaches this diffusion-only path.
+    flags = algorithm_to_flags(resolved)   # use_cache / use_block_diffusion
+    # then: the existing diffusion_generate body (_prepare_*, _sample) unchanged
+```
+
+`bd3lm_requested` is computed exactly as the current facade does it:
+`bool(kwargs.get("use_block_diffusion", False)) or algorithm == "bd3lm"`.
+
+The algorithm→flags resolution currently living in `FastDiffusionModel.generate` moves
+**down into the model's `generate()`**. `sampler.py`'s `resolve_algorithm` /
+`algorithm_to_flags` are reused as-is.
+
+`sampler.py` gains the `"ar"` concept: `resolve_algorithm` returns `"ar"` verbatim and the
+backbone `generate()` branches before `algorithm_to_flags` is ever called for `"ar"`.
+
+`FastDiffusionModel.generate` becomes a simple forwarder:
+
+```python
+@staticmethod
+def generate(model, inputs=None, *, algorithm="auto", **kwargs):
+    if not callable(getattr(model, "generate", None)):
+        raise TypeError(...)
+    return model.generate(inputs, algorithm=algorithm, **kwargs)
+```
+
+`resolve_algorithm` / `algorithm_to_flags` imports leave the facade and move to the model layer.
+
+### Backbone behavior
+
+| backbone | `generate` behavior |
+|---|---|
+| LLaDA | Remove the `generate→diffusion_generate` redirect. Inherit `MaskedDiffusionGenerationMixin.generate` (diffusion default). |
+| Dream | Rename `DreamGenerationMixin.diffusion_generate` → `generate`. Add `algorithm` acceptance. |
+| TinyA2D | `MaskedDiffusionBlockGenerationMixin.generate` (diffusion default). `algorithm="ar"` → `super().generate()` (transformers AR). MRO puts the mixin first, so diffusion wins by default. |
+
+## Section 3 — TinyA2D AR fallback and MRO
+
+The verified TinyA2D Llama MRO (with each class that *defines* `generate`):
+
+```
+TinyA2DLlamaLMHeadModel              (no generate)
+TinyA2DGenerationMixin               (no generate)
+MaskedDiffusionBlockGenerationMixin  (defines generate — Section 3 override, added here)
+BlockDecodeMixin                     (no generate)
+MaskedDiffusionGenerationMixin       (defines generate — Section 2 base, added here)
+LlamaForCausalLM                     (no generate)
+LlamaPreTrainedModel / PreTrainedModel / nn.Module / ...
+GenerationMixin                      (defines generate — transformers AR)   ← last
+ContinuousMixin / object
+```
+
+Today, **only `GenerationMixin.generate` exists** (the diffusion entry is `diffusion_generate`,
+a different name, so there is no `generate` collision yet). After this change two new `generate`
+definitions are inserted *before* `GenerationMixin` in the MRO, so by default a diffusion
+`generate` wins — exactly the desired behavior.
+
+`MaskedDiffusionBlockGenerationMixin` (the TinyA2D-only mixin) **overrides `generate`** to add
+the `algorithm="ar"` branch:
+
+```python
+def generate(self, inputs=None, *, algorithm="auto", generation_config=None, **kwargs):
+    if algorithm == "ar":
+        # super() walks the MRO past MaskedDiffusionGenerationMixin and LlamaForCausalLM
+        # (neither defines generate) down to transformers GenerationMixin.generate (AR).
+        return super().generate(inputs, generation_config=generation_config, **kwargs)
+    # delegate all diffusion algorithms to the base mixin's generate (Section 2),
+    # called explicitly by class so we skip GenerationMixin entirely.
+    return MaskedDiffusionGenerationMixin.generate(
+        self, inputs, algorithm=algorithm, generation_config=generation_config, **kwargs
+    )
+```
+
+Why the two call styles differ:
+
+- **`ar` path uses `super()`** — verified to reach `GenerationMixin.generate` (transformers AR),
+  since no intervening MRO class defines `generate`.
+- **diffusion path calls `MaskedDiffusionGenerationMixin.generate` explicitly by class** — a
+  bare `super()` from `MaskedDiffusionBlockGenerationMixin` would *also* land on the base
+  diffusion mixin (correct), but routing the `algorithm` kwarg through it explicitly keeps the
+  dispatch obvious and independent of future MRO insertions. The AR regression test pins both
+  paths.
+
+### Where `algorithm="ar"` is dispatched vs. rejected
+
+The `ar` value is handled at two different layers depending on the backbone:
+
+- **TinyA2D** inherits `MaskedDiffusionBlockGenerationMixin.generate`, whose `ar` branch fires
+  *before* `resolve_algorithm` is consulted. So for TinyA2D, `resolve_algorithm` only ever sees
+  diffusion algorithm names.
+- **LLaDA/Dream** do *not* inherit the TinyA2D mixin (no `ar` branch). Their `generate` is the
+  base `MaskedDiffusionGenerationMixin.generate`, which calls `resolve_algorithm(algorithm, self, ...)`
+  directly. There, `resolve_algorithm` raises `ValueError`
+  ("this model does not support autoregressive generation") when `algorithm == "ar"` and the
+  model is not AR-capable.
+
+This keeps a single source of truth: `resolve_algorithm` rejects `ar` for non-AR-capable models;
+the TinyA2D mixin short-circuits `ar` before reaching it.
+
+### `_supports_ar`
+
+Added to `sampler.py`, **model_type based** (TinyA2D family → AR-capable). model_type checking
+is preferred over MRO traversal for robustness. `resolve_algorithm` uses it: `algorithm == "ar"`
+with `_supports_ar(model) is False` → `ValueError`; otherwise `"ar"` is returned verbatim (the
+caller's `ar` branch will have already handled it for AR-capable models).
+
+## Section 4 — eval / facade / caller re-wiring
+
+### eval layer
+
+`getattr(model, "diffusion_generate", None)` existence checks (`eval/generation.py:108`,
+`eval/gsm8k.py:98`) become direct `model.generate(...)` calls. All dLLMs expose `generate`, so
+the existence check is dropped.
+
+### harness adapter
+
+`eval/harness` (lm-eval) paths that reach `diffusion_generate` are likewise pointed at `generate`.
+
+### Tests (12 files / ~99 sites)
+
+Mechanical replacement: `.diffusion_generate(` → `.generate(`. `FastDiffusionModel.generate`
+calls keep their arguments (facade name unchanged). **Assertions (expected outputs) are not
+changed** — behavioral contract preserved. After replacement, each file's tests are run to
+confirm green.
+
+### Removed symbols
+
+- `MaskedDiffusionGenerationMixin.diffusion_generate` (→ `generate`)
+- `DreamGenerationMixin.diffusion_generate` (→ `generate`)
+- `LLaDAModelLM.generate` redirect implementation (replaced by mixin inheritance)
+- `diffusion_generate` references inside `FastDiffusionModel`
+
+## Section 5 — implementation stages, tests, risks
+
+### Stages (1 PR)
+
+1. **infra**: rename `MaskedDiffusionGenerationMixin.diffusion_generate` → `generate`
+   (accept `algorithm` + `ar` branch). Same for `MaskedDiffusionBlockGenerationMixin`. Add
+   `_supports_ar` (model_type based) to `sampler.py`.
+2. **backbones**: rename Dream, remove LLaDA redirect, TinyA2D inherits automatically.
+3. **facade**: simplify `FastDiffusionModel.generate` to a forwarder, tidy imports.
+4. **eval**: repoint `generation.py` / `gsm8k.py` / harness `diffusion_generate` references to
+   `generate`.
+5. **tests**: mechanical replace across 12 files, confirm green per-file.
+6. **whole suite**: not-slow suite green (transformers 5.11: 424 tests + replaced sites).
+
+### Test strategy
+
+- Existing ~99 sites become `generate`-routed with **unchanged assertions** (behavioral
+  contract).
+- New: 1–2 regression tests — TinyA2D produces AR output for `algorithm="ar"`; LLaDA/Dream
+  raise `ValueError`.
+- Update the `FastDiffusionModel.generate` → `model.generate` forwarding unit test (mock).
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| `algorithm` kwarg collides with the transformers `generate` signature | dLLM `generate` defines `algorithm` keyword-only; AR path does not forward `algorithm` to `super().generate()`. |
+| TinyA2D MRO prioritizes AR generate over diffusion | model_type check + `super().generate()` explicit reach; covered by regression test. |
+| Dropping the eval existence check lets a non-dLLM slip in | eval is dLLM-only; type errors surface early. |
+
+### YAGNI
+
+- DiffusionGemma itself is **not** in this PR (next sub-project). This PR is the `generate`
+  unification only.
+- No backward-compatibility alias (repository being rebuilt).
+
+## Invariants preserved
+
+- Output (token IDs / model output) identical to current behavior. Only the generation entry
+  is re-wired.
+- Bidirectional attention and MDLM loss semantics untouched.
+- TinyA2D's AR generation path is retained via `algorithm="ar"` (pre-conversion behavior not lost).

--- a/docs/superpowers/specs/2026-06-11-generate-api-unification-design.md
+++ b/docs/superpowers/specs/2026-06-11-generate-api-unification-design.md
@@ -1,7 +1,7 @@
 # Generate API Unification — Design
 
 **Date:** 2026-06-11
-**Status:** Approved (design)
+**Status:** Approved (design) — amended 2026-06-12 (see Amendment)
 **Scope:** Single PR. Precursor sub-project to the DiffusionGemma backbone addition.
 
 ## Goal
@@ -244,4 +244,22 @@ confirm green.
 - Output (token IDs / model output) identical to current behavior. Only the generation entry
   is re-wired.
 - Bidirectional attention and MDLM loss semantics untouched.
-- TinyA2D's AR generation path is retained via `algorithm="ar"` (pre-conversion behavior not lost).
+- ~~TinyA2D's AR generation path is retained via `algorithm="ar"`~~ — dropped, see Amendment.
+
+## Amendment — 2026-06-12 (issue #22)
+
+`algorithm="ar"` is **dropped** from this design (decided during implementation review):
+
+- A converted Tiny-A2D checkpoint is a diffusion model; AR decoding of converted weights is
+  not a supported use case, and no in-repo consumer exists (benchmarks / eval / CLI are
+  diffusion-only).
+- Pre-conversion sanity checks can call `transformers.GenerationMixin.generate(model, ...)`
+  explicitly as an escape hatch.
+- Consequences: `_supports_ar` / `_AR_CAPABLE_MODEL_TYPES` / the `"ar"` branch in
+  `resolve_algorithm` are not implemented (Section 3's `_supports_ar` subsection is void).
+  `MaskedDiffusionBlockGenerationMixin` needs **no `generate` override** — the base mixin's
+  `generate` already precedes `transformers.GenerationMixin` in the TinyA2D MRO, so diffusion
+  wins by default (pinned by a regression test). `algorithm="ar"` now fails as an unknown
+  algorithm (`ValueError` from `resolve_algorithm`) for every model.
+- The `"ar"` concept can be reintroduced when a hybrid AR/diffusion backbone
+  (e.g. Nemotron-Diffusion) lands; the algorithm registry remains open for it.

--- a/examples/benchmark_a2d_aligned.py
+++ b/examples/benchmark_a2d_aligned.py
@@ -124,7 +124,7 @@ def describe_backend_path(mode: str, backend: str) -> str:
         if mode == "aligned-warm":
             return "block_diffusion_generator"
         if mode == "validator-warm":
-            return "diffusion_generate"
+            return "generate"
     if backend == "dllm" and mode in {"aligned-warm", "validator-warm"}:
         return "bd3lm_sampler"
     return f"{backend}:{mode}"
@@ -243,9 +243,7 @@ def run_unturtle_validator_once(run: RunSpec) -> tuple[str, dict[str, Any], int 
         **build_validator_generation_kwargs(run.settings),
         mask_token_id=mask_token_id,
     )
-    outputs = model.diffusion_generate(
-        inputs=input_ids, generation_config=generation_config
-    )
+    outputs = model.generate(inputs=input_ids, generation_config=generation_config)
     generated_tokens = outputs[:, input_ids.shape[1] :]
     text = tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)[0]
     token_count = int(outputs.shape[1] - input_ids.shape[1])

--- a/examples/benchmark_a2d_aligned.py
+++ b/examples/benchmark_a2d_aligned.py
@@ -243,7 +243,9 @@ def run_unturtle_validator_once(run: RunSpec) -> tuple[str, dict[str, Any], int 
         **build_validator_generation_kwargs(run.settings),
         mask_token_id=mask_token_id,
     )
-    outputs = model.generate(inputs=input_ids, generation_config=generation_config)
+    outputs = model.generate(
+        inputs=input_ids, generation_config=generation_config, algorithm="mdlm"
+    )
     generated_tokens = outputs[:, input_ids.shape[1] :]
     text = tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)[0]
     token_count = int(outputs.shape[1] - input_ids.shape[1])

--- a/examples/validate_a2d_real_inference.py
+++ b/examples/validate_a2d_real_inference.py
@@ -235,7 +235,9 @@ def run_unturtle_once(run: RunSpec) -> tuple[str, dict[str, Any], int | None]:
         **generation_kwargs,
         mask_token_id=mask_token_id,
     )
-    outputs = model.generate(inputs=input_ids, generation_config=generation_config)
+    outputs = model.generate(
+        inputs=input_ids, generation_config=generation_config, algorithm="mdlm"
+    )
     text = tokenizer.batch_decode(
         outputs[:, input_ids.shape[1] :], skip_special_tokens=True
     )[0]

--- a/examples/validate_a2d_real_inference.py
+++ b/examples/validate_a2d_real_inference.py
@@ -235,9 +235,7 @@ def run_unturtle_once(run: RunSpec) -> tuple[str, dict[str, Any], int | None]:
         **generation_kwargs,
         mask_token_id=mask_token_id,
     )
-    outputs = model.diffusion_generate(
-        inputs=input_ids, generation_config=generation_config
-    )
+    outputs = model.generate(inputs=input_ids, generation_config=generation_config)
     text = tokenizer.batch_decode(
         outputs[:, input_ids.shape[1] :], skip_special_tokens=True
     )[0]

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,10 @@ echo "==> installing build/test tooling"
 uv pip install "setuptools==80.9.0" "setuptools-scm==9.2.0" pytest ruff bitsandbytes
 
 echo "==> installing unturtle (editable) + huggingface extras"
+# unsloth 2026.6.x pins transformers<=5.5.0, but DiffusionGemma and upcoming models
+# require transformers>=5.8.0.  Install transformers first so uv keeps the newer
+# build; unsloth/unsloth_zoo have no runtime version enforcement (verified 2026-06-11).
+uv pip install "transformers>=5.8.0"
 uv pip install -e ".[huggingface]"
 
 if [[ "${1:-}" == "--eval" ]]; then

--- a/tests/diffusion/test_block_diffusion_generator.py
+++ b/tests/diffusion/test_block_diffusion_generator.py
@@ -91,7 +91,7 @@ class TestPrepareForSampling:
 
 
 # ---------------------------------------------------------------------------
-# BD3LM generation via model.diffusion_generate(use_block_diffusion=True)
+# BD3LM generation via model.generate(use_block_diffusion=True)
 # ---------------------------------------------------------------------------
 
 
@@ -102,7 +102,7 @@ class TestBD3LMViaModelAPI:
         max_new_tokens = 4
         padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -120,7 +120,7 @@ class TestBD3LMViaModelAPI:
         max_new_tokens = 8
         padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -137,7 +137,7 @@ class TestBD3LMViaModelAPI:
         max_new_tokens = 8
         padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -155,7 +155,7 @@ class TestBD3LMViaModelAPI:
         max_new_tokens = 4
         padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -175,7 +175,7 @@ class TestBD3LMViaModelAPI:
         max_new_tokens = 4
         padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -196,7 +196,7 @@ class TestBD3LMViaModelAPI:
         max_new_tokens = 8
         padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -260,7 +260,7 @@ def test_diffusion_stream_callback_called_with_x_snapshot():
         return_dict=False,
         stream_callback=stream_cb,
     )
-    _ = model.diffusion_generate(prompt, generation_config=cfg)
+    _ = model.generate(prompt, generation_config=cfg)
 
     assert [c[0] for c in called] == [1, 2, 3]
     assert all(c[1] == 3 for c in called)

--- a/tests/eval/test_evaluators.py
+++ b/tests/eval/test_evaluators.py
@@ -52,9 +52,7 @@ class TinyDiffusionModel(torch.nn.Module):
         self.dummy = torch.nn.Parameter(torch.zeros(1))
         self.config = type("Config", (), {"mask_token_id": mask_token_id})()
 
-    def diffusion_generate(
-        self, input_ids, max_length=None, attention_mask=None, **_kwargs
-    ):
+    def generate(self, input_ids, max_length=None, attention_mask=None, **_kwargs):
         self.calls += 1
         self.last_attention_mask = (
             attention_mask.clone() if attention_mask is not None else None
@@ -170,7 +168,7 @@ class TestGenerationEvaluator:
         }
         assert metrics["gen_num_examples"] == 1.0
 
-    def test_generation_uses_diffusion_generate(self):
+    def test_generation_uses_generate(self):
         model = TinyDiffusionModel()
         evaluator = GenerationEvaluator(model=model, tokenizer=None)
         dataset = [{"input_ids": [1, 2, 3, 0], "references": [7]}]

--- a/tests/eval/test_gsm8k.py
+++ b/tests/eval/test_gsm8k.py
@@ -85,9 +85,20 @@ class _CorrectAnswerModel(torch.nn.Module):
         super().__init__()
         self.dummy = torch.nn.Parameter(torch.zeros(1))
         self.calls = 0
+        self.last_algorithm: str | None = None
 
-    def generate(self, input_ids, max_length=None, steps=None, temperature=None, **_kw):
+    def generate(
+        self,
+        input_ids,
+        *,
+        algorithm="auto",
+        max_length=None,
+        steps=None,
+        temperature=None,
+        **_kw,
+    ):
         self.calls += 1
+        self.last_algorithm = algorithm
         pad = torch.full((input_ids.shape[0], 1), 7, dtype=input_ids.dtype)
         return torch.cat([input_ids, pad], dim=1)
 
@@ -225,3 +236,4 @@ class TestGSM8KEvaluator:
 
         evaluator.evaluate()
         assert model.calls == 1
+        assert model.last_algorithm == "mdlm"

--- a/tests/eval/test_gsm8k.py
+++ b/tests/eval/test_gsm8k.py
@@ -54,7 +54,7 @@ class TestExtractNumericAnswer:
 
 
 # ---------------------------------------------------------------------------
-# Stub model — mimics diffusion_generate behaviour without real weights
+# Stub model — mimics generate behaviour without real weights
 # ---------------------------------------------------------------------------
 
 
@@ -86,9 +86,7 @@ class _CorrectAnswerModel(torch.nn.Module):
         self.dummy = torch.nn.Parameter(torch.zeros(1))
         self.calls = 0
 
-    def diffusion_generate(
-        self, input_ids, max_length=None, steps=None, temperature=None, **_kw
-    ):
+    def generate(self, input_ids, max_length=None, steps=None, temperature=None, **_kw):
         self.calls += 1
         pad = torch.full((input_ids.shape[0], 1), 7, dtype=input_ids.dtype)
         return torch.cat([input_ids, pad], dim=1)
@@ -210,7 +208,7 @@ class TestGSM8KEvaluator:
         metrics = evaluator.evaluate(num_examples=3)
         assert metrics["gsm8k_num_examples"] == 3.0
 
-    def test_evaluate_uses_diffusion_generate(self, monkeypatch):
+    def test_evaluate_uses_generate(self, monkeypatch):
         tok = _StubTokenizer()
         tok._answer = r"\boxed{2}"
         model = _CorrectAnswerModel()

--- a/tests/eval/test_harness_adapter.py
+++ b/tests/eval/test_harness_adapter.py
@@ -34,7 +34,7 @@ class _StubModel:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
 
-    def diffusion_generate(self, input_ids, **kwargs):
+    def generate(self, input_ids, **kwargs):
         import torch
 
         self.calls.append(kwargs)
@@ -74,7 +74,7 @@ def test_build_harness_lm_requires_lm_eval(monkeypatch: pytest.MonkeyPatch) -> N
         )
 
 
-def test_generate_until_routes_through_diffusion_generate(
+def test_generate_until_routes_through_generate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_lm_eval(monkeypatch)
@@ -91,7 +91,7 @@ def test_generate_until_routes_through_diffusion_generate(
     )
     out = lm.generate_until([_FakeInstance("Q: 2+2?", {"until": ["STOP"]})])
     assert isinstance(out, list) and len(out) == 1
-    assert model.calls, "diffusion_generate was not called"
+    assert model.calls, "generate was not called"
     assert "STOP" not in out[0]
     assert out[0].startswith("the answer is 42")
 

--- a/tests/eval/test_harness_adapter.py
+++ b/tests/eval/test_harness_adapter.py
@@ -94,6 +94,10 @@ def test_generate_until_routes_through_generate(
     assert model.calls, "generate was not called"
     assert "STOP" not in out[0]
     assert out[0].startswith("the answer is 42")
+    # Verify steps, temperature, and mask_token_id are forwarded correctly
+    assert model.calls[-1]["steps"] == 4
+    assert model.calls[-1]["temperature"] == 0.0
+    assert model.calls[-1]["mask_token_id"] is None
 
 
 def test_generate_until_handles_string_until(

--- a/tests/eval/test_harness_adapter.py
+++ b/tests/eval/test_harness_adapter.py
@@ -34,10 +34,10 @@ class _StubModel:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
 
-    def generate(self, input_ids, **kwargs):
+    def generate(self, input_ids, *, algorithm="auto", **kwargs):
         import torch
 
-        self.calls.append(kwargs)
+        self.calls.append({"algorithm": algorithm, **kwargs})
         new = torch.tensor([[101, 102, 103]])
         return torch.cat([input_ids, new], dim=1)
 
@@ -94,10 +94,11 @@ def test_generate_until_routes_through_generate(
     assert model.calls, "generate was not called"
     assert "STOP" not in out[0]
     assert out[0].startswith("the answer is 42")
-    # Verify steps, temperature, and mask_token_id are forwarded correctly
+    # Verify steps, temperature, mask_token_id, and algorithm pin are forwarded correctly
     assert model.calls[-1]["steps"] == 4
     assert model.calls[-1]["temperature"] == 0.0
     assert model.calls[-1]["mask_token_id"] is None
+    assert model.calls[-1]["algorithm"] == "mdlm"
 
 
 def test_generate_until_handles_string_until(

--- a/tests/examples/test_benchmark_a2d_aligned.py
+++ b/tests/examples/test_benchmark_a2d_aligned.py
@@ -533,7 +533,7 @@ def test_describe_backend_path_returns_approved_task3_labels():
     assert (
         describe_backend_path("aligned-warm", "unturtle") == "block_diffusion_generator"
     )
-    assert describe_backend_path("validator-warm", "unturtle") == "diffusion_generate"
+    assert describe_backend_path("validator-warm", "unturtle") == "generate"
     assert describe_backend_path("aligned-warm", "dllm") == "bd3lm_sampler"
     assert describe_backend_path("validator-warm", "dllm") == "bd3lm_sampler"
 

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -681,19 +681,33 @@ class TestA2DGeneration:
         s_bd3lm = out_bd3lm.sequences if hasattr(out_bd3lm, "sequences") else out_bd3lm
         assert torch.equal(s_auto, s_bd3lm)
 
-    def test_generate_resolves_to_diffusion_mixin(self, llama_model):
+    @pytest.mark.parametrize(
+        "model_cls_name",
+        [
+            "TinyA2DLlamaLMHeadModel",
+            "TinyA2DQwen2LMHeadModel",
+            "TinyA2DQwen3LMHeadModel",
+        ],
+    )
+    def test_generate_resolves_to_diffusion_mixin(self, model_cls_name):
         from transformers.generation import GenerationMixin
 
+        from unturtle.models.conversion.a2d import tiny_a2d
         from unturtle.models.generation.diffusion_generation_utils import (
             MaskedDiffusionGenerationMixin,
         )
 
-        resolved = type(llama_model).generate
+        model_cls = getattr(tiny_a2d, model_cls_name)
+        resolved = model_cls.generate
+        # Intentionally strict identity pin: ANY override of generate on a TinyA2D
+        # class must be a conscious, reviewed decision (it risks shadowing the
+        # diffusion path with transformers' AR generate).
         assert resolved is MaskedDiffusionGenerationMixin.generate
         assert resolved is not GenerationMixin.generate
 
     def test_generate_ar_is_unknown_algorithm(self, llama_model):
         prompt = torch.tensor([[1, 2, 3, 4]])
+        # ValueError fires at algorithm resolution, before any masking/token work.
         with pytest.raises(ValueError, match="Unknown decoding algorithm"):
             llama_model.generate(prompt, algorithm="ar", max_new_tokens=4)
 

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -448,12 +448,12 @@ class TestFlashVarlenCompaction:
 
 
 # ---------------------------------------------------------------------------
-# A2D generation (diffusion_generate)
+# A2D generation (generate)
 # ---------------------------------------------------------------------------
 
 
 class TestA2DGeneration:
-    """Tests for TinyA2DGenerationMixin.diffusion_generate on tiny CPU models."""
+    """Tests for TinyA2DGenerationMixin.generate on tiny CPU models."""
 
     MASK_TOKEN_ID = 999
 
@@ -479,11 +479,11 @@ class TestA2DGeneration:
         model = TinyA2DLlamaLMHeadModel(llama_config).eval()
         return model
 
-    def test_has_diffusion_generate(self, llama_model):
+    def test_has_generate(self, llama_model):
         from unturtle.models.conversion.a2d.tiny_a2d import TinyA2DGenerationMixin
 
         assert isinstance(llama_model, TinyA2DGenerationMixin)
-        assert callable(llama_model.diffusion_generate)
+        assert callable(llama_model.generate)
 
     def test_output_shape(self, llama_model, llama_config):
         """Output shape should be [B, max_length].
@@ -498,7 +498,7 @@ class TestA2DGeneration:
         mask_fill = torch.full((B, L_new), self.MASK_TOKEN_ID, dtype=torch.long)
         input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
         with torch.no_grad():
-            out = llama_model.diffusion_generate(
+            out = llama_model.generate(
                 input_ids_full,
                 steps=3,
                 mask_token_id=self.MASK_TOKEN_ID,
@@ -514,7 +514,7 @@ class TestA2DGeneration:
         mask_fill = torch.full((B, L_new), self.MASK_TOKEN_ID, dtype=torch.long)
         input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
         with torch.no_grad():
-            out = llama_model.diffusion_generate(
+            out = llama_model.generate(
                 input_ids_full,
                 steps=3,
                 mask_token_id=self.MASK_TOKEN_ID,
@@ -522,7 +522,7 @@ class TestA2DGeneration:
             )
         # Original prompt positions were NOT mask tokens → should be preserved
         assert (out[0, :L_prompt] == prompt_ids[0]).all(), (
-            "Prompt tokens should not be overwritten by diffusion_generate"
+            "Prompt tokens should not be overwritten by generate"
         )
 
     def test_deterministic_with_seed(self, llama_model, llama_config):
@@ -531,7 +531,7 @@ class TestA2DGeneration:
         input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
         with torch.no_grad():
             torch.manual_seed(42)
-            out1 = llama_model.diffusion_generate(
+            out1 = llama_model.generate(
                 input_ids.clone(),
                 steps=2,
                 mask_token_id=self.MASK_TOKEN_ID,
@@ -539,7 +539,7 @@ class TestA2DGeneration:
                 max_length=L + 1,
             )
             torch.manual_seed(42)
-            out2 = llama_model.diffusion_generate(
+            out2 = llama_model.generate(
                 input_ids.clone(),
                 steps=2,
                 mask_token_id=self.MASK_TOKEN_ID,
@@ -553,7 +553,7 @@ class TestA2DGeneration:
         B, L = 1, 6
         input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
         with torch.no_grad():
-            out = llama_model.diffusion_generate(
+            out = llama_model.generate(
                 input_ids,
                 steps=1,
                 mask_token_id=self.MASK_TOKEN_ID,
@@ -570,7 +570,7 @@ class TestA2DGeneration:
         B, L = 1, 4
         input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
         with torch.no_grad():
-            out = llama_model.diffusion_generate(
+            out = llama_model.generate(
                 input_ids,
                 steps=2,
                 mask_token_id=self.MASK_TOKEN_ID,
@@ -585,7 +585,7 @@ class TestA2DGeneration:
         B, L = 1, 6
         input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
         with torch.no_grad():
-            out = llama_model.diffusion_generate(
+            out = llama_model.generate(
                 input_ids,
                 steps=3,
                 mask_token_id=self.MASK_TOKEN_ID,
@@ -599,7 +599,7 @@ class TestA2DGeneration:
         B, L = 1, 6
         input_ids = torch.full((B, L), self.MASK_TOKEN_ID, dtype=torch.long)
         with torch.no_grad():
-            out = llama_model.diffusion_generate(
+            out = llama_model.generate(
                 input_ids,
                 steps=2,
                 mask_token_id=self.MASK_TOKEN_ID,
@@ -615,7 +615,7 @@ class TestA2DGeneration:
         attention_mask = torch.ones((B, L), dtype=torch.long)
         attention_mask[1, -2:] = 0  # simulate padding in second sample
         with torch.no_grad():
-            out = llama_model.diffusion_generate(
+            out = llama_model.generate(
                 input_ids,
                 attention_mask=attention_mask,
                 steps=2,
@@ -1145,9 +1145,7 @@ class TestA2DBlockDecode:
         )
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
-                inputs=input_ids, generation_config=gen_config
-            )
+            output = tiny_model.generate(inputs=input_ids, generation_config=gen_config)
 
         # Basic shape check
         assert output.shape[0] == 1
@@ -1181,7 +1179,7 @@ class TestA2DBlockDecode:
             temperature=0.0,
         )
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=input_ids, generation_config=gen_config_block
             )
 
@@ -1227,9 +1225,7 @@ class TestA2DBlockDecode:
 
         monkeypatch.setattr(tiny_model, "_block_decode_loop", fake_block_decode_loop)
 
-        output = tiny_model.diffusion_generate(
-            inputs=input_ids, generation_config=gen_config
-        )
+        output = tiny_model.generate(inputs=input_ids, generation_config=gen_config)
 
         assert captured == {"use_replace_cache": False}
         assert output.shape == (1, 12)
@@ -1333,7 +1329,7 @@ class TestA2DBlockDiffusionGeneration:
         block_size = 4
         max_new_tokens = 8
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -1350,7 +1346,7 @@ class TestA2DBlockDiffusionGeneration:
         prompt = torch.tensor([[1, 2, 3, 4]])
         padded_prompt_len = 4  # 4 is multiple of block_size=4
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=4,
@@ -1374,7 +1370,7 @@ class TestA2DBlockDiffusionGeneration:
         max_new_tokens = 4
         padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -1397,7 +1393,7 @@ class TestA2DBlockDiffusionGeneration:
         max_new_tokens = 4
         padded_prompt_len = math.ceil(prompt.shape[1] / block_size) * block_size
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -1415,7 +1411,7 @@ class TestA2DBlockDiffusionGeneration:
         prompt = torch.tensor([[7, 8, 9]])
 
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=4,
@@ -1436,7 +1432,7 @@ class TestA2DBlockDiffusionGeneration:
         prompt = torch.tensor([[7, 8, 9, 10]])
 
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=4,
@@ -1507,7 +1503,7 @@ class TestA2DBlockDiffusionGeneration:
 
         prompt = torch.tensor([[1, 2, 3, 4]])
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=2,
@@ -1551,7 +1547,7 @@ class TestA2DBlockDiffusionGeneration:
         monkeypatch.setattr(tiny_model, "forward", fake_forward)
 
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=torch.tensor([[1, 2, 3, 4]]),
                 use_block_diffusion=True,
                 bd3lm_block_size=2,
@@ -1590,7 +1586,7 @@ class TestA2DBlockDiffusionGeneration:
 
         prompt = torch.tensor([[1, 2, 3, 10], [5, 6, 7, 8]])
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=2,
@@ -1630,7 +1626,7 @@ class TestA2DBlockDiffusionGeneration:
             stream_calls.append((step, total, x.shape))
 
         with torch.no_grad():
-            tiny_model.diffusion_generate(
+            tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -1666,7 +1662,7 @@ class TestA2DBlockDiffusionGeneration:
             step_calls.append((step, total))
 
         with torch.no_grad():
-            tiny_model.diffusion_generate(
+            tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=block_size,
@@ -1694,7 +1690,7 @@ class TestA2DBlockDiffusionGeneration:
             assert torch.equal(x[0, : prompt.shape[1]], prompt[0])
 
         with torch.no_grad():
-            tiny_model.diffusion_generate(
+            tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=4,
@@ -1725,7 +1721,7 @@ class TestA2DBlockDiffusionGeneration:
             raise RuntimeError("step callback boom")
 
         with torch.no_grad():
-            out = tiny_model.diffusion_generate(
+            out = tiny_model.generate(
                 inputs=prompt,
                 use_block_diffusion=True,
                 bd3lm_block_size=4,

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -681,6 +681,22 @@ class TestA2DGeneration:
         s_bd3lm = out_bd3lm.sequences if hasattr(out_bd3lm, "sequences") else out_bd3lm
         assert torch.equal(s_auto, s_bd3lm)
 
+    def test_generate_resolves_to_diffusion_mixin(self, llama_model):
+        from transformers.generation import GenerationMixin
+
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationMixin,
+        )
+
+        resolved = type(llama_model).generate
+        assert resolved is MaskedDiffusionGenerationMixin.generate
+        assert resolved is not GenerationMixin.generate
+
+    def test_generate_ar_is_unknown_algorithm(self, llama_model):
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        with pytest.raises(ValueError, match="Unknown decoding algorithm"):
+            llama_model.generate(prompt, algorithm="ar", max_new_tokens=4)
+
 
 # ---------------------------------------------------------------------------
 # RoPE unit tests

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -624,6 +624,63 @@ class TestA2DGeneration:
             )
         assert out.shape == (B, L + 1)
 
+    def test_generate_accepts_algorithm_kwarg(self, llama_model):
+        B, L_prompt, L_new = 1, 4, 4
+        L_total = L_prompt + L_new
+        prompt_ids = torch.tensor([[1, 2, 3, 4]])
+        mask_fill = torch.full((B, L_new), self.MASK_TOKEN_ID, dtype=torch.long)
+        input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
+        with torch.no_grad():
+            out = llama_model.generate(
+                input_ids_full,
+                algorithm="mdlm",
+                steps=3,
+                mask_token_id=self.MASK_TOKEN_ID,
+                max_length=L_total + 1,
+            )
+        seq = out.sequences if hasattr(out, "sequences") else out
+        assert seq.shape == (B, L_total + 1)
+
+    def test_generate_auto_matches_block_decode(self, llama_model):
+        B, L_prompt, L_new = 1, 4, 4
+        L_total = L_prompt + L_new
+        prompt_ids = torch.tensor([[1, 2, 3, 4]])
+        mask_fill = torch.full((B, L_new), self.MASK_TOKEN_ID, dtype=torch.long)
+        input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
+        gen = dict(steps=3, mask_token_id=self.MASK_TOKEN_ID, max_length=L_total + 1)
+
+        torch.manual_seed(0)
+        out_auto = llama_model.generate(input_ids_full, **gen)
+        torch.manual_seed(0)
+        out_block = llama_model.generate(
+            input_ids_full, algorithm="block_decode", **gen
+        )
+
+        s_auto = out_auto.sequences if hasattr(out_auto, "sequences") else out_auto
+        s_block = out_block.sequences if hasattr(out_block, "sequences") else out_block
+        assert torch.equal(s_auto, s_block)
+
+    def test_generate_auto_with_use_block_diffusion_resolves_bd3lm(self, llama_model):
+        # auto + use_block_diffusion=True must follow the same path as explicit bd3lm
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        gen = dict(
+            use_block_diffusion=True,
+            bd3lm_block_size=4,
+            max_new_tokens=4,
+            steps=2,
+            mask_token_id=self.MASK_TOKEN_ID,
+            pad_token_id=0,
+        )
+
+        torch.manual_seed(0)
+        out_auto = llama_model.generate(prompt, **gen)
+        torch.manual_seed(0)
+        out_bd3lm = llama_model.generate(prompt, algorithm="bd3lm", **gen)
+
+        s_auto = out_auto.sequences if hasattr(out_auto, "sequences") else out_auto
+        s_bd3lm = out_bd3lm.sequences if hasattr(out_bd3lm, "sequences") else out_bd3lm
+        assert torch.equal(s_auto, s_bd3lm)
+
 
 # ---------------------------------------------------------------------------
 # RoPE unit tests

--- a/tests/models/test_block_decode.py
+++ b/tests/models/test_block_decode.py
@@ -31,6 +31,7 @@ class TestA2DBlockDecode:
     @pytest.fixture
     def tiny_model(self):
         """Create a tiny A2D LLaMA model for testing."""
+        torch.manual_seed(0)
         config = TinyA2DLlamaConfig(
             vocab_size=128,
             hidden_size=64,

--- a/tests/models/test_block_decode.py
+++ b/tests/models/test_block_decode.py
@@ -50,7 +50,7 @@ class TestA2DBlockDecode:
         prompt = torch.tensor([[1, 2, 3, 4, 5]])
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=16,
                 steps=4,
@@ -71,14 +71,15 @@ class TestA2DBlockDecode:
         steps = 3
 
         with torch.no_grad():
-            output_no_cache = tiny_model.diffusion_generate(
+            output_no_cache = tiny_model.generate(
                 inputs=prompt,
+                algorithm="mdlm",  # explicit: auto would resolve block_decode and overwrite use_cache=False
                 max_new_tokens=max_new,
                 steps=steps,
                 use_cache=False,
                 mask_token_id=MASK_TOKEN_ID,
             )
-            output_with_cache = tiny_model.diffusion_generate(
+            output_with_cache = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=max_new,
                 steps=steps,
@@ -98,7 +99,7 @@ class TestA2DBlockDecode:
         prompt = torch.tensor([[1, 2, 3, 4, 5]]).cuda()
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=16,
                 steps=4,
@@ -139,8 +140,9 @@ class TestA2DBlockDecodeEquivalence:
 
         torch.manual_seed(123)
         with torch.no_grad():
-            output1 = tiny_model.diffusion_generate(
+            output1 = tiny_model.generate(
                 inputs=prompt,
+                algorithm="mdlm",  # explicit: auto would resolve block_decode and overwrite use_cache=False
                 max_new_tokens=8,
                 steps=4,
                 use_cache=False,
@@ -150,8 +152,9 @@ class TestA2DBlockDecodeEquivalence:
 
         torch.manual_seed(123)
         with torch.no_grad():
-            output2 = tiny_model.diffusion_generate(
+            output2 = tiny_model.generate(
                 inputs=prompt,
+                algorithm="mdlm",  # explicit: auto would resolve block_decode and overwrite use_cache=False
                 max_new_tokens=8,
                 steps=4,
                 use_cache=False,
@@ -176,7 +179,7 @@ class TestA2DBlockDecodeEquivalence:
         max_new = 12
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=max_new,
                 steps=6,  # num_blocks=3; steps must be divisible by num_blocks
@@ -201,7 +204,7 @@ class TestA2DBlockDecodeEquivalence:
         max_new = 8
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=max_new,
                 steps=4,

--- a/tests/models/test_block_decode_benchmark.py
+++ b/tests/models/test_block_decode_benchmark.py
@@ -70,8 +70,9 @@ class TestBlockDecodeBenchmark:
         # Warmup
         for _ in range(warmup_runs):
             with torch.no_grad():
-                benchmark_model.diffusion_generate(
+                benchmark_model.generate(
                     inputs=prompt,
+                    algorithm="mdlm",  # explicit: auto would resolve block_decode and overwrite use_cache=False
                     max_new_tokens=32,
                     steps=16,
                     use_cache=False,
@@ -83,8 +84,9 @@ class TestBlockDecodeBenchmark:
         start = time.perf_counter()
         for _ in range(test_runs):
             with torch.no_grad():
-                benchmark_model.diffusion_generate(
+                benchmark_model.generate(
                     inputs=prompt,
+                    algorithm="mdlm",  # explicit: auto would resolve block_decode and overwrite use_cache=False
                     max_new_tokens=32,
                     steps=16,
                     use_cache=False,
@@ -96,7 +98,7 @@ class TestBlockDecodeBenchmark:
         # Warmup cache
         for _ in range(warmup_runs):
             with torch.no_grad():
-                benchmark_model.diffusion_generate(
+                benchmark_model.generate(
                     inputs=prompt,
                     max_new_tokens=32,
                     steps=16,
@@ -110,7 +112,7 @@ class TestBlockDecodeBenchmark:
         start = time.perf_counter()
         for _ in range(test_runs):
             with torch.no_grad():
-                benchmark_model.diffusion_generate(
+                benchmark_model.generate(
                     inputs=prompt,
                     max_new_tokens=32,
                     steps=16,

--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -310,6 +310,21 @@ class TestDreamGenerationUtils:
         seq = out.sequences if hasattr(out, "sequences") else out
         assert seq.shape == (1, 8)
 
+    def test_dream_generate_bd3lm_raises(self, config):
+        """Dream does not implement BD3LM; explicit algorithm='bd3lm' must raise ValueError."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        with pytest.raises(ValueError, match="BD3LM"):
+            model.generate(
+                inputs=inputs,
+                algorithm="bd3lm",
+                steps=2,
+                mask_token_id=config.mask_token_id,
+                max_new_tokens=4,
+            )
+
 
 class TestDreamFastRoPE:
     """Tests for DreamAttention_fast_forward Triton RoPE path."""

--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -142,6 +142,7 @@ class TestDreamGenerationUtils:
     def test_cache_block_decode_trim_mode(self, config):
         from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
 
+        torch.manual_seed(0)
         model = DreamModel(config).cpu().eval()
         inputs = torch.tensor([[2, 3, 4, 5]])
         generation_config = DreamGenerationConfig(
@@ -161,6 +162,7 @@ class TestDreamGenerationUtils:
     def test_cache_block_decode_dual_cache_mode(self, config):
         from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
 
+        torch.manual_seed(0)
         model = DreamModel(config).cpu().eval()
         inputs = torch.tensor([[2, 3, 4, 5], [6, 7, 8, 9]])
         generation_config = DreamGenerationConfig(
@@ -209,6 +211,7 @@ class TestDreamGenerationUtils:
     def test_cache_block_decode_accepts_additive_attention_mask(self, config):
         from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
 
+        torch.manual_seed(0)
         model = DreamModel(config).cpu().eval()
         inputs = torch.tensor([[2, 3, 4, 5]])
         additive_mask = torch.zeros(1, 1, 8, 8)

--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -296,6 +296,25 @@ class TestDreamGenerationUtils:
 
         assert 3 in model.forward_lengths
 
+    def test_dream_generate_accepts_algorithm(self, config):
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        model = DreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            block_length=2,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            out = model.generate(
+                inputs=inputs, algorithm="mdlm", generation_config=generation_config
+            )
+        seq = out.sequences if hasattr(out, "sequences") else out
+        assert seq.shape == (1, 8)
+
 
 class TestDreamFastRoPE:
     """Tests for DreamAttention_fast_forward Triton RoPE path."""

--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -137,7 +137,7 @@ class TestDreamGenerationUtils:
         from unturtle.models.backbones.dream import DreamGenerationMixin
 
         assert DreamGenerationMixin is not None
-        assert hasattr(DreamGenerationMixin, "diffusion_generate")
+        assert hasattr(DreamGenerationMixin, "generate")
 
     def test_cache_block_decode_trim_mode(self, config):
         from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
@@ -154,9 +154,7 @@ class TestDreamGenerationUtils:
             pad_token_id=config.pad_token_id,
         )
         with torch.no_grad():
-            out = model.diffusion_generate(
-                inputs=inputs, generation_config=generation_config
-            )
+            out = model.generate(inputs=inputs, generation_config=generation_config)
         assert out.shape == (1, 8)
         assert not torch.any(out == config.mask_token_id)
 
@@ -175,9 +173,7 @@ class TestDreamGenerationUtils:
             pad_token_id=config.pad_token_id,
         )
         with torch.no_grad():
-            out = model.diffusion_generate(
-                inputs=inputs, generation_config=generation_config
-            )
+            out = model.generate(inputs=inputs, generation_config=generation_config)
         assert out.shape == (2, 8)
         assert not torch.any(out == config.mask_token_id)
 
@@ -227,7 +223,7 @@ class TestDreamGenerationUtils:
             pad_token_id=config.pad_token_id,
         )
         with torch.no_grad():
-            out = model.diffusion_generate(
+            out = model.generate(
                 inputs=inputs,
                 attention_mask=additive_mask,
                 generation_config=generation_config,
@@ -260,9 +256,7 @@ class TestDreamGenerationUtils:
             pad_token_id=config.pad_token_id,
         )
         with torch.no_grad():
-            _ = model.diffusion_generate(
-                inputs=inputs, generation_config=generation_config
-            )
+            _ = model.generate(inputs=inputs, generation_config=generation_config)
         assert model.seen_logits is not None
 
     def test_dual_cache_query_start_includes_previous_token(self, config):
@@ -290,9 +284,7 @@ class TestDreamGenerationUtils:
             pad_token_id=config.pad_token_id,
         )
         with torch.no_grad():
-            _ = model.diffusion_generate(
-                inputs=inputs, generation_config=generation_config
-            )
+            _ = model.generate(inputs=inputs, generation_config=generation_config)
 
         assert 3 in model.forward_lengths
 

--- a/tests/models/test_llada.py
+++ b/tests/models/test_llada.py
@@ -154,6 +154,23 @@ class TestLLaDAGeneration:
         assert isinstance(model, LLaDAGenerationMixin)
         assert callable(model.diffusion_generate)
 
+    def test_generate_is_mixin_generate(self, model):
+        """MRO identity pin: LLaDAModelLM.generate is the diffusion mixin's generate.
+
+        GenerationMixin is not in the LLaDAModelLM MRO, so this pin guards against
+        a future base-class or mixin insertion that could re-route generate to
+        transformers' autoregressive path.
+        """
+        from transformers.generation import GenerationMixin
+
+        from unturtle.models.backbones.llada import LLaDAModelLM
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationMixin,
+        )
+
+        assert LLaDAModelLM.generate is MaskedDiffusionGenerationMixin.generate
+        assert LLaDAModelLM.generate is not GenerationMixin.generate
+
     def test_prepare_inputs_for_generation_removed(self, model):
         """prepare_inputs_for_generation (AR protocol) must no longer exist."""
         assert not hasattr(model, "prepare_inputs_for_generation"), (
@@ -255,6 +272,30 @@ class TestLLaDAGeneration:
                 num_return_sequences=2,
             )
         assert out.shape == (B * 2, L + 1)
+
+    def test_llada_generate_runs_diffusion(self, model):
+        """model.generate(algorithm="mdlm") runs the diffusion denoising loop end-to-end."""
+        B, L_prompt, L_new = 1, 4, 4
+        L_total = L_prompt + L_new
+        prompt_ids = torch.tensor([[1, 2, 3, 4]])
+        mask_fill = torch.full((B, L_new), self.TINY_MASK_ID, dtype=torch.long)
+        input_ids_full = torch.cat([prompt_ids, mask_fill], dim=1)
+        with torch.no_grad():
+            out = model.generate(
+                input_ids_full,
+                algorithm="mdlm",
+                steps=3,
+                mask_token_id=self.TINY_MASK_ID,
+                max_length=L_total + 1,
+            )
+        seq = out.sequences if hasattr(out, "sequences") else out
+        assert seq.shape == (B, L_total + 1)
+
+    def test_llada_generate_ar_raises(self, model):
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        # No "ar" algorithm exists; pure dLLMs reject it at algorithm resolution.
+        with pytest.raises(ValueError, match="Unknown decoding algorithm"):
+            model.generate(prompt, algorithm="ar", max_new_tokens=4)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/test_llada.py
+++ b/tests/models/test_llada.py
@@ -297,6 +297,18 @@ class TestLLaDAGeneration:
         with pytest.raises(ValueError, match="Unknown decoding algorithm"):
             model.generate(prompt, algorithm="ar", max_new_tokens=4)
 
+    def test_llada_generate_bd3lm_raises(self, model):
+        """LLaDA does not implement BD3LM; explicit algorithm='bd3lm' must raise ValueError."""
+        prompt = torch.full((1, 4), self.TINY_MASK_ID, dtype=torch.long)
+        with pytest.raises(ValueError, match="BD3LM"):
+            model.generate(
+                prompt,
+                algorithm="bd3lm",
+                steps=2,
+                mask_token_id=self.TINY_MASK_ID,
+                max_length=8,
+            )
+
 
 # ---------------------------------------------------------------------------
 # LLaDA Triton RoPE fast path (_make_llada_fast_rope_forward)

--- a/tests/models/test_llada.py
+++ b/tests/models/test_llada.py
@@ -112,12 +112,12 @@ class TestLLaDAModel:
 
 
 # ---------------------------------------------------------------------------
-# LLaDA generation (diffusion_generate)
+# LLaDA generation (generate)
 # ---------------------------------------------------------------------------
 
 
 class TestLLaDAGeneration:
-    """Tests for LLaDAGenerationMixin.diffusion_generate on tiny CPU models."""
+    """Tests for LLaDAGenerationMixin.generate on tiny CPU models."""
 
     MASK_TOKEN_ID = 126336  # LLaDA default; overridden via config below
 
@@ -148,11 +148,11 @@ class TestLLaDAGeneration:
 
     TINY_MASK_ID = 511
 
-    def test_has_diffusion_generate(self, model):
+    def test_has_generate(self, model):
         from unturtle.models.backbones.llada import LLaDAGenerationMixin
 
         assert isinstance(model, LLaDAGenerationMixin)
-        assert callable(model.diffusion_generate)
+        assert callable(model.generate)
 
     def test_generate_is_mixin_generate(self, model):
         """MRO identity pin: LLaDAModelLM.generate is the diffusion mixin's generate.
@@ -182,7 +182,7 @@ class TestLLaDAGeneration:
         B, L = 2, 10
         input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
         with torch.no_grad():
-            out = model.diffusion_generate(
+            out = model.generate(
                 input_ids,
                 steps=2,
                 mask_token_id=self.TINY_MASK_ID,
@@ -196,7 +196,7 @@ class TestLLaDAGeneration:
         input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
         with torch.no_grad():
             torch.manual_seed(42)
-            out1 = model.diffusion_generate(
+            out1 = model.generate(
                 input_ids.clone(),
                 steps=2,
                 mask_token_id=self.TINY_MASK_ID,
@@ -204,7 +204,7 @@ class TestLLaDAGeneration:
                 max_length=L + 1,
             )
             torch.manual_seed(42)
-            out2 = model.diffusion_generate(
+            out2 = model.generate(
                 input_ids.clone(),
                 steps=2,
                 mask_token_id=self.TINY_MASK_ID,
@@ -221,7 +221,7 @@ class TestLLaDAGeneration:
             with pytest.raises(ValueError, match="mask_token_id"):
                 B, L = 1, 4
                 input_ids = torch.zeros((B, L), dtype=torch.long)
-                model.diffusion_generate(input_ids, steps=1, max_length=L + 1)
+                model.generate(input_ids, steps=1, max_length=L + 1)
         finally:
             model.config.mask_token_id = original
 
@@ -237,7 +237,7 @@ class TestLLaDAGeneration:
         attention_mask = torch.ones((B, L), dtype=torch.long)
         attention_mask[1, -2:] = 0  # simulate padding in second sample
         with torch.no_grad():
-            out = model.diffusion_generate(
+            out = model.generate(
                 input_ids,
                 attention_mask=attention_mask,
                 steps=2,
@@ -246,8 +246,8 @@ class TestLLaDAGeneration:
             )
         assert out.shape == (B, L + 1)
 
-    def test_generate_redirects_to_diffusion_generate(self, model):
-        """model.generate() must route to diffusion_generate(), not HF AR generate()."""
+    def test_generate_runs_diffusion_by_default(self, model):
+        """model.generate() must run the diffusion denoising loop, not HF AR generate()."""
         B, L = 1, 6
         input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
         with torch.no_grad():
@@ -264,7 +264,7 @@ class TestLLaDAGeneration:
         B, L = 1, 6
         input_ids = torch.full((B, L), self.TINY_MASK_ID, dtype=torch.long)
         with torch.no_grad():
-            out = model.diffusion_generate(
+            out = model.generate(
                 input_ids,
                 steps=2,
                 mask_token_id=self.TINY_MASK_ID,
@@ -918,7 +918,7 @@ class TestLLaDABlockDecode:
         )
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=input_ids,
                 generation_config=gen_config,
             )
@@ -955,7 +955,7 @@ class TestLLaDABlockDecode:
 
         torch.manual_seed(42)
         with torch.no_grad():
-            output_with_cache = tiny_model.diffusion_generate(
+            output_with_cache = tiny_model.generate(
                 inputs=input_ids.clone(),
                 generation_config=gen_config_with_cache,
             )
@@ -987,9 +987,7 @@ class TestLLaDABlockDecode:
         )
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
-                inputs=input_ids, generation_config=gen_config
-            )
+            output = tiny_model.generate(inputs=input_ids, generation_config=gen_config)
 
         assert output.shape == (1, 16)
         assert not torch.any(output[:, 8:] == tiny_config.mask_token_id)
@@ -1030,9 +1028,7 @@ class TestLLaDABlockDecode:
         )
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
-                inputs=input_ids, generation_config=gen_config
-            )
+            output = tiny_model.generate(inputs=input_ids, generation_config=gen_config)
 
         assert output.shape == (1, 16)
         assert not torch.any(output[:, 8:] == tiny_config.mask_token_id)
@@ -1058,9 +1054,7 @@ class TestLLaDABlockDecode:
         )
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
-                inputs=input_ids, generation_config=gen_config
-            )
+            output = tiny_model.generate(inputs=input_ids, generation_config=gen_config)
 
         assert output.shape == (1, 16)
         assert not torch.any(output[:, 8:] == tiny_config.mask_token_id)
@@ -1101,9 +1095,7 @@ class TestLLaDABlockDecode:
         )
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
-                inputs=input_ids, generation_config=gen_config
-            )
+            output = tiny_model.generate(inputs=input_ids, generation_config=gen_config)
 
         assert output.shape == (1, 16)
         assert not torch.any(output[:, 8:] == tiny_config.mask_token_id)

--- a/tests/models/test_modernbert_generation.py
+++ b/tests/models/test_modernbert_generation.py
@@ -1,0 +1,88 @@
+"""Tests for DiffusionModernBertForMaskedLM generation and algorithm resolution.
+
+Covers:
+- resolve_algorithm("auto", model) == "mdlm" (encoder backbone opts out of block-decode)
+- model.generate(...) runs without error (pre-fix this crashed via past_key_values AttributeError)
+- model.generate(..., algorithm="block_decode") raises ValueError
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from unturtle.models.generation.sampler import resolve_algorithm
+
+
+@pytest.fixture
+def tiny_config():
+    from unturtle.models.backbones.modernbert import DiffusionModernBertConfig
+
+    return DiffusionModernBertConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        # Override default token IDs which exceed tiny vocab_size=256
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+
+
+@pytest.fixture
+def tiny_model(tiny_config):
+    from unturtle.models.backbones.modernbert import DiffusionModernBertForMaskedLM
+
+    torch.manual_seed(0)
+    return DiffusionModernBertForMaskedLM(tiny_config).eval()
+
+
+MASK_TOKEN_ID = 103  # arbitrary token within tiny vocab
+
+
+def test_supports_block_decode_is_false(tiny_model) -> None:
+    """DiffusionModernBertForMaskedLM must declare supports_block_decode=False."""
+    assert getattr(tiny_model, "supports_block_decode", True) is False
+
+
+def test_resolve_algorithm_auto_returns_mdlm(tiny_model) -> None:
+    """auto on ModernBERT resolves to mdlm (encoder opts out of block-decode)."""
+    result = resolve_algorithm("auto", tiny_model, bd3lm_requested=False)
+    assert result == "mdlm"
+
+
+def test_generate_default_runs_without_error(tiny_model) -> None:
+    """model.generate() with auto algorithm runs without AttributeError.
+
+    This is the regression test for Defect 1 — before the fix, auto resolved to
+    block_decode, which crashed with:
+      AttributeError: 'MaskedLMOutput' object has no attribute 'past_key_values'
+    """
+    B, L = 1, 8
+    # Fill with mask tokens so all positions are generatable
+    input_ids = torch.full((B, L), MASK_TOKEN_ID, dtype=torch.long)
+    with torch.no_grad():
+        out = tiny_model.generate(
+            input_ids,
+            steps=2,
+            mask_token_id=MASK_TOKEN_ID,
+            max_length=L + 1,
+        )
+    seq = out.sequences if hasattr(out, "sequences") else out
+    assert seq.shape == (B, L + 1)
+
+
+def test_generate_explicit_block_decode_raises(tiny_model) -> None:
+    """Explicit algorithm='block_decode' on ModernBERT raises ValueError."""
+    B, L = 1, 8
+    input_ids = torch.full((B, L), MASK_TOKEN_ID, dtype=torch.long)
+    with pytest.raises(ValueError, match="block-decode"):
+        tiny_model.generate(
+            input_ids,
+            algorithm="block_decode",
+            steps=2,
+            mask_token_id=MASK_TOKEN_ID,
+            max_length=L + 1,
+        )

--- a/tests/models/test_parallel_decode.py
+++ b/tests/models/test_parallel_decode.py
@@ -49,7 +49,7 @@ class TestConfidenceParallelDecode:
         prompt = torch.tensor([[1, 2, 3, 4, 5]])
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=16,
                 steps=4,
@@ -70,7 +70,7 @@ class TestConfidenceParallelDecode:
         steps = 4
 
         with torch.no_grad():
-            output_non_parallel = tiny_model.diffusion_generate(
+            output_non_parallel = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=max_new,
                 steps=steps,
@@ -79,7 +79,7 @@ class TestConfidenceParallelDecode:
                 alg="maskgit_plus",
                 mask_token_id=100,
             )
-            output_parallel = tiny_model.diffusion_generate(
+            output_parallel = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=max_new,
                 steps=steps,
@@ -100,7 +100,7 @@ class TestConfidenceParallelDecode:
         # (confidence values are typically 0.01-0.2 for vocab=128)
         torch.manual_seed(123)
         with torch.no_grad():
-            output_low = tiny_model.diffusion_generate(
+            output_low = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=12,
                 steps=8,  # More steps for convergence
@@ -114,7 +114,7 @@ class TestConfidenceParallelDecode:
 
         torch.manual_seed(123)
         with torch.no_grad():
-            output_high = tiny_model.diffusion_generate(
+            output_high = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=12,
                 steps=8,
@@ -163,7 +163,7 @@ class TestConfidenceParallelDecode:
 
         prompt = torch.tensor([[1, 2, 3, 4]])
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=8,
                 steps=2,
@@ -186,7 +186,7 @@ class TestConfidenceParallelDecode:
         algorithms = ["maskgit_plus", "topk_margin", "entropy"]
         for alg in algorithms:
             with torch.no_grad():
-                output = tiny_model.diffusion_generate(
+                output = tiny_model.generate(
                     inputs=prompt,
                     max_new_tokens=8,
                     steps=4,
@@ -205,7 +205,7 @@ class TestConfidenceParallelDecode:
         prompt = torch.tensor([[1, 2, 3, 4, 5]]).cuda()
 
         with torch.no_grad():
-            output = tiny_model.diffusion_generate(
+            output = tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=16,
                 steps=4,
@@ -227,8 +227,9 @@ class TestConfidenceParallelDecode:
         with pytest.raises(
             ValueError, match="parallel_decode=True.*requires.*use_cache=True"
         ):
-            tiny_model.diffusion_generate(
+            tiny_model.generate(
                 inputs=prompt,
+                algorithm="mdlm",  # explicit: auto would resolve block_decode and overwrite use_cache=False, preventing the ValueError
                 max_new_tokens=8,
                 steps=4,
                 use_cache=False,
@@ -246,7 +247,7 @@ class TestConfidenceParallelDecode:
             pytest.raises(ValueError, match="does not support `alg='origin'`"),
             torch.no_grad(),
         ):
-            tiny_model.diffusion_generate(
+            tiny_model.generate(
                 inputs=prompt,
                 max_new_tokens=8,
                 steps=4,

--- a/tests/models/test_sampler.py
+++ b/tests/models/test_sampler.py
@@ -4,7 +4,6 @@ import pytest
 
 from unturtle.models.generation.sampler import (
     DISCRETE_ALGORITHMS,
-    _supports_ar,
     algorithm_to_flags,
     resolve_algorithm,
 )
@@ -30,18 +29,6 @@ class _BlockCapable:
 
 class _PlainDiffusion:
     """Stub without the cache hook."""
-
-
-class _FakeConfig:
-    def __init__(self, model_type):
-        self.model_type = model_type
-
-
-class _ARModel:
-    """Stub whose config model_type marks it AR-capable (TinyA2D family)."""
-
-    def __init__(self, model_type):
-        self.config = _FakeConfig(model_type)
 
 
 def test_known_algorithms_present() -> None:
@@ -98,36 +85,6 @@ def test_resolve_unknown_raises() -> None:
         resolve_algorithm("nope", _CacheCapable(), bd3lm_requested=False)
 
 
-@pytest.mark.parametrize(
-    "model_type,expected",
-    [
-        ("tiny-a2d-llama", True),
-        ("tiny-a2d-qwen2", True),
-        ("tiny-a2d-qwen3", True),
-        ("llada", False),
-        ("dream", False),
-        ("modernbert-diffusion", False),
-    ],
-)
-def test_supports_ar_by_model_type(model_type: str, expected: bool) -> None:
-    assert _supports_ar(_ARModel(model_type)) is expected
-
-
-def test_supports_ar_missing_config_is_false() -> None:
-    assert _supports_ar(_PlainDiffusion()) is False
-
-
-def test_resolve_ar_for_ar_capable_returns_ar() -> None:
-    model = _ARModel("tiny-a2d-llama")
-    assert resolve_algorithm("ar", model, bd3lm_requested=False) == "ar"
-
-
-def test_resolve_ar_for_non_ar_capable_raises() -> None:
-    model = _ARModel("llada")
-    with pytest.raises(ValueError, match="autoregressive"):
-        resolve_algorithm("ar", model, bd3lm_requested=False)
-
-
 def test_resolve_auto_block_decode_still_works() -> None:
     assert (
         resolve_algorithm("auto", _BlockCapable(), bd3lm_requested=False)
@@ -152,3 +109,8 @@ def test_algorithm_to_flags_unchanged() -> None:
         "use_cache": False,
         "use_block_diffusion": True,
     }
+
+
+def test_resolve_ar_is_unknown_algorithm() -> None:
+    with pytest.raises(ValueError, match="Unknown decoding algorithm"):
+        resolve_algorithm("ar", _PlainDiffusion(), bd3lm_requested=False)

--- a/tests/models/test_sampler.py
+++ b/tests/models/test_sampler.py
@@ -4,6 +4,7 @@ import pytest
 
 from unturtle.models.generation.sampler import (
     DISCRETE_ALGORITHMS,
+    _supports_ar,
     algorithm_to_flags,
     resolve_algorithm,
 )
@@ -18,6 +19,29 @@ class _CacheCapable:
 
 class _NoCache:
     """Stub model without block-decode capability."""
+
+
+class _BlockCapable:
+    """Stub exposing the block-decode cache hook."""
+
+    def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
+
+class _PlainDiffusion:
+    """Stub without the cache hook."""
+
+
+class _FakeConfig:
+    def __init__(self, model_type):
+        self.model_type = model_type
+
+
+class _ARModel:
+    """Stub whose config model_type marks it AR-capable (TinyA2D family)."""
+
+    def __init__(self, model_type):
+        self.config = _FakeConfig(model_type)
 
 
 def test_known_algorithms_present() -> None:
@@ -72,3 +96,59 @@ def test_resolve_explicit_passthrough() -> None:
 def test_resolve_unknown_raises() -> None:
     with pytest.raises(ValueError):
         resolve_algorithm("nope", _CacheCapable(), bd3lm_requested=False)
+
+
+@pytest.mark.parametrize(
+    "model_type,expected",
+    [
+        ("tiny-a2d-llama", True),
+        ("tiny-a2d-qwen2", True),
+        ("tiny-a2d-qwen3", True),
+        ("llada", False),
+        ("dream", False),
+        ("modernbert-diffusion", False),
+    ],
+)
+def test_supports_ar_by_model_type(model_type: str, expected: bool) -> None:
+    assert _supports_ar(_ARModel(model_type)) is expected
+
+
+def test_supports_ar_missing_config_is_false() -> None:
+    assert _supports_ar(_PlainDiffusion()) is False
+
+
+def test_resolve_ar_for_ar_capable_returns_ar() -> None:
+    model = _ARModel("tiny-a2d-llama")
+    assert resolve_algorithm("ar", model, bd3lm_requested=False) == "ar"
+
+
+def test_resolve_ar_for_non_ar_capable_raises() -> None:
+    model = _ARModel("llada")
+    with pytest.raises(ValueError, match="autoregressive"):
+        resolve_algorithm("ar", model, bd3lm_requested=False)
+
+
+def test_resolve_auto_block_decode_still_works() -> None:
+    assert (
+        resolve_algorithm("auto", _BlockCapable(), bd3lm_requested=False)
+        == "block_decode"
+    )
+
+
+def test_resolve_auto_mdlm_fallback_still_works() -> None:
+    assert resolve_algorithm("auto", _PlainDiffusion(), bd3lm_requested=False) == "mdlm"
+
+
+def test_algorithm_to_flags_unchanged() -> None:
+    assert algorithm_to_flags("mdlm") == {
+        "use_cache": False,
+        "use_block_diffusion": False,
+    }
+    assert algorithm_to_flags("block_decode") == {
+        "use_cache": True,
+        "use_block_diffusion": False,
+    }
+    assert algorithm_to_flags("bd3lm") == {
+        "use_cache": False,
+        "use_block_diffusion": True,
+    }

--- a/tests/models/test_sampler.py
+++ b/tests/models/test_sampler.py
@@ -31,6 +31,32 @@ class _PlainDiffusion:
     """Stub without the cache hook."""
 
 
+class _CacheCapableOptOut:
+    """Stub with the cache hook but supports_block_decode = False (encoder-style opt-out)."""
+
+    supports_block_decode = False
+
+    def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
+
+class _BD3LMCapable:
+    """Stub with both block-decode and BD3LM capability."""
+
+    def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
+    def _sample_block_diffusion(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
+
+class _BD3LMOnly:
+    """Stub with BD3LM but no block-decode cache hook."""
+
+    def _sample_block_diffusion(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
+
 def test_known_algorithms_present() -> None:
     assert set(DISCRETE_ALGORITHMS) == {"mdlm", "block_decode", "bd3lm"}
 
@@ -69,7 +95,7 @@ def test_resolve_auto_picks_block_decode_when_capable() -> None:
 
 
 def test_resolve_auto_picks_bd3lm_when_requested() -> None:
-    assert resolve_algorithm("auto", _CacheCapable(), bd3lm_requested=True) == "bd3lm"
+    assert resolve_algorithm("auto", _BD3LMCapable(), bd3lm_requested=True) == "bd3lm"
 
 
 def test_resolve_auto_falls_back_to_mdlm_without_cache_capability() -> None:
@@ -114,3 +140,58 @@ def test_algorithm_to_flags_unchanged() -> None:
 def test_resolve_ar_is_unknown_algorithm() -> None:
     with pytest.raises(ValueError, match="Unknown decoding algorithm"):
         resolve_algorithm("ar", _PlainDiffusion(), bd3lm_requested=False)
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 & 2: capability checks
+# ---------------------------------------------------------------------------
+
+
+def test_auto_opts_out_via_supports_block_decode_false() -> None:
+    """auto resolves to mdlm when model has the hook but supports_block_decode=False."""
+    assert (
+        resolve_algorithm("auto", _CacheCapableOptOut(), bd3lm_requested=False)
+        == "mdlm"
+    )
+
+
+def test_explicit_block_decode_non_capable_raises() -> None:
+    """explicit 'block_decode' on a non-capable model raises ValueError."""
+    with pytest.raises(ValueError, match="block-decode"):
+        resolve_algorithm("block_decode", _NoCache(), bd3lm_requested=False)
+
+
+def test_explicit_block_decode_opted_out_raises() -> None:
+    """explicit 'block_decode' on an opted-out model raises ValueError."""
+    with pytest.raises(ValueError, match="block-decode"):
+        resolve_algorithm("block_decode", _CacheCapableOptOut(), bd3lm_requested=False)
+
+
+def test_explicit_bd3lm_without_capability_raises() -> None:
+    """explicit 'bd3lm' on a model without _sample_block_diffusion raises ValueError."""
+    with pytest.raises(ValueError, match="BD3LM"):
+        resolve_algorithm("bd3lm", _CacheCapable(), bd3lm_requested=False)
+
+
+def test_auto_bd3lm_requested_without_capability_raises() -> None:
+    """auto + bd3lm_requested=True on a model without _sample_block_diffusion raises ValueError."""
+    with pytest.raises(ValueError, match="BD3LM"):
+        resolve_algorithm("auto", _CacheCapable(), bd3lm_requested=True)
+
+
+def test_auto_bd3lm_requested_with_capability_resolves() -> None:
+    """auto + bd3lm_requested=True resolves to 'bd3lm' when model has _sample_block_diffusion."""
+    assert resolve_algorithm("auto", _BD3LMCapable(), bd3lm_requested=True) == "bd3lm"
+
+
+def test_explicit_bd3lm_with_capability_resolves() -> None:
+    """explicit 'bd3lm' resolves correctly when model has _sample_block_diffusion."""
+    assert resolve_algorithm("bd3lm", _BD3LMCapable(), bd3lm_requested=False) == "bd3lm"
+
+
+def test_explicit_block_decode_with_capability_resolves() -> None:
+    """explicit 'block_decode' resolves correctly on a capable model."""
+    assert (
+        resolve_algorithm("block_decode", _CacheCapable(), bd3lm_requested=False)
+        == "block_decode"
+    )

--- a/tests/test_fast_diffusion_generate.py
+++ b/tests/test_fast_diffusion_generate.py
@@ -7,87 +7,33 @@ from unturtle.fast_diffusion_model import FastDiffusionModel
 
 
 class _RecordingModel:
-    """Stub dLLM model: records the kwargs diffusion_generate receives."""
+    """Stub dLLM model: records the args its generate() receives."""
 
-    def __init__(self, *, cache_capable: bool = True) -> None:
-        self.calls: list[dict] = []
-        self._cache_capable = cache_capable
-
-    def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
-        ...
-
-    def diffusion_generate(self, inputs=None, **kwargs):  # noqa: ANN001, ANN003
-        self.calls.append({"inputs": inputs, **kwargs})
-        return "GENERATED"
-
-
-class _NoCacheModel:
     def __init__(self) -> None:
         self.calls: list[dict] = []
 
-    def diffusion_generate(self, inputs=None, **kwargs):  # noqa: ANN001, ANN003
-        self.calls.append({"inputs": inputs, **kwargs})
+    def generate(self, inputs=None, *, algorithm="auto", **kwargs):  # noqa: ANN001, ANN003
+        self.calls.append({"inputs": inputs, "algorithm": algorithm, **kwargs})
         return "GENERATED"
 
 
-def test_generate_auto_selects_block_decode_for_cache_capable() -> None:
-    model = _RecordingModel(cache_capable=True)
-    out = FastDiffusionModel.generate(model, inputs="X", steps=8)
+def test_facade_forwards_inputs_and_algorithm() -> None:
+    model = _RecordingModel()
+    out = FastDiffusionModel.generate(model, inputs="X", algorithm="mdlm", steps=8)
     assert out == "GENERATED"
     call = model.calls[-1]
-    assert call["use_cache"] is True
-    assert call["use_block_diffusion"] is False
-    assert call["steps"] == 8
     assert call["inputs"] == "X"
+    assert call["algorithm"] == "mdlm"
+    assert call["steps"] == 8
 
 
-def test_generate_auto_falls_back_to_mdlm_without_cache() -> None:
-    model = _NoCacheModel()
-    FastDiffusionModel.generate(model, inputs="X")
-    call = model.calls[-1]
-    assert call["use_cache"] is False
-    assert call["use_block_diffusion"] is False
-
-
-def test_generate_explicit_mdlm_overrides_auto() -> None:
-    model = _RecordingModel(cache_capable=True)
-    FastDiffusionModel.generate(model, inputs="X", algorithm="mdlm")
-    call = model.calls[-1]
-    assert call["use_cache"] is False
-    assert call["use_block_diffusion"] is False
-
-
-def test_generate_explicit_bd3lm() -> None:
-    model = _RecordingModel(cache_capable=True)
-    FastDiffusionModel.generate(model, inputs="X", algorithm="bd3lm")
-    call = model.calls[-1]
-    assert call["use_block_diffusion"] is True
-    assert call["use_cache"] is False
-
-
-def test_generate_auto_with_use_block_diffusion_kwarg_picks_bd3lm() -> None:
-    model = _RecordingModel(cache_capable=True)
-    FastDiffusionModel.generate(model, inputs="X", use_block_diffusion=True)
-    call = model.calls[-1]
-    assert call["use_block_diffusion"] is True
-    assert call["use_cache"] is False
-
-
-def test_generate_unknown_algorithm_raises() -> None:
+def test_facade_default_algorithm_is_auto() -> None:
     model = _RecordingModel()
-    with pytest.raises(ValueError):
-        FastDiffusionModel.generate(model, inputs="X", algorithm="continuous_ddpm")
+    FastDiffusionModel.generate(model, inputs="X")
+    assert model.calls[-1]["algorithm"] == "auto"
 
 
-def test_generate_requires_diffusion_generate() -> None:
-    class _NotADLLM:
-        pass
-
-    with pytest.raises(TypeError):
-        FastDiffusionModel.generate(_NotADLLM(), inputs="X")
-
-
-def test_generate_passes_through_gen_kwargs() -> None:
+def test_facade_passes_through_gen_kwargs() -> None:
     model = _RecordingModel()
     FastDiffusionModel.generate(
         model, inputs="X", algorithm="block_decode", temperature=0.7, max_new_tokens=32
@@ -95,6 +41,14 @@ def test_generate_passes_through_gen_kwargs() -> None:
     call = model.calls[-1]
     assert call["temperature"] == 0.7
     assert call["max_new_tokens"] == 32
+
+
+def test_facade_requires_generate() -> None:
+    class _NotADLLM:
+        pass
+
+    with pytest.raises(TypeError, match="generate"):
+        FastDiffusionModel.generate(_NotADLLM(), inputs="X")
 
 
 def _tiny_a2d_model():
@@ -118,14 +72,9 @@ def _tiny_a2d_model():
     return model
 
 
-@pytest.mark.parametrize(
-    "algorithm,flags",
-    [
-        ("mdlm", {"use_cache": False, "use_block_diffusion": False}),
-        ("block_decode", {"use_cache": True, "use_block_diffusion": False}),
-    ],
-)
-def test_generate_parity_with_diffusion_generate(algorithm, flags) -> None:
+@pytest.mark.parametrize("algorithm", ["mdlm", "block_decode"])
+def test_facade_parity_with_direct_generate(algorithm) -> None:
+    """Facade output equals calling model.generate directly with the same algorithm."""
     model = _tiny_a2d_model()
     prompt = torch.tensor([[1, 2, 3, 4]])
     gen_kwargs = dict(
@@ -133,17 +82,17 @@ def test_generate_parity_with_diffusion_generate(algorithm, flags) -> None:
     )
 
     torch.manual_seed(0)
-    out_direct = model.diffusion_generate(inputs=prompt, **flags, **gen_kwargs)
+    out_direct = model.generate(inputs=prompt, algorithm=algorithm, **gen_kwargs)
 
     torch.manual_seed(0)
-    out_generate = FastDiffusionModel.generate(
+    out_facade = FastDiffusionModel.generate(
         model, inputs=prompt, algorithm=algorithm, **gen_kwargs
     )
 
     seq_direct = (
         out_direct.sequences if hasattr(out_direct, "sequences") else out_direct
     )
-    seq_generate = (
-        out_generate.sequences if hasattr(out_generate, "sequences") else out_generate
+    seq_facade = (
+        out_facade.sequences if hasattr(out_facade, "sequences") else out_facade
     )
-    assert torch.equal(seq_direct, seq_generate)
+    assert torch.equal(seq_direct, seq_facade)

--- a/unturtle/cli/commands/generate.py
+++ b/unturtle/cli/commands/generate.py
@@ -160,9 +160,7 @@ def generate(
     # --- Generate ---
     typer.echo("Generating...", err=True)
     try:
-        output = loaded_model.diffusion_generate(
-            input_ids, generation_config=gen_config
-        )
+        output = loaded_model.generate(input_ids, generation_config=gen_config)
     except Exception as e:
         typer.echo(f"Error: generation failed — {e}", err=True)
         raise typer.Exit(code=1)

--- a/unturtle/cli/commands/generate.py
+++ b/unturtle/cli/commands/generate.py
@@ -157,10 +157,17 @@ def generate(
         typer.echo(f"Error: invalid generation config — {e}", err=True)
         raise typer.Exit(code=1)
 
+    # Derive algorithm from config flags so auto-resolution cannot override
+    # the user's explicit use_cache intent. use_cache=True opts into block-decode;
+    # the default (False) keeps the MDLM no-cache path.
+    algorithm = "block_decode" if use_cache else "mdlm"
+
     # --- Generate ---
     typer.echo("Generating...", err=True)
     try:
-        output = loaded_model.generate(input_ids, generation_config=gen_config)
+        output = loaded_model.generate(
+            input_ids, generation_config=gen_config, algorithm=algorithm
+        )
     except Exception as e:
         typer.echo(f"Error: generation failed — {e}", err=True)
         raise typer.Exit(code=1)

--- a/unturtle/eval/generation.py
+++ b/unturtle/eval/generation.py
@@ -105,6 +105,12 @@ class GenerationEvaluator(BaseEvaluator):
                 self.device
             )
 
+        # Pin algorithm="mdlm" when no generation_config is supplied so the
+        # no-cache MDLM path (pre-unification default) is preserved and recorded
+        # DecodingConfigs stay accurate.  Callers that pass a generation_config
+        # object keep auto semantics — the config carries its own algorithm intent.
+        if "generation_config" not in generation_kwargs:
+            generation_kwargs["algorithm"] = "mdlm"
         sequences = self.model.generate(prompt_ids, **generation_kwargs)
 
         if hasattr(sequences, "sequences"):

--- a/unturtle/eval/generation.py
+++ b/unturtle/eval/generation.py
@@ -105,12 +105,7 @@ class GenerationEvaluator(BaseEvaluator):
                 self.device
             )
 
-        diffusion_generate = getattr(self.model, "diffusion_generate", None)
-        if callable(diffusion_generate):
-            sequences = diffusion_generate(prompt_ids, **generation_kwargs)
-        else:
-            generate = self.model.generate
-            sequences = generate(prompt_ids, **generation_kwargs)
+        sequences = self.model.generate(prompt_ids, **generation_kwargs)
 
         if hasattr(sequences, "sequences"):
             sequences = sequences.sequences

--- a/unturtle/eval/gsm8k.py
+++ b/unturtle/eval/gsm8k.py
@@ -51,7 +51,7 @@ class GSM8KEvaluator(BaseEvaluator):
 
     Loads the HuggingFace ``gsm8k`` dataset, formats each question as a
     zero-shot chat prompt via ``apply_chat_template``, generates with
-    ``diffusion_generate``, extracts the numeric answer, and compares to
+    ``generate``, extracts the numeric answer, and compares to
     the gold answer.
 
     Metrics returned by :meth:`evaluate`:
@@ -95,28 +95,13 @@ class GSM8KEvaluator(BaseEvaluator):
         ).to(self.device)
         prompt_len = input_ids.shape[1]
 
-        diffusion_generate = getattr(self.model, "diffusion_generate", None)
         max_length = prompt_len + self.max_new_tokens
-        if callable(diffusion_generate):
-            sequences = diffusion_generate(
-                input_ids,
-                max_length=max_length,
-                steps=self.num_steps,
-                temperature=self.temperature,
-            )
-        else:
-            import warnings
-
-            warnings.warn(
-                f"{type(self.model).__name__} has no diffusion_generate method. "
-                "Falling back to model.generate — results are NOT diffusion-model results.",
-                stacklevel=2,
-            )
-            hf_kwargs: dict[str, Any] = {"max_length": max_length}
-            if self.temperature > 0.0:
-                hf_kwargs["do_sample"] = True
-                hf_kwargs["temperature"] = self.temperature
-            sequences = self.model.generate(input_ids, **hf_kwargs)
+        sequences = self.model.generate(
+            input_ids,
+            max_length=max_length,
+            steps=self.num_steps,
+            temperature=self.temperature,
+        )
 
         if hasattr(sequences, "sequences"):
             sequences = sequences.sequences
@@ -143,7 +128,7 @@ class GSM8KEvaluator(BaseEvaluator):
         num_examples: int | None = None,
         seed: int = 42,
     ) -> dict[str, float]:
-        # Generation runs one example at a time: diffusion_generate is
+        # Generation runs one example at a time: generate is
         # memory-intensive and does not support batch_size > 1 here.
         dataset = self._load_dataset(split, seed, num_examples)
 

--- a/unturtle/eval/gsm8k.py
+++ b/unturtle/eval/gsm8k.py
@@ -96,8 +96,11 @@ class GSM8KEvaluator(BaseEvaluator):
         prompt_len = input_ids.shape[1]
 
         max_length = prompt_len + self.max_new_tokens
+        # algorithm="mdlm": pins pre-unification no-cache MDLM so recorded
+        # DecodingConfigs keep describing the real decode path.
         sequences = self.model.generate(
             input_ids,
+            algorithm="mdlm",
             max_length=max_length,
             steps=self.num_steps,
             temperature=self.temperature,

--- a/unturtle/eval/harness/configs.py
+++ b/unturtle/eval/harness/configs.py
@@ -45,8 +45,11 @@ class DecodingConfig:
 
 
 # NOTE: only hyperparameters that actually take effect in the adapter/generation path are
-# recorded here, so a recorded config never misrepresents the real decoding. Knobs the dLLM
-# paper highlights but that are not yet wired into generation (e.g. eos-suppression,
+# recorded here, so a recorded config never misrepresents the real decoding. The adapter
+# explicitly pins algorithm="mdlm" so the no-cache MDLM decode path (pre-unification
+# default) is preserved; adding an "algorithm" field to DecodingConfig is deliberately
+# deferred until a canonical path switch is intentionally recorded. Knobs the dLLM paper
+# highlights but that are not yet wired into generation (e.g. eos-suppression,
 # parallel-decode width) will be added when the generation path honors them.
 
 

--- a/unturtle/eval/harness/model_adapter.py
+++ b/unturtle/eval/harness/model_adapter.py
@@ -21,7 +21,6 @@ requires ``lm_eval``.
 
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 
@@ -74,7 +73,7 @@ def build_harness_lm(
     lm_base = _import_lm_base()
 
     class UnturtleHarnessLM(lm_base):  # type: ignore[misc, valid-type]
-        """Routes lm-eval ``generate_until`` through ``diffusion_generate``."""
+        """Routes lm-eval ``generate_until`` through ``generate``."""
 
         def __init__(self) -> None:
             super().__init__()
@@ -112,22 +111,13 @@ def build_harness_lm(
                     getattr(self._model, "config", None), "mask_token_id", None
                 )
 
-            diffusion_generate = getattr(self._model, "diffusion_generate", None)
-            if callable(diffusion_generate):
-                sequences = diffusion_generate(
-                    input_ids,
-                    max_length=max_length,
-                    mask_token_id=mask_token_id,
-                    steps=self._num_steps,
-                    temperature=self._temperature,
-                )
-            else:
-                warnings.warn(
-                    f"{type(self._model).__name__} has no diffusion_generate method. "
-                    "Falling back to model.generate — results are NOT diffusion results.",
-                    stacklevel=2,
-                )
-                sequences = self._model.generate(input_ids, max_length=max_length)
+            sequences = self._model.generate(
+                input_ids,
+                max_length=max_length,
+                mask_token_id=mask_token_id,
+                steps=self._num_steps,
+                temperature=self._temperature,
+            )
 
             if hasattr(sequences, "sequences"):
                 sequences = sequences.sequences

--- a/unturtle/eval/harness/model_adapter.py
+++ b/unturtle/eval/harness/model_adapter.py
@@ -111,8 +111,12 @@ def build_harness_lm(
                     getattr(self._model, "config", None), "mask_token_id", None
                 )
 
+            # algorithm="mdlm": pins pre-unification no-cache MDLM so recorded
+            # DecodingConfigs keep describing the real decode path; switching the
+            # canonical path to block-decode must be an explicit, recorded decision.
             sequences = self._model.generate(
                 input_ids,
+                algorithm="mdlm",
                 max_length=max_length,
                 mask_token_id=mask_token_id,
                 steps=self._num_steps,

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -84,10 +84,6 @@ from unturtle.models.backbones.modernbert._fast_forward import (
 from unturtle.models.conversion.a2d.tiny_a2d._fast_forward import (
     TinyA2DAttention_fast_forward,
 )
-from unturtle.models.generation.sampler import (
-    algorithm_to_flags,
-    resolve_algorithm,
-)
 from unturtle.save import patch_saving_functions, prepare_model_for_kbit_training
 
 _logger = logging.getLogger(__name__)
@@ -1216,46 +1212,28 @@ class FastDiffusionModel:
         algorithm: str = "auto",
         **kwargs: Any,
     ) -> Any:
-        """Generate from a dLLM with an explicit decoding algorithm.
+        """Generate from a dLLM via its unified ``generate`` entry point.
 
-        High-level, unsloth-style inference entry. ``algorithm`` selects the decoding path:
-
-          - ``"auto"`` (default): fastest discrete algorithm the model supports —
-            block-decode (Fast-dLLM) when available, else MDLM; BD3LM when requested.
-          - ``"mdlm"`` / ``"block_decode"`` / ``"bd3lm"``: force a named path
-            (benchmarking / research / algorithm comparison).
-
-        Delegates to ``model.diffusion_generate(...)`` with the flag set the chosen
-        algorithm implies, so output is identical to calling ``diffusion_generate`` with
-        those flags directly. ``**kwargs`` (steps, temperature, max_new_tokens, ...) are
-        forwarded unchanged.
+        Thin facade that forwards to ``model.generate(inputs, algorithm=...)``.
+        Algorithm resolution (auto/mdlm/block_decode/bd3lm) happens inside the
+        model's ``generate``. Output is whatever ``model.generate`` returns.
 
         Args:
-            model: A dLLM model exposing ``diffusion_generate`` (e.g. from
+            model: A dLLM model exposing ``generate`` (e.g. from
                 ``FastDiffusionModel.from_pretrained``).
             inputs: Prompt token IDs (``[B, L]``).
             algorithm: ``"auto"`` | ``"mdlm"`` | ``"block_decode"`` | ``"bd3lm"``.
-            **kwargs: Forwarded to ``diffusion_generate`` / the generation config.
+            **kwargs: Forwarded to ``model.generate`` / the generation config.
 
         Returns:
-            Whatever ``model.diffusion_generate`` returns (token IDs or model output).
+            Whatever ``model.generate`` returns (token IDs or model output).
         """
-        if not callable(getattr(model, "diffusion_generate", None)):
+        if not callable(getattr(model, "generate", None)):
             raise TypeError(
-                f"{type(model).__name__} has no `diffusion_generate` method; "
+                f"{type(model).__name__} has no `generate` method; "
                 "FastDiffusionModel.generate requires a dLLM model."
             )
-
-        bd3lm_requested = bool(kwargs.get("use_block_diffusion", False)) or (
-            algorithm == "bd3lm"
-        )
-        resolved = resolve_algorithm(algorithm, model, bd3lm_requested=bd3lm_requested)
-        flags = algorithm_to_flags(resolved)
-
-        # Explicit algorithm flags win over any conflicting legacy flags in kwargs,
-        # so the named algorithm is authoritative.
-        call_kwargs = {**kwargs, **flags}
-        return model.diffusion_generate(inputs=inputs, **call_kwargs)
+        return model.generate(inputs, algorithm=algorithm, **kwargs)
 
     @staticmethod
     def for_training(model: Any, use_gradient_checkpointing: bool | str = True) -> Any:

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -1185,8 +1185,9 @@ class FastDiffusionModel:
         Sets ``model.eval()`` and disables gradient checkpointing so that
         inference is as fast as possible.  Returns the model for convenience.
 
-        Note: dLLMs do not use KV cache, so there is no cache-enabling step
-        unlike ``FastLanguageModel.for_inference`` for AR models.
+        Note: plain MDLM does not use KV cache; block-decode models manage their
+        own dLLM cache internally.  Either way, no external cache-enabling step
+        is needed here, unlike ``FastLanguageModel.for_inference`` for AR models.
 
         Usage::
 

--- a/unturtle/models/backbones/dream/generation_utils.py
+++ b/unturtle/models/backbones/dream/generation_utils.py
@@ -164,7 +164,7 @@ class DreamGenerationConfig(GenerationConfig):
 
         self.validate(is_init=True)
 
-    def validate(self, is_init: bool = False):
+    def validate(self, is_init: bool = False, **kwargs):
         if self.parallel_decode and not self.use_cache:
             raise ValueError("`parallel_decode=True` requires `use_cache=True`.")
         if self.parallel_decode and self.alg == "origin":

--- a/unturtle/models/backbones/dream/generation_utils.py
+++ b/unturtle/models/backbones/dream/generation_utils.py
@@ -362,12 +362,25 @@ class DreamGenerationMixin(BlockDecodeMixin):
         generation_config._mask_token_tensor = mask_token_tensor
 
     @torch.no_grad()
-    def diffusion_generate(
+    def generate(
         self,
         inputs: Optional[torch.Tensor] = None,
+        *,
+        algorithm: str = "auto",
         generation_config: Optional[DreamGenerationConfig] = None,
         **kwargs,
     ) -> Union[DreamModelOutput, torch.LongTensor]:
+        from unturtle.models.generation.sampler import (
+            algorithm_to_flags,
+            resolve_algorithm,
+        )
+
+        bd3lm_requested = bool(kwargs.get("use_block_diffusion", False)) or (
+            algorithm == "bd3lm"
+        )
+        resolved = resolve_algorithm(algorithm, self, bd3lm_requested=bd3lm_requested)
+        kwargs = {**kwargs, **algorithm_to_flags(resolved)}
+
         # 1. Handle `generation_config` and kwargs that might update it, and validate the `.generate()` call
         generation_config = self._prepare_generation_config(generation_config, **kwargs)
         generation_tokens_hook_func = kwargs.pop("generation_tokens_hook_func", None)

--- a/unturtle/models/backbones/dream/generation_utils.py
+++ b/unturtle/models/backbones/dream/generation_utils.py
@@ -370,6 +370,15 @@ class DreamGenerationMixin(BlockDecodeMixin):
         generation_config: Optional[DreamGenerationConfig] = None,
         **kwargs,
     ) -> Union[DreamModelOutput, torch.LongTensor]:
+        """Run masked-diffusion generation.
+
+        ``algorithm`` selects the decode path: ``"auto"`` (default) resolves to
+        ``"block_decode"`` when the model supports it, else ``"mdlm"``;
+        ``"mdlm"`` and ``"block_decode"`` are also accepted explicitly.
+        ``"bd3lm"`` raises ``ValueError`` — Dream does not implement
+        ``_sample_block_diffusion``.  The resolved algorithm's flags are injected
+        into kwargs, overriding any conflicting ``generation_config`` fields.
+        """
         from unturtle.models.generation.sampler import (
             algorithm_to_flags,
             resolve_algorithm,

--- a/unturtle/models/backbones/llada/generation_utils.py
+++ b/unturtle/models/backbones/llada/generation_utils.py
@@ -92,8 +92,8 @@ class LLaDAGenerationMixin(BlockDecodeMixin, MaskedDiffusionGenerationMixin):
         if mask_token_id is None:
             raise ValueError(
                 "`mask_token_id` must be set in `generation_config` or `model.config` before calling "
-                "`diffusion_generate()`.  Pass it explicitly: "
-                "`model.diffusion_generate(inputs, mask_token_id=<id>, ...)`"
+                "`generate()`.  Pass it explicitly: "
+                "`model.generate(inputs, mask_token_id=<id>, ...)`"
             )
 
         histories = [] if (return_dict_out and output_history) else None

--- a/unturtle/models/backbones/llada/modeling_llada.py
+++ b/unturtle/models/backbones/llada/modeling_llada.py
@@ -1960,22 +1960,6 @@ class LLaDAModelLM(LLaDAGenerationMixin, LLaDAPreTrainedModel):
     def can_generate(self) -> bool:
         return True
 
-    def generate(self, inputs=None, generation_config=None, **kwargs):
-        """Redirect HF autoregressive ``generate()`` to ``diffusion_generate()``.
-
-        LLaDA uses MDLM-style masked diffusion, not autoregressive KV-cache
-        generation.  Calling HF's inherited ``generate()`` would invoke
-        ``prepare_inputs_for_generation()`` (AR protocol) and produce incorrect
-        output.  This override ensures that ``model.generate(...)`` always
-        routes to :meth:`diffusion_generate`.
-
-        The ``generation_config`` positional argument mirrors HF's signature so
-        that callers that pass it positionally work correctly.
-        """
-        return self.diffusion_generate(
-            inputs, generation_config=generation_config, **kwargs
-        )
-
     # TODO: these are required to make the implementation complete.
     # def resize_position_embeddings(self, new_num_position_embeddings: int):
     #     pass

--- a/unturtle/models/backbones/modernbert/modeling.py
+++ b/unturtle/models/backbones/modernbert/modeling.py
@@ -69,6 +69,8 @@ class DiffusionModernBertForMaskedLM(
     """
 
     config_class = DiffusionModernBertConfig
+    # Encoder backbone returns no past_key_values; block-decode cache hook unusable.
+    supports_block_decode = False
 
     def __init__(self, config: DiffusionModernBertConfig):
         super().__init__(config)

--- a/unturtle/models/generation/block_decode_mixin.py
+++ b/unturtle/models/generation/block_decode_mixin.py
@@ -78,6 +78,13 @@ class BlockDecodeMixin:
         block_length = getattr(generation_config, "block_length", None)
         steps = generation_config.steps
         mask_token_id = generation_config.mask_token_id
+        if mask_token_id is None:
+            mask_token_id = getattr(self.config, "mask_token_id", None)
+        if mask_token_id is None:
+            raise ValueError(
+                "`mask_token_id` must be set in `generation_config` or `model.config` before calling "
+                "`generate()` with `use_cache=True`."
+            )
         use_replace_cache = getattr(generation_config, "use_replace_cache", False)
         alg = generation_config.alg
         temperature = getattr(generation_config, "temperature", 1.0)

--- a/unturtle/models/generation/diffusion_generation_utils.py
+++ b/unturtle/models/generation/diffusion_generation_utils.py
@@ -517,7 +517,7 @@ def _diffusion_step_block(
 
 @dataclass
 class MaskedDiffusionModelOutput(ModelOutput):
-    """Output of :meth:`MaskedDiffusionGenerationMixin.diffusion_generate`."""
+    """Output of :meth:`MaskedDiffusionGenerationMixin.generate`."""
 
     sequences: torch.LongTensor = None
     history: Optional[Tuple[torch.LongTensor, ...]] = None
@@ -699,10 +699,10 @@ class MaskedDiffusionGenerationConfig(GenerationConfig):
 class MaskedDiffusionGenerationMixin:
     """Generation mixin for MDLM-style masked diffusion LMs.
 
-    Provides :meth:`diffusion_generate` which implements the iterative masked-
-    token denoising loop.  The mixin is designed to be mixed into model classes
-    as the *first* base class so that its :meth:`diffusion_generate` takes
-    precedence over HuggingFace's autoregressive ``generate``.
+    Provides :meth:`generate` which implements the iterative masked-token
+    denoising loop with algorithm dispatch.  The mixin is designed to be mixed
+    into model classes as the *first* base class so that its :meth:`generate`
+    takes precedence over HuggingFace's autoregressive ``generate``.
 
     Subclasses must implement a HF-compatible ``forward(input_ids, ...)`` that
     returns an object with a ``.logits`` attribute of shape ``[B, L, V]``.
@@ -813,19 +813,31 @@ class MaskedDiffusionGenerationMixin:
     # ------------------------------------------------------------------
 
     @torch.no_grad()
-    def diffusion_generate(
+    def generate(
         self,
         inputs: Optional[torch.Tensor] = None,
+        *,
+        algorithm: str = "auto",
         generation_config: Optional[MaskedDiffusionGenerationConfig] = None,
         **kwargs,
     ) -> Union[MaskedDiffusionModelOutput, torch.LongTensor]:
-        """Generate sequences via MDLM-style iterative masked-token denoising.
+        """Generate sequences via masked diffusion.
+
+        ``algorithm`` selects the discrete decoding path (``"auto"`` |
+        ``"mdlm"`` | ``"block_decode"`` | ``"bd3lm"``). The resolved
+        algorithm's flags (``use_cache`` / ``use_block_diffusion``) are
+        injected before the denoising loop runs.
 
         Parameters
         ----------
         inputs : LongTensor of shape ``[B, L]``
             Prompt token IDs.  Completion positions should already be filled
             with ``mask_token_id``.
+        algorithm : str, optional
+            Decoding algorithm to use.  ``"auto"`` (default) picks the
+            fastest discrete path the model supports: block-decode when
+            available, else plain MDLM; BD3LM when
+            ``use_block_diffusion=True`` is set in kwargs.
         generation_config : MaskedDiffusionGenerationConfig, optional
             Generation parameters.  If ``None``, model defaults are used.
         **kwargs
@@ -839,6 +851,18 @@ class MaskedDiffusionGenerationMixin:
             :class:`MaskedDiffusionModelOutput`; otherwise returns the
             token-ID tensor directly.
         """
+        from unturtle.models.generation.sampler import (
+            algorithm_to_flags,
+            resolve_algorithm,
+        )
+
+        bd3lm_requested = bool(kwargs.get("use_block_diffusion", False)) or (
+            algorithm == "bd3lm"
+        )
+        resolved = resolve_algorithm(algorithm, self, bd3lm_requested=bd3lm_requested)
+        flags = algorithm_to_flags(resolved)
+        kwargs = {**kwargs, **flags}
+
         generation_config = self._prepare_generation_config(generation_config, **kwargs)
 
         assert inputs is not None, "`inputs` (input_ids) must be provided"
@@ -861,7 +885,7 @@ class MaskedDiffusionGenerationMixin:
 
         if not is_torchdynamo_compiling() and self.device.type != input_ids.device.type:
             warnings.warn(
-                "You are calling .diffusion_generate() with `input_ids` on a different device type than the model."
+                "You are calling .generate() with `input_ids` on a different device type than the model."
                 f" `input_ids` is on {input_ids.device.type}, model is on {self.device.type}.",
                 UserWarning,
             )
@@ -916,8 +940,8 @@ class MaskedDiffusionGenerationMixin:
         if mask_token_id is None:
             raise ValueError(
                 "`mask_token_id` must be set in `generation_config` or `model.config` before calling "
-                "`diffusion_generate()`.  Pass it explicitly: "
-                "`model.diffusion_generate(inputs, mask_token_id=<id>, ...)`"
+                "`generate()`.  Pass it explicitly: "
+                "`model.generate(inputs, mask_token_id=<id>, ...)`"
             )
 
         histories = [] if (return_dict_out and output_history) else None
@@ -1104,7 +1128,7 @@ class MaskedDiffusionGenerationMixin:
         if mask_token_id is None:
             raise ValueError(
                 "`mask_token_id` must be set in `generation_config` or `model.config` before calling "
-                "`diffusion_generate()` with `use_cache=True`."
+                "`generate()` with `use_cache=True`."
             )
 
         # Warn if output_history is requested (not yet supported in cache path)

--- a/unturtle/models/generation/masked_diffusion_block_mixin.py
+++ b/unturtle/models/generation/masked_diffusion_block_mixin.py
@@ -186,7 +186,7 @@ class MaskedDiffusionBlockGenerationMixin(
         if mask_id is None:
             raise ValueError(
                 "`mask_token_id` must be set in `generation_config` or `model.config` "
-                "before calling `diffusion_generate(use_block_diffusion=True)`."
+                "before calling `generate(algorithm='bd3lm')`."
             )
 
         pad_id = generation_config.pad_token_id
@@ -195,7 +195,7 @@ class MaskedDiffusionBlockGenerationMixin(
         if pad_id is None:
             raise ValueError(
                 "`pad_token_id` must be set in `generation_config` or `model.config` "
-                "before calling `diffusion_generate(use_block_diffusion=True)`."
+                "before calling `generate(algorithm='bd3lm')`."
             )
 
         eos_id = generation_config.eos_token_id

--- a/unturtle/models/generation/sampler.py
+++ b/unturtle/models/generation/sampler.py
@@ -16,13 +16,16 @@
 
 Makes the decoding algorithm an explicit, first-class choice instead of an implicit
 combination of ``MaskedDiffusionGenerationConfig`` flags. Each named algorithm maps to the
-flag set that the existing ``diffusion_generate`` dispatch already understands — so this is
+flag set that the model's ``generate`` dispatch understands — so this is
 pure *selection*, with no generation logic of its own.
 
 Algorithms (discrete masked diffusion):
   - ``mdlm``         : plain MDLM denoising loop
   - ``block_decode`` : Fast-dLLM KV-cache block decode (parallel decode is an option within)
   - ``bd3lm``        : BD3LM block diffusion
+
+Algorithms (autoregressive):
+  - ``ar``           : autoregressive generation for AR-capable backbones (TinyA2D family)
 
 The registry is intentionally open: continuous-diffusion algorithms (e.g. ``continuous_*``)
 would be added to a separate table when continuous diffusion LMs land. The current loops are
@@ -39,6 +42,11 @@ DISCRETE_ALGORITHMS: dict[str, dict[str, bool]] = {
     "block_decode": {"use_cache": True, "use_block_diffusion": False},
     "bd3lm": {"use_cache": False, "use_block_diffusion": True},
 }
+
+#: model_types whose backbone retains a usable transformers autoregressive generate.
+_AR_CAPABLE_MODEL_TYPES: frozenset[str] = frozenset(
+    {"tiny-a2d-llama", "tiny-a2d-qwen2", "tiny-a2d-qwen3"}
+)
 
 
 def algorithm_to_flags(algorithm: str) -> dict[str, bool]:
@@ -57,14 +65,22 @@ def _supports_block_decode(model: Any) -> bool:
     return callable(getattr(model, "_model_forward_with_cache", None))
 
 
+def _supports_ar(model: Any) -> bool:
+    """True if the model exposes a usable autoregressive ``generate`` (TinyA2D family)."""
+    config = getattr(model, "config", None)
+    model_type = getattr(config, "model_type", None)
+    return model_type in _AR_CAPABLE_MODEL_TYPES
+
+
 def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> str:
-    """Resolve ``algorithm`` to a concrete discrete algorithm name.
+    """Resolve ``algorithm`` to a concrete algorithm name.
 
     ``auto`` picks the fastest discrete path the model supports:
       - BD3LM if requested,
       - else block-decode (Fast-dLLM) when the model supports the cache hook,
       - else plain MDLM.
-    An explicit algorithm name is validated and returned as-is.
+    ``ar`` is returned verbatim for AR-capable models and raises for others.
+    An explicit discrete algorithm name is validated and returned as-is.
     """
     if algorithm == "auto":
         if bd3lm_requested:
@@ -72,9 +88,16 @@ def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> s
         if _supports_block_decode(model):
             return "block_decode"
         return "mdlm"
+    if algorithm == "ar":
+        if not _supports_ar(model):
+            raise ValueError(
+                f"{type(model).__name__} does not support autoregressive "
+                "generation (algorithm='ar'); it is a pure diffusion model."
+            )
+        return "ar"
     if algorithm not in DISCRETE_ALGORITHMS:
         raise ValueError(
             f"Unknown decoding algorithm {algorithm!r}. "
-            f"Supported: {sorted(DISCRETE_ALGORITHMS)} (or 'auto')."
+            f"Supported: {sorted(DISCRETE_ALGORITHMS)} (or 'auto'/'ar')."
         )
     return algorithm

--- a/unturtle/models/generation/sampler.py
+++ b/unturtle/models/generation/sampler.py
@@ -21,8 +21,15 @@ pure *selection*, with no generation logic of its own.
 
 Algorithms (discrete masked diffusion):
   - ``mdlm``         : plain MDLM denoising loop
-  - ``block_decode`` : Fast-dLLM KV-cache block decode (parallel decode is an option within)
-  - ``bd3lm``        : BD3LM block diffusion
+  - ``block_decode`` : Fast-dLLM KV-cache block decode (parallel decode is an option within);
+                       requires the model to implement ``_model_forward_with_cache`` and opt in
+                       via ``supports_block_decode`` (defaults to ``True`` when absent).
+  - ``bd3lm``        : BD3LM block diffusion; requires ``_sample_block_diffusion``
+                       (TinyA2D family today).
+
+Explicit algorithm choices are capability-checked: passing an algorithm the model cannot
+execute raises ``ValueError`` immediately rather than silently falling back or crashing
+mid-generation.
 
 The registry is intentionally open: continuous-diffusion algorithms (e.g. ``continuous_*``)
 would be added to a separate table when continuous diffusion LMs land. The current loops are
@@ -53,21 +60,43 @@ def algorithm_to_flags(algorithm: str) -> dict[str, bool]:
 
 
 def _supports_block_decode(model: Any) -> bool:
-    """True if the model implements the Fast-dLLM block-decode cache hook."""
+    """True if the model implements the block-decode cache hook AND opts in.
+
+    ``supports_block_decode = False`` lets a backbone that inherits the mixin
+    generically (e.g. encoder backbones without KV cache) opt out of the
+    block-decode fast path.
+    """
+    if not getattr(model, "supports_block_decode", True):
+        return False
     return callable(getattr(model, "_model_forward_with_cache", None))
+
+
+def _supports_bd3lm(model: Any) -> bool:
+    """True if the model implements BD3LM block-diffusion sampling."""
+    return callable(getattr(model, "_sample_block_diffusion", None))
 
 
 def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> str:
     """Resolve ``algorithm`` to a concrete algorithm name.
 
     ``auto`` picks the fastest discrete path the model supports:
-      - BD3LM if requested,
+      - BD3LM if requested (and the model implements ``_sample_block_diffusion``),
       - else block-decode (Fast-dLLM) when the model supports the cache hook,
       - else plain MDLM.
-    An explicit discrete algorithm name is validated and returned as-is.
+
+    Explicit discrete algorithm names are capability-checked:
+      - ``"block_decode"`` requires ``_supports_block_decode(model)``.
+      - ``"bd3lm"`` (explicit or via auto + bd3lm_requested) requires
+        ``_supports_bd3lm(model)``; BD3LM is implemented on the TinyA2D family today.
     """
     if algorithm == "auto":
         if bd3lm_requested:
+            if not _supports_bd3lm(model):
+                raise ValueError(
+                    f"{type(model).__name__} does not implement BD3LM "
+                    f"(_sample_block_diffusion); supported on the TinyA2D family. "
+                    f"Use algorithm='mdlm' or 'block_decode'."
+                )
             return "bd3lm"
         if _supports_block_decode(model):
             return "block_decode"
@@ -76,5 +105,16 @@ def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> s
         raise ValueError(
             f"Unknown decoding algorithm {algorithm!r}. "
             f"Supported: {sorted(DISCRETE_ALGORITHMS)} (or 'auto')."
+        )
+    if algorithm == "block_decode" and not _supports_block_decode(model):
+        raise ValueError(
+            f"{type(model).__name__} does not support block-decode "
+            f"(no usable KV-cache forward); use algorithm='mdlm'."
+        )
+    if algorithm == "bd3lm" and not _supports_bd3lm(model):
+        raise ValueError(
+            f"{type(model).__name__} does not implement BD3LM "
+            f"(_sample_block_diffusion); supported on the TinyA2D family. "
+            f"Use algorithm='mdlm' or 'block_decode'."
         )
     return algorithm

--- a/unturtle/models/generation/sampler.py
+++ b/unturtle/models/generation/sampler.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from typing import Any
 
-#: Discrete masked-diffusion algorithms -> the diffusion_generate flag set each selects.
+#: Discrete masked-diffusion algorithms -> the generate() flag set each selects.
 DISCRETE_ALGORITHMS: dict[str, dict[str, bool]] = {
     "mdlm": {"use_cache": False, "use_block_diffusion": False},
     "block_decode": {"use_cache": True, "use_block_diffusion": False},
@@ -42,7 +42,7 @@ DISCRETE_ALGORITHMS: dict[str, dict[str, bool]] = {
 
 
 def algorithm_to_flags(algorithm: str) -> dict[str, bool]:
-    """Return the diffusion_generate flag set for a named discrete algorithm."""
+    """Return the generate() flag set for a named discrete algorithm."""
     try:
         return dict(DISCRETE_ALGORITHMS[algorithm])
     except KeyError as exc:

--- a/unturtle/models/generation/sampler.py
+++ b/unturtle/models/generation/sampler.py
@@ -24,9 +24,6 @@ Algorithms (discrete masked diffusion):
   - ``block_decode`` : Fast-dLLM KV-cache block decode (parallel decode is an option within)
   - ``bd3lm``        : BD3LM block diffusion
 
-Algorithms (autoregressive):
-  - ``ar``           : autoregressive generation for AR-capable backbones (TinyA2D family)
-
 The registry is intentionally open: continuous-diffusion algorithms (e.g. ``continuous_*``)
 would be added to a separate table when continuous diffusion LMs land. The current loops are
 discrete-masked-only.
@@ -42,11 +39,6 @@ DISCRETE_ALGORITHMS: dict[str, dict[str, bool]] = {
     "block_decode": {"use_cache": True, "use_block_diffusion": False},
     "bd3lm": {"use_cache": False, "use_block_diffusion": True},
 }
-
-#: model_types whose backbone retains a usable transformers autoregressive generate.
-_AR_CAPABLE_MODEL_TYPES: frozenset[str] = frozenset(
-    {"tiny-a2d-llama", "tiny-a2d-qwen2", "tiny-a2d-qwen3"}
-)
 
 
 def algorithm_to_flags(algorithm: str) -> dict[str, bool]:
@@ -65,13 +57,6 @@ def _supports_block_decode(model: Any) -> bool:
     return callable(getattr(model, "_model_forward_with_cache", None))
 
 
-def _supports_ar(model: Any) -> bool:
-    """True if the model exposes a usable autoregressive ``generate`` (TinyA2D family)."""
-    config = getattr(model, "config", None)
-    model_type = getattr(config, "model_type", None)
-    return model_type in _AR_CAPABLE_MODEL_TYPES
-
-
 def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> str:
     """Resolve ``algorithm`` to a concrete algorithm name.
 
@@ -79,7 +64,6 @@ def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> s
       - BD3LM if requested,
       - else block-decode (Fast-dLLM) when the model supports the cache hook,
       - else plain MDLM.
-    ``ar`` is returned verbatim for AR-capable models and raises for others.
     An explicit discrete algorithm name is validated and returned as-is.
     """
     if algorithm == "auto":
@@ -88,16 +72,9 @@ def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> s
         if _supports_block_decode(model):
             return "block_decode"
         return "mdlm"
-    if algorithm == "ar":
-        if not _supports_ar(model):
-            raise ValueError(
-                f"{type(model).__name__} does not support autoregressive "
-                "generation (algorithm='ar'); it is a pure diffusion model."
-            )
-        return "ar"
     if algorithm not in DISCRETE_ALGORITHMS:
         raise ValueError(
             f"Unknown decoding algorithm {algorithm!r}. "
-            f"Supported: {sorted(DISCRETE_ALGORITHMS)} (or 'auto'/'ar')."
+            f"Supported: {sorted(DISCRETE_ALGORITHMS)} (or 'auto')."
         )
     return algorithm


### PR DESCRIPTION
Closes #22

## Summary

- **Breaking (intentional, no alias):** `diffusion_generate` is removed everywhere. The sole dLLM inference entry is now transformers-standard `model.generate(inputs, *, algorithm="auto", generation_config=None, **kwargs)`, with diffusion as the default behavior.
- Algorithm→flags resolution moved from the `FastDiffusionModel.generate` facade down into the model `generate` (base `MaskedDiffusionGenerationMixin` + Dream's own mixin). LLaDA drops its `generate`→`diffusion_generate` redirect and inherits the mixin. The facade is now a thin forwarder, behaviorally identical to calling `model.generate` directly.
- **Design amendment (2026-06-12):** `algorithm="ar"` was dropped (YAGNI — converted Tiny-A2D checkpoints are diffusion models; no in-repo AR consumer). `"ar"` now fails as an unknown algorithm. The `"ar"` concept can return when a hybrid AR/diffusion backbone (e.g. Nemotron-Diffusion) lands. See the amended design spec/plan in `docs/superpowers/`.
- eval layer (`generation.py` / `gsm8k.py` / harness adapter), CLI `generate` command, examples, and benchmarks re-wired; ~99 test call sites routed through `generate` with assertions unchanged.

## Behavior notes for reviewers

- The resolved algorithm's flags (`use_cache`/`use_block_diffusion`) are injected into kwargs and **override `generation_config` fields**. Former *direct* `diffusion_generate` callers with `use_cache=False` intent (CLI default, examples, benchmark no-cache arm) now pin `algorithm="mdlm"` (or derive it from the flag) to preserve exact pre-refactor behavior — see `da49b46`.
- `algorithm="auto"` on cache-capable backbones selects block-decode (facade-equivalent fastest path). MRO precedence (diffusion `generate` over transformers AR `generate` on TinyA2D) is pinned by identity tests across llama/qwen2/qwen3 + LLaDA.
- Passing a non-dLLM model to the facade surfaces as a transformers `ValueError` ("model_kwargs not used: ['algorithm']") — accepted design risk (eval/facade are dLLM-only).
- Two RNG-order test flakes surfaced during the rewrite (unseeded random init + mask-absence assertions) and were seeded; the underlying decode question is tracked as a follow-up issue.

## Test plan

- [x] Full not-slow suite: **549 passed, 1 skipped, 0 failed**
- [x] `ruff check` / `ruff format --check` clean
- [x] New regression tests: sampler resolution + `"ar"`-rejected contract; MRO identity pins (TinyA2D ×3 variants, LLaDA); facade↔direct parity (mdlm/block_decode); `auto`≡block_decode and `auto+use_block_diffusion`≡bd3lm equivalence; harness adapter pins steps/temperature/mask_token_id forwarding
- [x] Per-task two-stage subagent review (spec compliance + code quality) + final whole-branch review
- [ ] (post-merge) targeted real-checkpoint slow/gpu regressions for generation paths

## Notes

- `origin/main` is currently 3 commits behind local `main`; once those are pushed this PR's diff reduces to the 18 branch commits.
- Default merge strategy: **Squash and merge** (repo convention).