### PR TITLE
🐛 fix(backbones): MDLM-DiT get/set input+output embeddings for DiffusionTrainer compat (#33)

### DIFF
--- a/tests/models/test_mdlm_dit.py
+++ b/tests/models/test_mdlm_dit.py
@@ -275,6 +275,129 @@ class TestMDLMDiTGeneration:
         assert (s1 == s2).all()
 
 
+class TestMDLMDiTEmbeddings:
+    def test_get_input_embeddings_has_weight(self, tiny_config):
+        from unturtle.models.backbones.mdlm_dit import MDLMDiTForMaskedDiffusionLM
+
+        model = MDLMDiTForMaskedDiffusionLM(tiny_config)
+        emb = model.get_input_embeddings()
+        assert emb is not None
+        # HF trainer init reads get_input_embeddings().weight.dtype
+        assert emb.weight.dtype == next(model.parameters()).dtype
+        assert emb.weight.shape == (tiny_config.vocab_size, tiny_config.hidden_size)
+
+    def test_set_input_embeddings_replaces(self, tiny_config):
+        import torch.nn as nn
+
+        from unturtle.models.backbones.mdlm_dit import MDLMDiTForMaskedDiffusionLM
+
+        model = MDLMDiTForMaskedDiffusionLM(tiny_config)
+        new = nn.Embedding(tiny_config.vocab_size, tiny_config.hidden_size)
+        model.set_input_embeddings(new)
+        assert model.get_input_embeddings() is new
+
+    def test_state_dict_key_unchanged(self, tiny_config):
+        from unturtle.models.backbones.mdlm_dit import MDLMDiTForMaskedDiffusionLM
+
+        model = MDLMDiTForMaskedDiffusionLM(tiny_config)
+        # The persisted key must remain `model.vocab_embed.embedding`
+        # (adding a `weight` property must NOT introduce a new persisted key).
+        keys = set(model.state_dict().keys())
+        assert "model.vocab_embed.embedding" in keys
+        assert "model.vocab_embed.weight" not in keys
+
+
+class TestMDLMDiTTrainerE2E:
+    def test_diffusion_trainer_runs(self, tmp_path):
+        """Real DiffusionTrainer.train() must run end-to-end (regression for #33).
+
+        This is the path the unit tests missed: TRL/unsloth SFTTrainer init calls
+        model.get_input_embeddings().weight.dtype.
+        """
+        from tokenizers import Tokenizer, models, normalizers, pre_tokenizers
+        from transformers import PreTrainedTokenizerFast
+
+        from unturtle.diffusion import (
+            DiffusionTrainer,
+            DiffusionTrainingArguments,
+            MaskedDiffusionDataCollator,
+        )
+        from unturtle.models.backbones.mdlm_dit import (
+            MDLMDiTConfig,
+            MDLMDiTForMaskedDiffusionLM,
+        )
+
+        raw = Tokenizer(models.BPE(unk_token="[UNK]"))
+        raw.normalizer = normalizers.Lowercase()
+        raw.pre_tokenizer = pre_tokenizers.Whitespace()
+        tok = PreTrainedTokenizerFast(
+            tokenizer_object=raw,
+            unk_token="[UNK]",
+            mask_token="[MASK]",
+            pad_token="[PAD]",
+        )
+        tok.add_special_tokens(
+            {"unk_token": "[UNK]", "mask_token": "[MASK]", "pad_token": "[PAD]"}
+        )
+        tok.name_or_path = "local"
+        mask_token_id = tok.mask_token_id or 1
+
+        cfg = MDLMDiTConfig(
+            vocab_size=256,
+            hidden_size=64,
+            cond_dim=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            dropout=0.0,
+            max_position_embeddings=64,
+            mask_token_id=mask_token_id,
+            pad_token_id=tok.pad_token_id or 0,
+        )
+        assert mask_token_id < cfg.vocab_size
+        model = MDLMDiTForMaskedDiffusionLM(cfg).train()
+
+        L = 16
+        dataset = [
+            {
+                "input_ids": torch.randint(2, cfg.vocab_size, (L,)).tolist(),
+                "labels": torch.randint(2, cfg.vocab_size, (L,)).tolist(),
+                "attention_mask": [1] * L,
+            }
+            for _ in range(8)
+        ]
+        collator = MaskedDiffusionDataCollator(
+            tokenizer=tok, mask_token_id=mask_token_id, completion_only=False
+        )
+        args = DiffusionTrainingArguments(
+            output_dir=str(tmp_path / "ckpt"),
+            num_train_epochs=1,
+            max_steps=3,
+            per_device_train_batch_size=2,
+            logging_steps=1,
+            save_steps=100,
+            use_cpu=True,
+            bf16=False,
+            fp16=False,
+            # MDLM-DiT declares supports_gradient_checkpointing = False (no KV cache /
+            # checkpointing machinery); the HF Trainer default would otherwise call
+            # gradient_checkpointing_enable() and raise.
+            gradient_checkpointing=False,
+            dataloader_drop_last=True,
+            remove_unused_columns=False,
+            report_to="none",
+        )
+        trainer = DiffusionTrainer(
+            model=model,
+            args=args,
+            train_dataset=dataset,
+            data_collator=collator,
+            processing_class=tok,
+        )
+        result = trainer.train()
+        assert result.training_loss is not None
+        assert torch.isfinite(torch.tensor(result.training_loss))
+
+
 class TestMDLMDiTRegistration:
     def test_reexported_from_backbones(self):
         from unturtle.models.backbones import (

--- a/unturtle/models/backbones/mdlm_dit/modeling_mdlm_dit.py
+++ b/unturtle/models/backbones/mdlm_dit/modeling_mdlm_dit.py
@@ -106,6 +106,13 @@ class EmbeddingLayer(nn.Module):
         self.embedding = nn.Parameter(torch.empty((vocab_dim, dim)))
         nn.init.kaiming_uniform_(self.embedding, a=math.sqrt(5))
 
+    @property
+    def weight(self) -> torch.Tensor:
+        # Expose the embedding table as `.weight` for HF compatibility
+        # (get_input_embeddings().weight). The persisted parameter is still
+        # named `embedding`, so state_dict keys are unchanged.
+        return self.embedding
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.embedding[x]
 
@@ -321,6 +328,22 @@ class MDLMDiTForMaskedDiffusionLM(
         super().__init__(config)
         self.model = MDLMDiTModel(config)
         self.post_init()
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.model.vocab_embed
+
+    def set_input_embeddings(self, value: nn.Module) -> None:
+        self.model.vocab_embed = value
+
+    def get_output_embeddings(self) -> nn.Module:
+        # The final logit projection is the natural output embedding. unsloth's
+        # SFTTrainer init (fix_untrained_tokens) unconditionally reads
+        # get_output_embeddings().weight, so this must not return None. Weights are
+        # untied (tie_word_embeddings=False), so tie_weights() short-circuits.
+        return self.model.output_layer.linear
+
+    def set_output_embeddings(self, value: nn.Module) -> None:
+        self.model.output_layer.linear = value
 
     def forward(
         self,


### PR DESCRIPTION
Fixes #33.

## What

Running a real end-to-end `DiffusionTrainer.train()` on the newly-added MDLM-DiT backbone
(#31/#32) crashed at TRL/unsloth `SFTTrainer` init:

```
NotImplementedError: get_input_embeddings not auto-handled for MDLMDiTForMaskedDiffusionLM
```

The unit tests only called `model(**inputs)` directly, so they never exercised the
trainer-init path and missed this. This PR implements the missing HF embedding accessors.

## Changes

- `EmbeddingLayer.weight` **property** returning `self.embedding` — exposes `.weight` for
  `get_input_embeddings().weight.dtype` **without renaming** the parameter, so the merged
  `model.vocab_embed.embedding` state_dict key is unchanged (save/reload parity preserved).
- `get_input_embeddings` / `set_input_embeddings` on `MDLMDiTForMaskedDiffusionLM`
  (return/replace `self.model.vocab_embed`).
- `get_output_embeddings` / `set_output_embeddings` (return/replace
  `self.model.output_layer.linear`) — required because unsloth's `fix_untrained_tokens`
  unconditionally reads `model.get_output_embeddings().weight` during SFTTrainer init. Safe:
  `tie_word_embeddings=False` keeps `tie_weights()` a no-op (verified distinct `data_ptr`s),
  matching the sibling Dream pattern.

## Tests

- `TestMDLMDiTEmbeddings` — accessors + `.weight.dtype` + state_dict key unchanged.
- `TestMDLMDiTTrainerE2E::test_diffusion_trainer_runs` — **the regression test that would have
  caught this**: a real `DiffusionTrainer.train()` on a tiny CPU model with a local tokenizer
  and synthetic data, asserting finite loss. Unmarked (CPU, no download), matching the sibling
  `tests/test_e2e_integration.py` trainer-test convention.
- Full `tests/models/test_mdlm_dit.py`: **27 passed**. Verified manually end-to-end:
  train (loss 3.12→2.58 over 8 steps) → `generate(algorithm="mdlm")` → `GenerationEvaluator`
  all run.

## Follow-up (not in this PR)

`DiffusionTrainingArguments` defaults `gradient_checkpointing=True` (inherited from unsloth),
but `MDLMDiTPreTrainedModel.supports_gradient_checkpointing=False`, so a default MDLM-DiT
training run raises `ValueError` unless `gradient_checkpointing=False` is set. Worth smoothing
in `DiffusionTrainer` (auto-disable when unsupported) or documenting — tracked separately.