### PR TITLE
♻️ refactor(eval): align GSM8KEvaluator mask_token_id resolution with harness adapter (#24)

### DIFF
--- a/tests/eval/test_gsm8k.py
+++ b/tests/eval/test_gsm8k.py
@@ -86,6 +86,7 @@ class _CorrectAnswerModel(torch.nn.Module):
         self.dummy = torch.nn.Parameter(torch.zeros(1))
         self.calls = 0
         self.last_algorithm: str | None = None
+        self.last_mask_token_id: object = "<unset>"
 
     def generate(
         self,
@@ -95,10 +96,12 @@ class _CorrectAnswerModel(torch.nn.Module):
         max_length=None,
         steps=None,
         temperature=None,
+        mask_token_id="<unset>",
         **_kw,
     ):
         self.calls += 1
         self.last_algorithm = algorithm
+        self.last_mask_token_id = mask_token_id
         pad = torch.full((input_ids.shape[0], 1), 7, dtype=input_ids.dtype)
         return torch.cat([input_ids, pad], dim=1)
 
@@ -237,3 +240,50 @@ class TestGSM8KEvaluator:
         evaluator.evaluate()
         assert model.calls == 1
         assert model.last_algorithm == "mdlm"
+
+    def test_mask_token_id_resolved_from_tokenizer(self, monkeypatch):
+        tok = _StubTokenizer()
+        tok._answer = r"\boxed{2}"
+        tok.mask_token_id = 99
+        model = _CorrectAnswerModel()
+        # config fallback present but should be shadowed by the tokenizer value.
+        model.config = type("Cfg", (), {"mask_token_id": 7})()
+
+        from unturtle.eval.gsm8k import GSM8KEvaluator
+
+        evaluator = GSM8KEvaluator(
+            model=model, tokenizer=tok, num_steps=4, max_new_tokens=8
+        )
+        assert evaluator.mask_token_id == 99
+
+        dataset = [{"question": "What is 1 + 1?", "answer": "#### 2"}]
+        monkeypatch.setattr(
+            evaluator, "_load_dataset", lambda split, seed, num_examples: dataset
+        )
+        evaluator.evaluate()
+        assert model.last_mask_token_id == 99
+
+    def test_mask_token_id_falls_back_to_model_config(self, monkeypatch):
+        tok = _StubTokenizer()
+        tok._answer = r"\boxed{2}"
+        tok.mask_token_id = None  # tokenizer cannot supply it
+        model = _CorrectAnswerModel()
+        model.config = type("Cfg", (), {"mask_token_id": 7})()
+
+        from unturtle.eval.gsm8k import GSM8KEvaluator
+
+        evaluator = GSM8KEvaluator(
+            model=model, tokenizer=tok, num_steps=4, max_new_tokens=8
+        )
+        assert evaluator.mask_token_id == 7
+
+        dataset = [{"question": "What is 1 + 1?", "answer": "#### 2"}]
+        monkeypatch.setattr(
+            evaluator, "_load_dataset", lambda split, seed, num_examples: dataset
+        )
+        evaluator.evaluate()
+        assert model.last_mask_token_id == 7
+
+
+def test_gsm8k_evaluator_docstring_marks_it_as_dllm_only() -> None:
+    assert "dllm-only" in (GSM8KEvaluator.__doc__ or "").lower()

--- a/tests/eval/test_gsm8k.py
+++ b/tests/eval/test_gsm8k.py
@@ -284,6 +284,29 @@ class TestGSM8KEvaluator:
         evaluator.evaluate()
         assert model.last_mask_token_id == 7
 
+    def test_mask_token_id_none_when_unavailable(self, monkeypatch):
+        # Neither the tokenizer nor model.config supplies a mask_token_id.
+        # The contract is to forward None explicitly (the MDLM sampler resolves
+        # the real mask token), NOT to omit the kwarg or raise.
+        tok = _StubTokenizer()  # no mask_token_id attribute
+        tok._answer = r"\boxed{2}"
+        model = _CorrectAnswerModel()  # no .config attribute
+
+        from unturtle.eval.gsm8k import GSM8KEvaluator
+
+        evaluator = GSM8KEvaluator(
+            model=model, tokenizer=tok, num_steps=4, max_new_tokens=8
+        )
+        assert evaluator.mask_token_id is None
+
+        dataset = [{"question": "What is 1 + 1?", "answer": "#### 2"}]
+        monkeypatch.setattr(
+            evaluator, "_load_dataset", lambda split, seed, num_examples: dataset
+        )
+        evaluator.evaluate()
+        # `is None`, not `== "<unset>"`: proves the kwarg was forwarded, not omitted.
+        assert model.last_mask_token_id is None
+
 
 def test_gsm8k_evaluator_docstring_marks_it_as_dllm_only() -> None:
     assert "dllm-only" in (GSM8KEvaluator.__doc__ or "").lower()

--- a/unturtle/eval/gsm8k.py
+++ b/unturtle/eval/gsm8k.py
@@ -83,9 +83,9 @@ class GSM8KEvaluator(BaseEvaluator):
         self.temperature = temperature
         self.system_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
         self.metric_key_prefix = metric_key_prefix
-        # Two-stage lookup mirroring the harness adapter: tokenizer first, then
-        # the model config (real checkpoints may carry mask_token_id only on
-        # model.config, not the tokenizer).
+        # Two-stage lookup mirroring unturtle/eval/harness/model_adapter.py:
+        # tokenizer first, then the model config (real checkpoints may carry
+        # mask_token_id only on model.config, not the tokenizer).
         mask_token_id = getattr(tokenizer, "mask_token_id", None)
         if mask_token_id is None:
             mask_token_id = getattr(

--- a/unturtle/eval/gsm8k.py
+++ b/unturtle/eval/gsm8k.py
@@ -46,6 +46,10 @@ def _extract_gold_answer(answer_text: str) -> float | None:
 class GSM8KEvaluator(BaseEvaluator):
     """Smoke-only GSM8K evaluator for masked-diffusion models.
 
+    dLLM-only by design: it pins ``algorithm="mdlm"`` and forwards a
+    masked-diffusion ``mask_token_id``, so it cannot drive non-masked
+    backbones (e.g. DiffusionGemma block-AR).
+
     This evaluator is kept for fast local sanity checks and benchmark-harness
     debugging. It is not the authoritative formal benchmark path for Unturtle.
 
@@ -79,6 +83,15 @@ class GSM8KEvaluator(BaseEvaluator):
         self.temperature = temperature
         self.system_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
         self.metric_key_prefix = metric_key_prefix
+        # Two-stage lookup mirroring the harness adapter: tokenizer first, then
+        # the model config (real checkpoints may carry mask_token_id only on
+        # model.config, not the tokenizer).
+        mask_token_id = getattr(tokenizer, "mask_token_id", None)
+        if mask_token_id is None:
+            mask_token_id = getattr(
+                getattr(model, "config", None), "mask_token_id", None
+            )
+        self.mask_token_id = mask_token_id
 
     def _build_prompt(self, question: str) -> str:
         messages = [
@@ -102,6 +115,7 @@ class GSM8KEvaluator(BaseEvaluator):
             input_ids,
             algorithm="mdlm",
             max_length=max_length,
+            mask_token_id=self.mask_token_id,
             steps=self.num_steps,
             temperature=self.temperature,
         )


### PR DESCRIPTION
## Summary

Closes #24.

Aligns `GSM8KEvaluator`'s `mask_token_id` resolution with the authoritative
harness adapter path. Previously the smoke evaluator passed only
`max_length`/`steps`/`temperature` to `generate` and relied on
`_prepare_generation_config`'s implicit `model.config` fallback — an asymmetry
flagged during the #22 review.

## Changes

- **Two-stage lookup** (`GSM8KEvaluator.__init__`): resolve `mask_token_id` from
  the tokenizer first, then fall back to `model.config`, stored as
  `self.mask_token_id`. Mirrors `harness/model_adapter.py` and the sibling
  `MaskedDiffusionEvaluator` (`eval/diffusion.py`).
- **Explicit forwarding** in `_generate`: pass `mask_token_id=self.mask_token_id`
  to `model.generate`, instead of leaning on the implicit config fallback.
- **Docstring note**: documents the evaluator as **dLLM-only by design** (pins
  `algorithm="mdlm"`, forwards a masked-diffusion `mask_token_id`; cannot drive
  non-masked backbones such as DiffusionGemma block-AR).

Matches the CLAUDE.md gotcha: *"for real checkpoints, `mask_token_id` may need
to come from `model.config`, not the tokenizer."*

## Acceptance criteria

- [x] Replicate the two-stage lookup in `GSM8KEvaluator.__init__`, forward
  `mask_token_id` in `_generate`
- [x] Docstring note that the smoke evaluator is dLLM-only by design

## Test plan

- [x] `tests/eval/test_gsm8k.py` — **20 passed** (17 existing + 3 new), via the
  repo `.venv`
- [x] New regression tests: tokenizer-first resolution, `model.config` fallback,
  and forwarding into `generate`
- [x] `ruff check` + `ruff format --check` clean on changed files
