### PR TITLE
✨ feat(backbones): DiffusionGemma backbone + block_ar algorithm + harness support (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,11 @@ unturtle       dLLM method layer: conversion, objective trainers, inference acce
 
 A concrete dLLM is a point in three independent axes. Place new code on the right axis:
 
-- **Backbone architecture** (`unturtle.models.backbones.{llada,dream,modernbert}`):
+- **Backbone architecture** (`unturtle.models.backbones.{llada,dream,modernbert,diffusion_gemma}`):
   native diffusion backbones Unturtle implements. LLaDA/Dream are full from-scratch
-  implementations; ModernBERT-diffusion wraps the upstream bidirectional encoder.
+  implementations; ModernBERT-diffusion wraps the upstream bidirectional encoder;
+  DiffusionGemma wraps the upstream `transformers` implementation — self-conditioned canvas
+  block diffusion, NOT masked diffusion (no mask token).
 - **Conversion method** (`unturtle.models.conversion`): how a non-diffusion backbone
   becomes a dLLM — a *method*, not a model. `a2d` is the AR→Diffusion family; the
   implemented recipe is **Tiny-A2D** (`unturtle.models.conversion.a2d.tiny_a2d`, classes
@@ -66,7 +68,7 @@ See `docs/dllm-gap-map.md` for the implemented-vs-missing method map and the roa
 │   ├── diffusion/          # trainer, collator, scheduler, GRPO
 │   ├── kernels/            # Triton kernels / fast LoRA
 │   ├── models/
-│   │   ├── backbones/      # native diffusion backbones: llada / dream / modernbert
+│   │   ├── backbones/      # native diffusion backbones: llada / dream / modernbert / diffusion_gemma
 │   │   ├── conversion/     # methods: a2d/ (family) → tiny_a2d/ (recipe)
 │   │   └── generation/     # shared infra: cache / block-decode / generation mixins
 │   ├── eval/               # smoke evaluators + lm-evaluation-harness adapter
@@ -173,19 +175,25 @@ must not require it (the adapter/runner import `lm_eval` lazily).
 
 `model.generate(inputs, algorithm="auto", **kwargs)` is the unified dLLM inference entry
 (transformers-standard name; diffusion is the default behavior). `algorithm` is explicit:
-`"auto"` (default — fastest discrete path the model supports: BD3LM when requested via the
-`use_block_diffusion=True` KWARG, else block-decode when available, else MDLM), or force
-`"mdlm"` / `"block_decode"` / `"bd3lm"`. The resolved algorithm's flags
-(`use_cache` / `use_block_diffusion`) are injected into kwargs and override
+`"auto"` (default — fastest discrete path the model supports: `"block_ar"` when the model
+supports it, else BD3LM when requested via the `use_block_diffusion=True` KWARG, else
+block-decode when available, else MDLM), or force `"mdlm"` / `"block_decode"` /
+`"bd3lm"` / `"block_ar"`. `"block_ar"` is self-conditioned canvas block diffusion
+(DiffusionGemma-style; no mask token); it is distinct from `"bd3lm"`, which is Unturtle's
+masked block diffusion (requires a mask token, TinyA2D family). The resolved algorithm's
+flags (`use_cache` / `use_block_diffusion`) are injected into kwargs and override
 `generation_config` fields — pin `algorithm="mdlm"` explicitly when the no-cache MDLM
 path is the intent on a block-decode-capable model. Explicit algorithm choices are
-capability-checked and raise `ValueError` immediately for unsupported combinations:
-`"bd3lm"` requires the model to implement `_sample_block_diffusion` (TinyA2D family today;
-Dream and LLaDA raise). `FastDiffusionModel.generate(model, inputs, algorithm=..., **kwargs)`
+capability-checked and raise `ValueError` immediately for unsupported combinations (e.g.
+`"bd3lm"` on DiffusionGemma, or `"block_ar"` on a masked-diffusion model). `FastDiffusionModel.generate(model, inputs, algorithm=..., **kwargs)`
 remains as a thin forwarder (unsloth-style facade, behaviorally identical to calling
-`model.generate` directly). Decoding algorithms are registered in
-`unturtle/models/generation/sampler.py`
-(discrete-masked-only today; the registry is open for future continuous-diffusion algorithms).
+`model.generate` directly). CLI `generate` is masked-dLLM-only (derives `mdlm` /
+`block_decode` from `--use-cache`); it cannot drive DiffusionGemma (no mask token — it
+fails at mask-token resolution) — use `model.generate(algorithm="block_ar")` directly for
+block-AR inference. Decoding algorithms are registered in
+`unturtle/models/generation/sampler.py` (masked loops mdlm/block_decode/bd3lm are
+discrete-masked-only; `block_ar` covers the canvas family; the registry is open for
+future continuous-diffusion algorithms).
 
 ## Issue, branch, commit, PR workflow
 

--- a/docs/dllm-gap-map.md
+++ b/docs/dllm-gap-map.md
@@ -35,7 +35,7 @@ unimportant, but not this library's job.
 | Training objectives | MDLM, BD3LM | ✅ | `unturtle/diffusion/trainer.py`, `block_diffusion_trainer.py` | core | maintain |
 | AR→Diffusion conversion | A2D family; Tiny-A2D recipe (DiffuLLaMA / TESS-2 / SDAR family) | ✅ | `unturtle/models/conversion/a2d/tiny_a2d/` | core | maintain |
 | Encoder backbones | ModernBERT-chat | ✅ | `unturtle/models/backbones/modernbert/` | medium | maintain |
-| Block-AR diffusion backbone | **DiffusionGemma** (Google, 26B-A4B MoE, block-AR diffusion; `transformers` `models/diffusion_gemma` wrapper) | ❌ (candidate) | — | high | **P1** |
+| Block-AR diffusion backbone | **DiffusionGemma** (Google, 26B-A4B MoE, block-AR diffusion; `transformers` `models/diffusion_gemma` wrapper) | ✅ (#25) | `unturtle/models/backbones/diffusion_gemma/` | high | maintain |
 | Tri-mode AR+diffusion backbone | **Nemotron-Labs-Diffusion** (NVIDIA 3B/8B/14B, AR + diffusion + self-spec; HF weights public) | ❌ (candidate) | — | medium | evaluate |
 | Evaluation discipline | lm-eval-harness, hyperparam sensitivity | ✅ | `unturtle/eval/harness/` | high | maintain |
 | High-level generation entry | `FastDiffusionModel.generate(algorithm=…)` | ✅ | `unturtle/models/generation/sampler.py` + `fast_diffusion_model.py` | high | maintain |
@@ -58,6 +58,8 @@ unimportant, but not this library's job.
 - Taxonomy axis-split (PR #292), eval canonicalization (PR #294), gap-map (PR #296),
   physical taxonomy migration (PR #298), high-level `FastDiffusionModel.generate` +
   algorithm registry (PR #300).
+- DiffusionGemma backbone wrapper + `block_ar` algorithm (self-conditioned canvas block
+  diffusion; no mask token) + `("diffusion_gemma","gsm8k")` DecodingConfig entry (#25).
 
 ### First roadmap after the clean migration
 
@@ -67,7 +69,7 @@ sequence is:
 1. **DiffusionGemma backbone** — wrap the upstream `transformers` `models/diffusion_gemma`
    implementation as a native block-AR diffusion backbone. Pairs with the `FastModel`
    delegation work (#15): models that carry their own loss/generation route through the
-   standard path, so this lands as a backbone wrapper, not a new objective.
+   standard path, so this lands as a backbone wrapper, not a new objective. — done (#25)
 2. **Nemotron evaluation** — evaluate Nemotron-Labs-Diffusion (tri-mode AR+diffusion+self-spec)
    on the canonical harness to decide whether to add it as a backbone.
 3. **unsloth CLI plugin mechanism** — propose the `unturtle` CLI integration as a plugin

--- a/tests/eval/test_harness_adapter.py
+++ b/tests/eval/test_harness_adapter.py
@@ -170,3 +170,78 @@ def test_loglikelihood_raises_not_implemented(
         lm.loglikelihood([_FakeInstance("ctx", {})])
     with pytest.raises(NotImplementedError):
         lm.loglikelihood_rolling([_FakeInstance("ctx", {})])
+
+
+# ---------------------------------------------------------------------------
+# block_ar algorithm path tests
+# ---------------------------------------------------------------------------
+
+
+def test_block_ar_algorithm_uses_correct_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """block_ar path forwards algorithm, max_new_tokens, max_denoising_steps only."""
+    _install_fake_lm_eval(monkeypatch)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    model = _StubModel()
+    lm = build_harness_lm(
+        model=model,
+        tokenizer=_StubTokenizer(),
+        num_steps=48,
+        max_new_tokens=256,
+        temperature=0.0,
+        use_chat_template=False,
+        algorithm="block_ar",
+    )
+    lm.generate_until([_FakeInstance("Q: 2+2?", {"until": []})])
+    assert model.calls, "generate was not called"
+    call = model.calls[-1]
+    assert call["algorithm"] == "block_ar"
+    assert call["max_denoising_steps"] == 48
+    assert "max_new_tokens" in call
+    # block_ar must NOT forward masked-diffusion-specific kwargs
+    for forbidden in ("steps", "mask_token_id", "temperature", "max_length"):
+        assert forbidden not in call, (
+            f"unexpected kwarg in block_ar call: {forbidden!r}"
+        )
+
+
+def test_mdlm_default_algorithm_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default path (no algorithm arg) still uses mdlm + masked kwargs."""
+    _install_fake_lm_eval(monkeypatch)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    model = _StubModel()
+    lm = build_harness_lm(
+        model=model,
+        tokenizer=_StubTokenizer(),
+        num_steps=4,
+        max_new_tokens=8,
+        temperature=0.5,
+        use_chat_template=False,
+    )
+    lm.generate_until([_FakeInstance("Q", {"until": []})])
+    call = model.calls[-1]
+    assert call["algorithm"] == "mdlm"
+    assert call["steps"] == 4
+    assert call["temperature"] == 0.5
+    assert "mask_token_id" in call
+    assert "max_length" in call
+
+
+def test_decoding_config_algorithm_field() -> None:
+    """DecodingConfig has algorithm field; existing entries default to 'mdlm'."""
+    from unturtle.eval.harness.configs import DecodingConfig, get_decoding_config
+
+    # Existing entries default to mdlm
+    cfg_a2d = get_decoding_config("a2d_qwen3", "gsm8k")
+    assert cfg_a2d.algorithm == "mdlm"
+
+    # diffusion_gemma entry uses block_ar
+    cfg_dg = get_decoding_config("diffusion_gemma", "gsm8k")
+    assert cfg_dg.algorithm == "block_ar"
+    assert cfg_dg.num_steps == 48
+    assert cfg_dg.max_new_tokens == 256

--- a/tests/eval/test_harness_runner.py
+++ b/tests/eval/test_harness_runner.py
@@ -102,3 +102,32 @@ def test_runner_requires_lm_eval(monkeypatch: pytest.MonkeyPatch) -> None:
             model_family="a2d_qwen3",
             task="gsm8k",
         )
+
+
+def test_runner_threads_algorithm_to_build_harness_lm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DecodingConfig.algorithm is passed through to build_harness_lm."""
+    captured: dict[str, Any] = {}
+    _install_fake_lm_eval(monkeypatch, captured)
+    _patch_loader(monkeypatch)
+
+    import unturtle.eval.harness.runner as runner_mod
+
+    class _StubHarnessLM:
+        pass
+
+    def capturing_build_harness_lm(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+        return _StubHarnessLM()
+
+    monkeypatch.setattr(runner_mod, "build_harness_lm", capturing_build_harness_lm)
+
+    from unturtle.eval.harness.runner import run_harness_evaluation
+
+    run_harness_evaluation(
+        model_name="dummy/model",
+        model_family="diffusion_gemma",
+        task="gsm8k",
+    )
+    assert captured["algorithm"] == "block_ar"

--- a/tests/models/test_diffusion_gemma.py
+++ b/tests/models/test_diffusion_gemma.py
@@ -1,0 +1,192 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the UnturtleDiffusionGemmaForBlockDiffusion wrapper.
+
+Step-0 findings (CPU generate confirmed working):
+  - DiffusionGemmaForBlockDiffusion(config) takes the top-level DiffusionGemmaConfig.
+  - vision_config=None triggers AutoModel.from_config(None) → ValueError; a real
+    (tiny) Gemma4VisionConfig is required.
+  - DiffusionGemmaTextConfig requires num_experts / top_k_experts / moe_intermediate_size
+    (all default to None, but the encoder layer always instantiates the router+experts).
+  - num_global_key_value_heads must be set; full-attention layers use it for GQA.
+  - Minimal working config: hidden_size=32, num_hidden_layers=2, num_experts=2,
+    top_k_experts=1, moe_intermediate_size=32, canvas_length=16.
+  - Tiny generate call: DiffusionGemmaGenerationConfig(max_new_tokens=8,
+    max_denoising_steps=2); output is DiffusionGemmaGenerationOutput with .sequences.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def _tiny_model():
+    """Build a minimal CPU DiffusionGemma model for fast unit tests.
+
+    All field sizes are kept as small as possible (hidden=32, 2 layers, vocab=256,
+    2 experts) so that model construction and a short generate pass run in seconds
+    on CPU.
+    """
+    from transformers import Gemma4VisionConfig
+    from transformers.models.diffusion_gemma import (
+        DiffusionGemmaConfig,
+        DiffusionGemmaTextConfig,
+    )
+
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+
+    vis_cfg = Gemma4VisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=64,
+        pooling_kernel_size=2,
+        patch_size=4,
+        position_embedding_size=16,
+    )
+
+    text_cfg = DiffusionGemmaTextConfig(
+        vocab_size=256,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_global_key_value_heads=2,
+        head_dim=16,
+        global_head_dim=16,
+        max_position_embeddings=64,
+        sliding_window=64,
+        num_experts=2,
+        top_k_experts=1,
+        moe_intermediate_size=32,
+    )
+
+    cfg = DiffusionGemmaConfig(
+        text_config=text_cfg,
+        vision_config=vis_cfg,
+        canvas_length=16,
+    )
+
+    model = UnturtleDiffusionGemmaForBlockDiffusion(cfg)
+    model.eval()
+    return model
+
+
+def _tiny_gen_cfg(max_denoising_steps: int = 2, max_new_tokens: int = 8):
+    from transformers.models.diffusion_gemma import DiffusionGemmaGenerationConfig
+
+    cfg = DiffusionGemmaGenerationConfig(
+        max_new_tokens=max_new_tokens,
+        max_denoising_steps=max_denoising_steps,
+    )
+    cfg.pad_token_id = 0
+    cfg.eos_token_id = 1
+    return cfg
+
+
+def test_generate_auto_runs_block_ar():
+    model = _tiny_model()
+    prompt = torch.tensor([[1, 2, 3, 4]])
+    with torch.no_grad():
+        out = model.generate(prompt, generation_config=_tiny_gen_cfg())
+    seq = out.sequences if hasattr(out, "sequences") else out
+    assert seq.shape[0] == 1
+    assert seq.shape[-1] >= prompt.shape[-1]
+
+
+@pytest.mark.parametrize("algorithm", ["mdlm", "block_decode", "bd3lm"])
+def test_generate_masked_algorithms_raise(algorithm):
+    model = _tiny_model()
+    prompt = torch.tensor([[1, 2, 3, 4]])
+    with pytest.raises(ValueError):
+        model.generate(prompt, algorithm=algorithm, generation_config=_tiny_gen_cfg())
+
+
+def test_generate_explicit_block_ar_matches_auto():
+    """Explicit ``algorithm='block_ar'`` must produce the same result as ``'auto'``."""
+    model = _tiny_model()
+    prompt = torch.tensor([[1, 2, 3, 4]])
+    gen_cfg_auto = _tiny_gen_cfg()
+    gen_cfg_explicit = _tiny_gen_cfg()
+
+    with torch.no_grad():
+        # Use same seed so the stochastic denoising loop produces identical outputs.
+        torch.manual_seed(42)
+        out_auto = model.generate(
+            prompt, algorithm="auto", generation_config=gen_cfg_auto
+        )
+        torch.manual_seed(42)
+        out_explicit = model.generate(
+            prompt, algorithm="block_ar", generation_config=gen_cfg_explicit
+        )
+
+    seq_auto = out_auto.sequences if hasattr(out_auto, "sequences") else out_auto
+    seq_explicit = (
+        out_explicit.sequences if hasattr(out_explicit, "sequences") else out_explicit
+    )
+    assert torch.equal(seq_auto, seq_explicit)
+
+
+def test_generate_is_shim_not_upstream():
+    from transformers.models.diffusion_gemma import DiffusionGemmaGenerationMixin
+
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+
+    assert (
+        UnturtleDiffusionGemmaForBlockDiffusion.generate
+        is not DiffusionGemmaGenerationMixin.generate
+    )
+
+
+def test_model_type_unchanged():
+    """Wrapping must NOT change the upstream model_type (real checkpoints carry it)."""
+    model = _tiny_model()
+    assert model.config.model_type == "diffusion_gemma"
+
+
+def test_no_masked_diffusion_mixin():
+    """The wrapper must NOT inherit any masked-diffusion mixin."""
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+
+    # These mixins carry mask-token semantics and must not be in the MRO.
+    from unturtle.models.generation.diffusion_generation_utils import (
+        MaskedDiffusionGenerationMixin,
+    )
+
+    assert not issubclass(
+        UnturtleDiffusionGemmaForBlockDiffusion, MaskedDiffusionGenerationMixin
+    ), "Wrapper must not inherit MaskedDiffusionGenerationMixin"
+
+
+def test_generate_keyword_input_ids():
+    """model.generate(input_ids=...) must work (HF canonical call style)."""
+    model = _tiny_model()
+    prompt = torch.tensor([[1, 2, 3, 4]])
+    with torch.no_grad():
+        out = model.generate(input_ids=prompt, generation_config=_tiny_gen_cfg())
+    seq = out.sequences if hasattr(out, "sequences") else out
+    assert seq.shape[0] == 1
+    assert seq.shape[-1] >= prompt.shape[-1]

--- a/tests/models/test_diffusion_gemma.py
+++ b/tests/models/test_diffusion_gemma.py
@@ -267,3 +267,25 @@ def test_post_load_swap_installs_shim():
     assert type(model) is not UnturtleDiffusionGemmaForBlockDiffusion
     fdm._apply_post_load_class_swap(model)
     assert type(model) is UnturtleDiffusionGemmaForBlockDiffusion
+
+
+def test_post_load_swap_removes_instance_generate_patch():
+    """unsloth installs an instance-level generate; the swap must drop it so the shim wins."""
+    from unturtle import fast_diffusion_model as fdm
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+
+    model = _tiny_upstream_model()
+    sentinel_called = []
+
+    def _fake_unsloth_generate(*a, **k):
+        sentinel_called.append(True)
+
+    model.generate = _fake_unsloth_generate  # instance-level patch, like unsloth
+    fdm._apply_post_load_class_swap(model)
+    assert "generate" not in model.__dict__
+    assert type(model) is UnturtleDiffusionGemmaForBlockDiffusion
+    # bound method now resolves to the shim, not the sentinel
+    assert model.generate.__func__ is UnturtleDiffusionGemmaForBlockDiffusion.generate
+    assert not sentinel_called

--- a/tests/models/test_diffusion_gemma.py
+++ b/tests/models/test_diffusion_gemma.py
@@ -91,6 +91,60 @@ def _tiny_model():
     return model
 
 
+def _tiny_upstream_model():
+    """Build a minimal upstream DiffusionGemmaForBlockDiffusion (not wrapped).
+
+    Uses the same tiny config as _tiny_model() but returns the upstream class
+    directly, for testing class swap behavior.
+    """
+    from transformers import Gemma4VisionConfig
+    from transformers.models.diffusion_gemma import (
+        DiffusionGemmaConfig,
+        DiffusionGemmaForBlockDiffusion,
+        DiffusionGemmaTextConfig,
+    )
+
+    vis_cfg = Gemma4VisionConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=64,
+        pooling_kernel_size=2,
+        patch_size=4,
+        position_embedding_size=16,
+    )
+
+    text_cfg = DiffusionGemmaTextConfig(
+        vocab_size=256,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        num_global_key_value_heads=2,
+        head_dim=16,
+        global_head_dim=16,
+        max_position_embeddings=64,
+        sliding_window=64,
+        num_experts=2,
+        top_k_experts=1,
+        moe_intermediate_size=32,
+    )
+
+    cfg = DiffusionGemmaConfig(
+        text_config=text_cfg,
+        vision_config=vis_cfg,
+        canvas_length=16,
+    )
+
+    model = DiffusionGemmaForBlockDiffusion(cfg)
+    model.eval()
+    return model
+
+
 def _tiny_gen_cfg(max_denoising_steps: int = 2, max_new_tokens: int = 8):
     from transformers.models.diffusion_gemma import DiffusionGemmaGenerationConfig
 
@@ -190,3 +244,26 @@ def test_generate_keyword_input_ids():
     seq = out.sequences if hasattr(out, "sequences") else out
     assert seq.shape[0] == 1
     assert seq.shape[-1] >= prompt.shape[-1]
+
+
+def test_class_swap_registered_for_diffusion_gemma():
+    from unturtle import fast_diffusion_model as fdm
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+
+    resolver = fdm._POST_LOAD_CLASS_SWAPS.get("diffusion_gemma")
+    assert resolver is not None
+    assert resolver() is UnturtleDiffusionGemmaForBlockDiffusion
+
+
+def test_post_load_swap_installs_shim():
+    from unturtle import fast_diffusion_model as fdm
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+
+    model = _tiny_upstream_model()
+    assert type(model) is not UnturtleDiffusionGemmaForBlockDiffusion
+    fdm._apply_post_load_class_swap(model)
+    assert type(model) is UnturtleDiffusionGemmaForBlockDiffusion

--- a/tests/models/test_sampler.py
+++ b/tests/models/test_sampler.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 
 from unturtle.models.generation.sampler import (
+    ALL_ALGORITHMS,
+    CANVAS_ALGORITHMS,
     DISCRETE_ALGORITHMS,
     algorithm_to_flags,
     resolve_algorithm,
@@ -12,6 +14,9 @@ from unturtle.models.generation.sampler import (
 class _CacheCapable:
     """Stub model that supports block-decode (implements _model_forward_with_cache)."""
 
+    def _sample(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
     def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
         ...
 
@@ -19,9 +24,15 @@ class _CacheCapable:
 class _NoCache:
     """Stub model without block-decode capability."""
 
+    def _sample(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
 
 class _BlockCapable:
     """Stub exposing the block-decode cache hook."""
+
+    def _sample(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
 
     def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
         ...
@@ -30,11 +41,17 @@ class _BlockCapable:
 class _PlainDiffusion:
     """Stub without the cache hook."""
 
+    def _sample(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
 
 class _CacheCapableOptOut:
     """Stub with the cache hook but supports_block_decode = False (encoder-style opt-out)."""
 
     supports_block_decode = False
+
+    def _sample(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
 
     def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
         ...
@@ -42,6 +59,9 @@ class _CacheCapableOptOut:
 
 class _BD3LMCapable:
     """Stub with both block-decode and BD3LM capability."""
+
+    def _sample(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
 
     def _model_forward_with_cache(self, *a, **k):  # noqa: ANN002, ANN003
         ...
@@ -53,12 +73,17 @@ class _BD3LMCapable:
 class _BD3LMOnly:
     """Stub with BD3LM but no block-decode cache hook."""
 
+    def _sample(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
     def _sample_block_diffusion(self, *a, **k):  # noqa: ANN002, ANN003
         ...
 
 
 def test_known_algorithms_present() -> None:
     assert set(DISCRETE_ALGORITHMS) == {"mdlm", "block_decode", "bd3lm"}
+    assert set(CANVAS_ALGORITHMS) == {"block_ar"}
+    assert set(ALL_ALGORITHMS) == set(DISCRETE_ALGORITHMS) | set(CANVAS_ALGORITHMS)
 
 
 def test_algorithm_to_flags_mdlm() -> None:
@@ -195,3 +220,55 @@ def test_explicit_block_decode_with_capability_resolves() -> None:
         resolve_algorithm("block_decode", _CacheCapable(), bd3lm_requested=False)
         == "block_decode"
     )
+
+
+# ---------------------------------------------------------------------------
+# block_ar algorithm (DiffusionGemma / canvas block diffusion family)
+# ---------------------------------------------------------------------------
+
+
+class _BlockArCapable:
+    """Stub mimicking DiffusionGemmaGenerationMixin capability.
+
+    Deliberately no _sample: the canvas family has no mask semantics.
+    """
+
+    def _denoising_step(self, *a, **k):  # noqa: ANN002, ANN003
+        ...
+
+
+def test_resolve_auto_prefers_block_ar() -> None:
+    assert (
+        resolve_algorithm("auto", _BlockArCapable(), bd3lm_requested=False)
+        == "block_ar"
+    )
+
+
+def test_resolve_explicit_block_ar_on_masked_model_raises() -> None:
+    with pytest.raises(ValueError, match="block_ar"):
+        resolve_algorithm("block_ar", _PlainDiffusion(), bd3lm_requested=False)
+
+
+def test_resolve_explicit_mdlm_on_block_ar_model_raises() -> None:
+    # block_ar families have no mask semantics -> mdlm is inapplicable.
+    with pytest.raises(ValueError, match="masked"):
+        resolve_algorithm("mdlm", _BlockArCapable(), bd3lm_requested=False)
+
+
+def test_algorithm_to_flags_block_ar_is_empty() -> None:
+    assert algorithm_to_flags("block_ar") == {}
+
+
+def test_resolve_auto_block_ar_takes_priority_over_bd3lm_requested() -> None:
+    # canvas family has no _sample; auto returns block_ar
+    # instead of honoring (and then failing) the bd3lm request.
+    assert (
+        resolve_algorithm("auto", _BlockArCapable(), bd3lm_requested=True) == "block_ar"
+    )
+
+
+def test_resolve_auto_no_capability_raises() -> None:
+    class _NoAlgorithms: ...
+
+    with pytest.raises(ValueError, match="known decoding algorithm"):
+        resolve_algorithm("auto", _NoAlgorithms(), bd3lm_requested=False)

--- a/tests/test_e2e_diffusion_gemma_real.py
+++ b/tests/test_e2e_diffusion_gemma_real.py
@@ -1,0 +1,58 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2E test: DiffusionGemma real checkpoint loads and generates via FastDiffusionModel.
+
+This test downloads the official DiffusionGemma checkpoint from HuggingFace and
+exercises the full load + inference pipeline.
+
+**Skipped by default.** To run::
+
+    pytest tests/test_e2e_diffusion_gemma_real.py -m "slow and gpu" -v
+
+Requirements:
+- CUDA GPU
+- Sufficient disk space (~32 GB for 26B 4-bit checkpoint)
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+CHECKPOINT = "google/diffusiongemma-26B-A4B-it"
+
+
+@pytest.mark.slow
+@pytest.mark.gpu
+def test_real_checkpoint_loads_via_fastmodel_and_generates():
+    """DiffusionGemma checkpoint loads via FastDiffusionModel and generates successfully."""
+    from unturtle.fast_diffusion_model import FastDiffusionModel
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA GPU required for slow E2E test")
+
+    model, tokenizer = FastDiffusionModel.from_pretrained(CHECKPOINT, load_in_4bit=True)
+    assert type(model) is UnturtleDiffusionGemmaForBlockDiffusion
+    prompt = tokenizer("The capital of France is", return_tensors="pt").input_ids.to(
+        model.device
+    )
+    with torch.no_grad():
+        out = model.generate(prompt, max_new_tokens=16)
+    seq = out.sequences if hasattr(out, "sequences") else out
+    text = tokenizer.decode(seq[0], skip_special_tokens=True)
+    assert len(text) > 0

--- a/tests/test_e2e_diffusion_gemma_real.py
+++ b/tests/test_e2e_diffusion_gemma_real.py
@@ -12,18 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""E2E test: DiffusionGemma real checkpoint loads and generates via FastDiffusionModel.
+"""E2E test: DiffusionGemma real checkpoint via FastDiffusionModel.
 
 This test downloads the official DiffusionGemma checkpoint from HuggingFace and
-exercises the full load + inference pipeline.
+exercises the unturtle-owned pipeline: FastModel delegation -> post-load class
+swap -> unified ``generate(algorithm=...)`` shim dispatching to the upstream
+canvas loop.
 
 **Skipped by default.** To run::
 
     pytest tests/test_e2e_diffusion_gemma_real.py -m "slow and gpu" -v
 
 Requirements:
-- CUDA GPU
-- Sufficient disk space (~32 GB for 26B 4-bit checkpoint)
+- CUDA GPU (~18 GB free for the 4-bit load)
+- Sufficient disk space (~32 GB checkpoint)
+
+Known upstream limitations (verified 2026-06-12, torch 2.10 / transformers 5.11
+/ unsloth 2026.6.2):
+
+- **bnb-4bit MoE generation is broken upstream**: transformers'
+  ``integrations/moe.py`` ``_can_use_grouped_mm`` does not check dtype on CUDA,
+  so 4-bit-packed expert weights (uint8) reach ``torch.grouped_mm`` and raise
+  ``RuntimeError: Expected mat_a to be Float32, BFloat16 or Float16, got Byte``.
+  The generation step is therefore ``xfail`` until upstream supports quantized
+  experts (unsloth recommends the GGUF/llama.cpp route for DG inference today).
+- **bf16 multi-GPU via FastModel leaves meta tensors**: passing
+  ``load_in_4bit=False, device_map="auto"`` through unsloth FastModel returns a
+  non-materialized (meta) model, and 26B bf16 does not fit a single 48 GB GPU —
+  so full-precision generation cannot be exercised here either.
 """
 
 from __future__ import annotations
@@ -36,8 +52,10 @@ CHECKPOINT = "google/diffusiongemma-26B-A4B-it"
 
 @pytest.mark.slow
 @pytest.mark.gpu
-def test_real_checkpoint_loads_via_fastmodel_and_generates():
-    """DiffusionGemma checkpoint loads via FastDiffusionModel and generates successfully."""
+def test_real_checkpoint_load_swap_and_shim_generate():
+    """4-bit load succeeds, the class swap installs the shim, and generate
+    dispatches through it into the upstream canvas loop (generation itself is
+    xfail on the upstream 4-bit MoE grouped_mm gap)."""
     from unturtle.fast_diffusion_model import FastDiffusionModel
     from unturtle.models.backbones.diffusion_gemma import (
         UnturtleDiffusionGemmaForBlockDiffusion,
@@ -47,12 +65,35 @@ def test_real_checkpoint_loads_via_fastmodel_and_generates():
         pytest.skip("CUDA GPU required for slow E2E test")
 
     model, tokenizer = FastDiffusionModel.from_pretrained(CHECKPOINT, load_in_4bit=True)
+
+    # unturtle-owned contract: swap installed the wrapper and removed unsloth's
+    # instance-level fast-generate patch so the unified shim wins.
     assert type(model) is UnturtleDiffusionGemmaForBlockDiffusion
-    prompt = tokenizer("The capital of France is", return_tensors="pt").input_ids.to(
-        model.device
+    assert "generate" not in model.__dict__
+    assert (
+        type(model).generate
+        is UnturtleDiffusionGemmaForBlockDiffusion.__dict__["generate"]
     )
-    with torch.no_grad():
-        out = model.generate(prompt, max_new_tokens=16)
+
+    # The shim rejects masked algorithms even on the real checkpoint.
+    bad_prompt = torch.tensor([[1, 2, 3, 4]], device=model.device)
+    with pytest.raises(ValueError):
+        model.generate(bad_prompt, algorithm="mdlm", max_new_tokens=4)
+
+    # FastModel returns the multimodal Gemma4 *processor*; its (unsloth-patched)
+    # __call__ takes images first, so text must be passed by keyword.
+    enc = tokenizer(text="The capital of France is", return_tensors="pt")
+    prompt = enc["input_ids"].to(model.device)
+    try:
+        with torch.no_grad():
+            out = model.generate(prompt, max_new_tokens=16)
+    except RuntimeError as exc:
+        if "got Byte" in str(exc):
+            pytest.xfail(
+                "upstream: transformers grouped_mm does not support bnb-4bit "
+                f"MoE expert weights ({exc})"
+            )
+        raise
     seq = out.sequences if hasattr(out, "sequences") else out
     text = tokenizer.decode(seq[0], skip_special_tokens=True)
     assert len(text) > 0

--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -1643,3 +1643,19 @@ class TestPostLoadClassSwap:
         m = _Other()
         fdm._apply_post_load_class_swap(m)
         assert type(m) is _Other
+
+    def test_unregistered_model_keeps_instance_generate(self):
+        """Unregistered model types must NOT have their instance-level generate removed."""
+        from unturtle import fast_diffusion_model as fdm
+
+        class _Other:
+            class config:
+                model_type = "nobody-registered-this"
+
+        sentinel = object()
+
+        m = _Other()
+        m.generate = sentinel  # type: ignore[attr-defined]
+        fdm._apply_post_load_class_swap(m)
+        # Unregistered — instance attribute must be preserved
+        assert m.__dict__.get("generate") is sentinel

--- a/unturtle/eval/harness/configs.py
+++ b/unturtle/eval/harness/configs.py
@@ -38,6 +38,7 @@ class DecodingConfig:
     temperature: float
     use_chat_template: bool
     fewshot: int
+    algorithm: str = "mdlm"
 
     def as_dict(self) -> dict[str, Any]:
         """Serialize for recording alongside benchmark results."""
@@ -45,12 +46,15 @@ class DecodingConfig:
 
 
 # NOTE: only hyperparameters that actually take effect in the adapter/generation path are
-# recorded here, so a recorded config never misrepresents the real decoding. The adapter
-# explicitly pins algorithm="mdlm" so the no-cache MDLM decode path (pre-unification
-# default) is preserved; adding an "algorithm" field to DecodingConfig is deliberately
-# deferred until a canonical path switch is intentionally recorded. Knobs the dLLM paper
-# highlights but that are not yet wired into generation (e.g. eos-suppression,
-# parallel-decode width) will be added when the generation path honors them.
+# recorded here, so a recorded config never misrepresents the real decoding. The
+# ``algorithm`` field selects the decode path: "mdlm" (default) uses the no-cache MDLM
+# path with steps/temperature/mask_token_id; "block_ar" uses the DiffusionGemma
+# block-autoregressive path with max_denoising_steps (temperature is recorded in the
+# config for documentation but is NOT forwarded on the block_ar path — entropy knobs
+# stay at upstream defaults). Each recorded config is stored alongside its score so the
+# decode path is always unambiguous. Knobs the dLLM paper highlights but not yet wired
+# into generation (e.g. eos-suppression, parallel-decode width) will be added when the
+# generation path honors them.
 
 
 # Canonical decoding configs. Keyed by (model_family, task).
@@ -73,6 +77,17 @@ _DECODING_CONFIGS: dict[tuple[str, str], DecodingConfig] = {
         temperature=0.0,
         use_chat_template=True,
         fewshot=8,
+    ),
+    ("diffusion_gemma", "gsm8k"): DecodingConfig(
+        model_family="diffusion_gemma",
+        task="gsm8k",
+        max_new_tokens=256,
+        num_steps=48,
+        # temperature recorded for documentation; NOT forwarded on block_ar path
+        temperature=0.0,
+        use_chat_template=True,
+        fewshot=0,
+        algorithm="block_ar",
     ),
 }
 

--- a/unturtle/eval/harness/configs.py
+++ b/unturtle/eval/harness/configs.py
@@ -82,7 +82,7 @@ _DECODING_CONFIGS: dict[tuple[str, str], DecodingConfig] = {
         model_family="diffusion_gemma",
         task="gsm8k",
         max_new_tokens=256,
-        num_steps=48,
+        num_steps=48,  # pinned for DG/gsm8k reproducibility (coincides with the upstream default today)
         # temperature recorded for documentation; NOT forwarded on block_ar path
         temperature=0.0,
         use_chat_template=True,

--- a/unturtle/eval/harness/model_adapter.py
+++ b/unturtle/eval/harness/model_adapter.py
@@ -64,6 +64,7 @@ def build_harness_lm(
     max_new_tokens: int,
     temperature: float,
     use_chat_template: bool,
+    algorithm: str = "mdlm",
 ) -> Any:
     """Build an lm_eval LM wrapping an Unturtle diffusion model.
 
@@ -83,6 +84,7 @@ def build_harness_lm(
             self._max_new_tokens = max_new_tokens
             self._temperature = temperature
             self._use_chat_template = use_chat_template
+            self._algorithm = algorithm
 
         def _build_prompt(self, context: str) -> str:
             apply = getattr(self._tokenizer, "apply_chat_template", None)
@@ -105,23 +107,32 @@ def build_harness_lm(
             max_new = int(gen_kwargs.get("max_gen_toks", self._max_new_tokens))
             max_length = prompt_len + max_new
 
-            mask_token_id = getattr(self._tokenizer, "mask_token_id", None)
-            if mask_token_id is None:
-                mask_token_id = getattr(
-                    getattr(self._model, "config", None), "mask_token_id", None
+            if self._algorithm == "block_ar":
+                # DiffusionGemma block-AR path: no mask_token_id, no temperature
+                # forwarding (entropy knobs stay at upstream defaults); num_steps maps
+                # to max_denoising_steps.
+                sequences = self._model.generate(
+                    input_ids,
+                    algorithm="block_ar",
+                    max_new_tokens=max_new,
+                    max_denoising_steps=self._num_steps,
                 )
-
-            # algorithm="mdlm": pins pre-unification no-cache MDLM so recorded
-            # DecodingConfigs keep describing the real decode path; switching the
-            # canonical path to block-decode must be an explicit, recorded decision.
-            sequences = self._model.generate(
-                input_ids,
-                algorithm="mdlm",
-                max_length=max_length,
-                mask_token_id=mask_token_id,
-                steps=self._num_steps,
-                temperature=self._temperature,
-            )
+            else:
+                # Masked-diffusion families (mdlm default; explicit pin recorded with
+                # the score so the config never misrepresents the decode path).
+                mask_token_id = getattr(self._tokenizer, "mask_token_id", None)
+                if mask_token_id is None:
+                    mask_token_id = getattr(
+                        getattr(self._model, "config", None), "mask_token_id", None
+                    )
+                sequences = self._model.generate(
+                    input_ids,
+                    algorithm=self._algorithm,
+                    max_length=max_length,
+                    mask_token_id=mask_token_id,
+                    steps=self._num_steps,
+                    temperature=self._temperature,
+                )
 
             if hasattr(sequences, "sequences"):
                 sequences = sequences.sequences

--- a/unturtle/eval/harness/runner.py
+++ b/unturtle/eval/harness/runner.py
@@ -64,6 +64,7 @@ def run_harness_evaluation(
         max_new_tokens=config.max_new_tokens,
         temperature=config.temperature,
         use_chat_template=config.use_chat_template,
+        algorithm=config.algorithm,
     )
 
     results = simple_evaluate(

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -619,6 +619,14 @@ def _apply_post_load_class_swap(model: Any) -> None:
     ``transformers`` class.  Backbone modules can register a resolver in
     :data:`_POST_LOAD_CLASS_SWAPS` so that the thin Unturtle wrapper class is
     installed via ``__class__`` assignment after loading.
+
+    After the class swap (or when the model is already the wrapper class),
+    any instance-level ``generate`` attribute is removed.  unsloth FastModel
+    installs ``unsloth_base_fast_generate`` as an instance attribute (saving
+    the original as ``self._old_generate``), which would shadow the wrapper
+    class's unified ``generate`` shim AND forces ``cache_implementation=
+    "static"``, crashing DiffusionGemma's flex-attention canvas block loop.
+    Dropping the instance attribute lets the class-level shim win.
     """
     model_type = getattr(getattr(model, "config", None), "model_type", None)
     resolver = _POST_LOAD_CLASS_SWAPS.get(model_type)
@@ -627,6 +635,14 @@ def _apply_post_load_class_swap(model: Any) -> None:
     wrapper_cls = resolver()
     if not isinstance(model, wrapper_cls):
         model.__class__ = wrapper_cls
+    # unsloth FastModel installs an instance-level fast-generate wrapper
+    # (saving the original as `_old_generate`). It would shadow the wrapper
+    # class's unified `generate` shim AND forces cache_implementation="static",
+    # which breaks DiffusionGemma's canvas flex-attention block mask. Drop the
+    # instance attribute so the class-level shim (verbatim upstream delegation)
+    # wins. This runs whether the class was just swapped or was already the
+    # wrapper (covers re-entrant / double-swap scenarios).
+    model.__dict__.pop("generate", None)
 
 
 def _native_model_classes() -> dict[str, Any]:

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -601,6 +601,17 @@ def _load_model_with_optional_4bit_fallback(
 _POST_LOAD_CLASS_SWAPS: dict[str, Any] = {}
 
 
+def _resolve_diffusion_gemma_wrapper() -> Any:
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+
+    return UnturtleDiffusionGemmaForBlockDiffusion
+
+
+_POST_LOAD_CLASS_SWAPS["diffusion_gemma"] = _resolve_diffusion_gemma_wrapper
+
+
 def _apply_post_load_class_swap(model: Any) -> None:
     """Swap model's class to the registered wrapper, if any.
 

--- a/unturtle/models/backbones/__init__.py
+++ b/unturtle/models/backbones/__init__.py
@@ -29,11 +29,15 @@ Native bidirectional backbones:
   - Dream  (unturtle.models.backbones.dream)
   - ModernBERT diffusion  (unturtle.models.backbones.modernbert)
 
+Canvas block-diffusion backbones (self-conditioned, not masked-diffusion):
+  - DiffusionGemma  (unturtle.models.backbones.diffusion_gemma)
+
 AR backbones reachable via the A2D conversion method live under
 ``unturtle.models.conversion`` (see unturtle.models.conversion.a2d) — they are a
 conversion *method*, not a peer architecture, so they are not re-exported here.
 """
 
+from .diffusion_gemma import UnturtleDiffusionGemmaForBlockDiffusion
 from .dream import DreamConfig, DreamModel
 from .llada import LLaDAConfig, LLaDAModel, LLaDAModelLM
 from .modernbert import (
@@ -43,6 +47,7 @@ from .modernbert import (
 )
 
 __all__ = [
+    "UnturtleDiffusionGemmaForBlockDiffusion",
     "DreamConfig",
     "DreamModel",
     "LLaDAConfig",

--- a/unturtle/models/backbones/diffusion_gemma/__init__.py
+++ b/unturtle/models/backbones/diffusion_gemma/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DiffusionGemma backbone wrapper.
+
+DiffusionGemma is NOT a masked diffusion LM: it denoises a per-block "canvas"
+with self-conditioning under entropy/confidence acceptance (no mask token).
+This subpackage wraps the upstream ``DiffusionGemmaForBlockDiffusion`` with a
+unified ``generate(algorithm=...)`` shim so the Unturtle contract holds.
+
+Usage::
+
+    from unturtle.models.backbones.diffusion_gemma import (
+        UnturtleDiffusionGemmaForBlockDiffusion,
+    )
+"""
+
+from .modeling import UnturtleDiffusionGemmaForBlockDiffusion
+
+__all__ = [
+    "UnturtleDiffusionGemmaForBlockDiffusion",
+]

--- a/unturtle/models/backbones/diffusion_gemma/modeling.py
+++ b/unturtle/models/backbones/diffusion_gemma/modeling.py
@@ -1,0 +1,86 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DiffusionGemma backbone wrapper.
+
+DiffusionGemma is NOT a masked diffusion LM: it denoises a per-block "canvas"
+with self-conditioning under entropy/confidence acceptance (no mask token).
+This wrapper adds ONLY the unified ``generate(algorithm=...)`` shim — no
+masked-diffusion mixins, no config subclass, and the upstream
+``model_type = "diffusion_gemma"`` is unchanged (real checkpoints carry it).
+The class is deliberately field-free so the loader can ``__class__``-swap a
+FastModel-loaded upstream instance (see ``_POST_LOAD_CLASS_SWAPS``).
+"""
+
+from __future__ import annotations
+
+from transformers.models.diffusion_gemma import DiffusionGemmaForBlockDiffusion
+
+
+class UnturtleDiffusionGemmaForBlockDiffusion(DiffusionGemmaForBlockDiffusion):
+    """Unturtle wrapper for ``DiffusionGemmaForBlockDiffusion``.
+
+    Adds a unified ``generate(algorithm=...)`` entry-point while delegating
+    entirely to the upstream canvas block-diffusion loop. Masked-diffusion
+    algorithms (mdlm / block_decode / bd3lm) raise ``ValueError`` via
+    ``resolve_algorithm`` — this family has no mask-token semantics.
+
+    This class is field-free by design: the loader ``__class__``-swaps a
+    FastModel-loaded upstream instance onto this class so that real checkpoints
+    acquire the shim without re-instantiation.
+    """
+
+    def generate(
+        self,
+        inputs=None,
+        *,
+        algorithm: str = "auto",
+        generation_config=None,
+        **kwargs,
+    ):
+        """Generate via the upstream block-AR canvas diffusion.
+
+        Parameters
+        ----------
+        inputs:
+            Token IDs passed as ``input_ids`` to the upstream ``generate``.
+        algorithm:
+            ``"auto"`` or ``"block_ar"`` — both delegate to the upstream loop
+            verbatim; no vocabulary translation.  Masked-diffusion algorithms
+            (``"mdlm"`` / ``"block_decode"`` / ``"bd3lm"``) raise
+            ``ValueError`` immediately via ``resolve_algorithm``.
+        generation_config:
+            A ``DiffusionGemmaGenerationConfig`` (or compatible mapping).
+            Forwarded unchanged to the upstream ``generate``.
+        **kwargs:
+            Forwarded unchanged to the upstream ``generate``.
+
+        See Also
+        --------
+        transformers.models.diffusion_gemma.DiffusionGemmaGenerationConfig :
+            Controls max_denoising_steps, sampler_config, t_min/t_max,
+            stability_threshold, and confidence_threshold.
+        """
+        from unturtle.models.generation.sampler import resolve_algorithm
+
+        if inputs is None and "input_ids" in kwargs:
+            # HF canonical call style: model.generate(input_ids=...).
+            inputs = kwargs.pop("input_ids")
+
+        resolve_algorithm(algorithm, self, bd3lm_requested=False)
+        return super().generate(
+            input_ids=inputs,
+            generation_config=generation_config,
+            **kwargs,
+        )

--- a/unturtle/models/generation/diffusion_generation_utils.py
+++ b/unturtle/models/generation/diffusion_generation_utils.py
@@ -823,10 +823,12 @@ class MaskedDiffusionGenerationMixin:
     ) -> Union[MaskedDiffusionModelOutput, torch.LongTensor]:
         """Generate sequences via masked diffusion.
 
-        ``algorithm`` selects the discrete decoding path (``"auto"`` |
-        ``"mdlm"`` | ``"block_decode"`` | ``"bd3lm"``). The resolved
-        algorithm's flags (``use_cache`` / ``use_block_diffusion``) are
-        injected before the denoising loop runs.
+        ``algorithm`` selects the decoding path (``"auto"`` | ``"mdlm"`` |
+        ``"block_decode"`` | ``"bd3lm"`` | ``"block_ar"``). ``block_ar``
+        is the DiffusionGemma canvas family (no mask token) and is rejected
+        here; the masked paths (mdlm/block_decode/bd3lm) resolve via capability
+        checks and inject their flags (``use_cache`` / ``use_block_diffusion``)
+        before the denoising loop runs.
 
         Parameters
         ----------
@@ -834,10 +836,11 @@ class MaskedDiffusionGenerationMixin:
             Prompt token IDs.  Completion positions should already be filled
             with ``mask_token_id``.
         algorithm : str, optional
-            Decoding algorithm to use.  ``"auto"`` (default) picks the
-            fastest discrete path the model supports: block-decode when
-            available, else plain MDLM; BD3LM when
-            ``use_block_diffusion=True`` is set in kwargs.
+            Decoding algorithm to use (see main docstring for full list).
+            ``"auto"`` (default) picks the fastest discrete path the model
+            supports: block-decode when available, else plain MDLM; BD3LM when
+            ``use_block_diffusion=True`` is set in kwargs. ``block_ar``
+            (DiffusionGemma canvas) is rejected (raises ValueError).
         generation_config : MaskedDiffusionGenerationConfig, optional
             Generation parameters.  If ``None``, model defaults are used.
         **kwargs

--- a/unturtle/models/generation/sampler.py
+++ b/unturtle/models/generation/sampler.py
@@ -24,16 +24,30 @@ Algorithms (discrete masked diffusion):
   - ``block_decode`` : Fast-dLLM KV-cache block decode (parallel decode is an option within);
                        requires the model to implement ``_model_forward_with_cache`` and opt in
                        via ``supports_block_decode`` (defaults to ``True`` when absent).
-  - ``bd3lm``        : BD3LM block diffusion; requires ``_sample_block_diffusion``
-                       (TinyA2D family today).
+  - ``bd3lm``        : Unturtle's masked block diffusion (BD3LM); requires
+                       ``_sample_block_diffusion`` (TinyA2D family today).
+
+Algorithm (self-conditioned canvas block diffusion):
+  - ``block_ar``     : upstream native canvas block diffusion for the DiffusionGemma family;
+                       requires ``_denoising_step`` (the DiffusionGemmaGenerationMixin probe).
+                       No mask token is used — the upstream ``GenerationConfig`` governs the
+                       generation loop entirely, so ``algorithm_to_flags("block_ar")`` returns
+                       ``{}`` (no ``use_cache``/``use_block_diffusion`` injection).
+
+Key distinction — ``bd3lm`` vs ``block_ar``:
+  - ``bd3lm``        : Unturtle's *masked* block diffusion; requires a mask token; uses
+                       ``_sample_block_diffusion``; flag ``use_block_diffusion=True`` injected.
+  - ``block_ar``     : upstream *self-conditioned* canvas block diffusion (DiffusionGemma);
+                       no mask token; governed by the upstream generation config; no flags
+                       injected.
 
 Explicit algorithm choices are capability-checked: passing an algorithm the model cannot
 execute raises ``ValueError`` immediately rather than silently falling back or crashing
 mid-generation.
 
 The registry is intentionally open: continuous-diffusion algorithms (e.g. ``continuous_*``)
-would be added to a separate table when continuous diffusion LMs land. The current loops are
-discrete-masked-only.
+would be added to a separate table when continuous diffusion LMs land. The masked-diffusion
+loops (mdlm/block_decode/bd3lm) are discrete-masked-only; block_ar is for the canvas family.
 """
 
 from __future__ import annotations
@@ -47,16 +61,59 @@ DISCRETE_ALGORITHMS: dict[str, dict[str, bool]] = {
     "bd3lm": {"use_cache": False, "use_block_diffusion": True},
 }
 
+#: Canvas block-diffusion algorithms -> the generate() flag set each selects.
+#: ``block_ar`` injects no flags; the upstream GenerationConfig governs the loop.
+CANVAS_ALGORITHMS: dict[str, dict[str, bool]] = {
+    "block_ar": {},
+}
+
+#: All registered algorithms.
+ALL_ALGORITHMS: dict[str, dict[str, bool]] = {
+    **DISCRETE_ALGORITHMS,
+    **CANVAS_ALGORITHMS,
+}
+
 
 def algorithm_to_flags(algorithm: str) -> dict[str, bool]:
-    """Return the generate() flag set for a named discrete algorithm."""
+    """Return the generate() flag set for a named algorithm.
+
+    For discrete masked algorithms (mdlm / block_decode / bd3lm) this returns the
+    ``use_cache`` / ``use_block_diffusion`` flags that the model's generate dispatch
+    understands.
+
+    For ``block_ar`` (DiffusionGemma canvas block diffusion) this returns ``{}`` —
+    no flags are injected because the upstream ``GenerationConfig`` governs the loop
+    entirely; Unturtle only selects the algorithm, it does not override the config.
+    """
     try:
-        return dict(DISCRETE_ALGORITHMS[algorithm])
+        return dict(ALL_ALGORITHMS[algorithm])
     except KeyError as exc:
         raise ValueError(
             f"Unknown decoding algorithm {algorithm!r}. "
-            f"Supported: {sorted(DISCRETE_ALGORITHMS)}."
+            f"Supported: {sorted(ALL_ALGORITHMS)}."
         ) from exc
+
+
+def _supports_block_ar(model: Any) -> bool:
+    """True if the model is a DiffusionGemma-family canvas block-diffusion model.
+
+    The presence of ``_denoising_step`` is the canonical probe for
+    ``DiffusionGemmaGenerationMixin``.  These models use self-conditioned canvas
+    block diffusion (no mask token) and their generation loop is governed by the
+    upstream ``GenerationConfig`` rather than Unturtle flags.
+    """
+    return callable(getattr(model, "_denoising_step", None))
+
+
+def _supports_mdlm(model: Any) -> bool:
+    """True if the model implements the masked-diffusion sampling loop.
+
+    The presence of ``_sample`` is the canonical probe for the masked-diffusion
+    generation mixin (LLaDA / Dream / TinyA2D / ModernBERT all define it).
+    Models without ``_sample`` have no mask-token semantics and cannot run
+    mdlm / block_decode / bd3lm algorithms.
+    """
+    return callable(getattr(model, "_sample", None))
 
 
 def _supports_block_decode(model: Any) -> bool:
@@ -79,17 +136,25 @@ def _supports_bd3lm(model: Any) -> bool:
 def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> str:
     """Resolve ``algorithm`` to a concrete algorithm name.
 
-    ``auto`` picks the fastest discrete path the model supports:
-      - BD3LM if requested (and the model implements ``_sample_block_diffusion``),
+    ``auto`` picks the fastest path the model supports:
+      - ``block_ar`` first, when the model is a DiffusionGemma-family canvas model
+        (implements ``_denoising_step``); this takes priority over masked algorithms.
+      - Else BD3LM if requested (and the model implements ``_sample_block_diffusion``),
       - else block-decode (Fast-dLLM) when the model supports the cache hook,
       - else plain MDLM.
 
-    Explicit discrete algorithm names are capability-checked:
+    Explicit algorithm names are capability-checked:
+      - ``"block_ar"`` requires ``_supports_block_ar(model)`` (DiffusionGemma family);
+        raises ``ValueError`` mentioning "block_ar" otherwise.
+      - ``"mdlm"`` requires ``_supports_mdlm(model)`` (masked-diffusion loop); raises
+        ``ValueError`` mentioning "masked" when called on a canvas-block model.
       - ``"block_decode"`` requires ``_supports_block_decode(model)``.
       - ``"bd3lm"`` (explicit or via auto + bd3lm_requested) requires
         ``_supports_bd3lm(model)``; BD3LM is implemented on the TinyA2D family today.
     """
     if algorithm == "auto":
+        if _supports_block_ar(model):
+            return "block_ar"
         if bd3lm_requested:
             if not _supports_bd3lm(model):
                 raise ValueError(
@@ -100,11 +165,28 @@ def resolve_algorithm(algorithm: str, model: Any, *, bd3lm_requested: bool) -> s
             return "bd3lm"
         if _supports_block_decode(model):
             return "block_decode"
-        return "mdlm"
-    if algorithm not in DISCRETE_ALGORITHMS:
+        if _supports_mdlm(model):
+            return "mdlm"
+        raise ValueError(
+            f"{type(model).__name__} does not implement any known decoding algorithm "
+            "(no _denoising_step, _model_forward_with_cache, or _sample). "
+            "Ensure the model is a supported dLLM backbone."
+        )
+    if algorithm not in ALL_ALGORITHMS:
         raise ValueError(
             f"Unknown decoding algorithm {algorithm!r}. "
-            f"Supported: {sorted(DISCRETE_ALGORITHMS)} (or 'auto')."
+            f"Supported: {sorted(ALL_ALGORITHMS)} (or 'auto')."
+        )
+    if algorithm == "block_ar" and not _supports_block_ar(model):
+        raise ValueError(
+            f"{type(model).__name__} does not support block_ar "
+            f"(native canvas block diffusion, DiffusionGemma family); "
+            f"use algorithm='mdlm' or 'block_decode' for masked models."
+        )
+    if algorithm == "mdlm" and not _supports_mdlm(model):
+        raise ValueError(
+            f"{type(model).__name__} has no masked-diffusion sampling loop "
+            f"(no mask-token semantics); use algorithm='block_ar'."
         )
     if algorithm == "block_decode" and not _supports_block_decode(model):
         raise ValueError(


### PR DESCRIPTION
Closes #25

## Summary

- **New native backbone**: `unturtle/models/backbones/diffusion_gemma/` wraps upstream transformers `DiffusionGemmaForBlockDiffusion` with a field-free subclass adding only the unified `generate(inputs, *, algorithm=..., generation_config=..., **kwargs)` shim. **DiffusionGemma is NOT a masked diffusion LM** — self-conditioned canvas block diffusion (no mask token); the wrapper inherits no masked-diffusion mixin and keeps `model_type="diffusion_gemma"`.
- **New algorithm `"block_ar"`** in the sampler registry (distinct from `"bd3lm"` = unturtle's *masked* block diffusion): `auto` prefers it on capable models; explicit choices are capability-checked (`block_ar` on masked models, `mdlm` on canvas models → actionable `ValueError`); `algorithm_to_flags("block_ar")` injects no flags (upstream config governs itself). The auto fallthrough now raises early if a model implements no known algorithm (probe-fragility guard).
- **Loader class swap**: FastModel-loaded `diffusion_gemma` instances are `__class__`-swapped onto the wrapper, and **unsloth's instance-level fast-generate patch is dropped** during the swap — it would shadow the shim AND forces `cache_implementation="static"`, which crashes DiffusionGemma's canvas flex-attention block mask (verified on real GPU).
- **Eval**: `DecodingConfig` gains `algorithm` (default `"mdlm"`, recorded with scores — un-defers the PR #23 item); harness adapter branches block_ar (`max_new_tokens` + `max_denoising_steps=num_steps`, no masked kwargs) vs masked (unchanged); new `("diffusion_gemma","gsm8k")` entry. `temperature` on that entry is recorded-for-documentation only (not forwarded on block_ar; entropy knobs stay at upstream defaults).

## Real-checkpoint verification (`google/diffusiongemma-26B-A4B-it`, 4× RTX 6000 Ada)

The slow/gpu e2e (`tests/test_e2e_diffusion_gemma_real.py`) **passes (1 xfailed)**: FastModel 4-bit load, class swap, instance-patch removal, shim dispatch, and masked-algorithm rejection are all hard-verified on the real 26B checkpoint. The generation step is `xfail` on a verified **upstream gap**: transformers `integrations/moe.py::_can_use_grouped_mm` doesn't dtype-check on CUDA, so bnb-4bit-packed MoE expert weights (uint8) reach `torch.grouped_mm` → `RuntimeError ... got Byte`. bf16 multi-GPU via FastModel is also not currently materializable (meta tensors). Details in the test module docstring; tiny-config CPU tests cover the full generation loop.

## Test plan

- [x] Full not-slow suite: **592 passed, 1 skipped, 0 failed**; ruff check/format clean
- [x] Sampler: block_ar resolution/capability/table-completeness pins (28 tests)
- [x] Wrapper: real tiny-model generation (auto/block_ar seed-matched), masked-algorithm rejection, HF `input_ids=` kwarg style, shim-identity, no-masked-mixin, model_type pins
- [x] Loader: swap registration, instance-generate removal regression, unregistered-type untouched
- [x] Eval: block_ar kwargs (+forbidden masked kwargs), mdlm default unchanged, runner threading pin
- [x] Real-checkpoint e2e: 1 xfailed (see above)

## Follow-ups (not filed as issues yet)

- upstream: bnb-4bit MoE expert weights vs `grouped_mm` (transformers); bf16 multi-GPU meta tensors (unsloth)
- CLI `--algorithm` flag (CLI remains masked-dLLM-only; cannot drive DiffusionGemma)

Design spec: `docs/superpowers/specs/2026-06-12-diffusion-gemma-design.md` / plan: `docs/superpowers/plans/2026-06-12-diffusion-gemma.md` (PR 2 of 2; PR 1 was #26).