### PR TITLE
🐛 fix(test): symmetrize LoRA save/reload forward comparison (#16)

### DIFF
--- a/tests/test_e2e_real_checkpoint.py
+++ b/tests/test_e2e_real_checkpoint.py
@@ -270,16 +270,30 @@ class TestAdapterSaveReload:
         adapter_dir = tmp_path / "adapter"
         peft_model.save_pretrained(str(adapter_dir))
 
-        # Reload: fresh from_pretrained + load adapter
+        # Reload: fresh from_pretrained + load adapter.
+        #
+        # The comparison must be SYMMETRIC: the save side went through
+        # get_peft_model (prepare_model_for_kbit_training + PEFT wrap +
+        # patch_peft_model), and each of those steps deterministically changes
+        # the 4bit/bf16 forward numerics (kernel dispatch / dequant path) even
+        # with LoRA B=0 — measured 0.79 max logit diff on LLaDA-8B when the
+        # reload side skips them (issue #16: NOT a save/reload weight bug; the
+        # adapter weights round-trip exactly).
         base_model2, _ = FastDiffusionModel.from_pretrained(
             _DEFAULT_CHECKPOINT,
             max_seq_length=64,
             load_in_4bit=True,
             trust_remote_code=True,
         )
+        from peft import prepare_model_for_kbit_training
+
+        base_model2 = prepare_model_for_kbit_training(
+            base_model2, use_gradient_checkpointing=False
+        )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             reloaded = PeftModel.from_pretrained(base_model2, str(adapter_dir))
+        FastDiffusionModel.patch_peft_model(reloaded, lora_dropout=0, bias="none")
         reloaded.eval()
 
         with torch.no_grad():


### PR DESCRIPTION
Closes #16

## Root cause (issue title was a misdiagnosis)

The 0.7968 max-diff was **not** a save/reload weight bug nor bf16 numerical drift from the torch/transformers upgrade — it reproduces identically (variance 0.000000) on torch 2.10/2.11 × transformers 5.5/5.11. Systematic isolation showed:

| Contribution | Source |
|---|---|
| 0.4948 | `prepare_model_for_kbit_training` + PEFT wrap deterministically change the 4bit/bf16 forward numerics, even with LoRA B=0 (upstream behavior; reproduces with zero unturtle patches) |
| +0.3020 | `_patch_llada_peft`'s fast-RoPE rebind — RoPE **outputs are bit-identical** to the standard path (verified on synthetic and real in-forward q/k); the delta comes from downstream kernel-dispatch/memory-layout differences, also fully deterministic |

The adapter weights round-trip exactly (reloaded LoRA contribution vs fresh base = 0.000000). The test was comparing two **differently-patched** models: the save side went through `FastDiffusionModel.get_peft_model` (kbit prep + PEFT + patch_peft_model), the reload side through bare `PeftModel.from_pretrained` (no unturtle patches).

## Fix

Symmetrize the reload side: apply `prepare_model_for_kbit_training` + `FastDiffusionModel.patch_peft_model` (documented "safe to call again") after `PeftModel.from_pretrained`. Both sides now take the identical deterministic path, and the test passes with the original strict `atol=1e-3` — no tolerance relaxation needed.

## Test plan

- [x] `TestAdapterSaveReload::test_save_reload_forward_matches` (slow+gpu, LLaDA-8B 4bit): **1 passed** on torch 2.10 / transformers 5.11
- [x] ruff check/format clean