### PR TITLE
🐛 fix(dream): GC crash, silent padding leak in eager/fast attention, ignored position_ids (#38)

### DIFF
--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -888,3 +888,36 @@ class TestDreamFastRoPE:
             out = model(input_ids=input_ids)
         assert out.logits.shape == (B, L, config.vocab_size)
         assert not torch.isnan(out.logits).any()
+
+
+class TestDreamSavePretrained:
+    """transformers 5.x requires dict-style _tied_weights_keys; the legacy list
+    form crashes remove_tied_weights_from_state_dict during save_pretrained
+    (and therefore every Trainer checkpoint save)."""
+
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.backbones.dream import DreamConfig
+
+        return DreamConfig(
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+            pad_token_id=0,
+            mask_token_id=1,
+        )
+
+    def test_save_pretrained_roundtrip(self, config, tmp_path):
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu()
+        model.save_pretrained(tmp_path / "ckpt")
+        reloaded = DreamModel.from_pretrained(tmp_path / "ckpt").cpu()
+        assert reloaded.config.vocab_size == config.vocab_size
+        torch.testing.assert_close(
+            reloaded.lm_head.weight, model.lm_head.weight, atol=0, rtol=0
+        )

--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -98,6 +98,143 @@ class TestDreamModel:
         grads = [p.grad for p in model.parameters() if p.grad is not None]
         assert len(grads) > 0
 
+    def test_gradient_checkpointing_forward_backward(self, config):
+        """Training-mode forward+backward with gradient checkpointing must not raise.
+
+        Regression: the checkpointed call used to pass 10 positional args to
+        DreamDecoderLayer.forward (8 positionals + **kwargs) -> TypeError.
+        """
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu()
+        model.gradient_checkpointing_enable()
+        model.train()
+        B, L = 2, 8
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        labels = torch.randint(0, config.vocab_size, (B, L))
+        labels[:, ::2] = -100
+        out = model(input_ids=input_ids, labels=labels)
+        assert out.loss is not None
+        assert not torch.isnan(out.loss)
+        out.loss.backward()
+        grads = [p.grad for p in model.parameters() if p.grad is not None]
+        assert len(grads) > 0
+
+    def test_gradient_checkpointing_matches_plain_forward(self, config):
+        """Checkpointed forward must be numerically identical to the plain path."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu()
+        model.train()
+        B, L = 2, 8
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        plain = model(input_ids=input_ids).logits.detach()
+        model.gradient_checkpointing_enable()
+        checkpointed = model(input_ids=input_ids).logits.detach()
+        assert torch.allclose(plain, checkpointed, atol=1e-6)
+
+    def test_padded_batch_eager_masks_padding(self, config):
+        """Eager attention must actually mask padding (bool keep-mask handling).
+
+        Regression: the eager path added the bool [B,1,L,L] keep-mask to the
+        attention scores (+1/+0) instead of masking with -inf, so padding
+        silently leaked into attention. output_attentions=True forces the
+        eager DreamAttention.forward fallback.
+        """
+        from unturtle.models.backbones.dream import DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+        L_real, L_pad = 6, 8
+        real_ids = torch.randint(2, config.vocab_size, (1, L_real))
+        padded_ids = torch.full((1, L_pad), config.pad_token_id, dtype=torch.long)
+        padded_ids[:, :L_real] = real_ids
+        attention_mask = torch.zeros(1, L_pad, dtype=torch.long)
+        attention_mask[:, :L_real] = 1
+
+        with torch.no_grad():
+            ref = model(input_ids=real_ids, output_attentions=True).logits
+            masked = model(
+                input_ids=padded_ids,
+                attention_mask=attention_mask,
+                output_attentions=True,
+            ).logits
+            unmasked = model(input_ids=padded_ids, output_attentions=True).logits
+
+        # Non-pad positions of the masked padded batch match the unpadded run
+        assert torch.allclose(ref, masked[:, :L_real], atol=1e-5), (
+            f"max_diff={(ref - masked[:, :L_real]).abs().max().item():.2e}"
+        )
+        # ... and differ from the unmasked run (padding actually masked)
+        assert not torch.allclose(ref, unmasked[:, :L_real], atol=1e-5)
+
+    def test_padded_batch_sdpa_masks_padding(self, config):
+        """Same padding-equivalence guarantee on the default SDPA path."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+        L_real, L_pad = 6, 8
+        real_ids = torch.randint(2, config.vocab_size, (1, L_real))
+        padded_ids = torch.full((1, L_pad), config.pad_token_id, dtype=torch.long)
+        padded_ids[:, :L_real] = real_ids
+        attention_mask = torch.zeros(1, L_pad, dtype=torch.long)
+        attention_mask[:, :L_real] = 1
+
+        with torch.no_grad():
+            ref = model(input_ids=real_ids).logits
+            masked = model(input_ids=padded_ids, attention_mask=attention_mask).logits
+
+        assert torch.allclose(ref, masked[:, :L_real], atol=1e-5), (
+            f"max_diff={(ref - masked[:, :L_real]).abs().max().item():.2e}"
+        )
+
+    def test_all_ones_attention_mask_eager_does_not_crash(self, config):
+        """All-ones 2-D mask becomes the string sentinel 'full'; the eager path
+        must treat it as no-mask instead of crashing on string addition."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+        B, L = 2, 8
+        input_ids = torch.randint(2, config.vocab_size, (B, L))
+        attention_mask = torch.ones(B, L, dtype=torch.long)
+        with torch.no_grad():
+            with_mask = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                output_attentions=True,
+            ).logits
+            no_mask = model(input_ids=input_ids, output_attentions=True).logits
+        assert torch.allclose(with_mask, no_mask, atol=1e-6)
+
+    def test_position_ids_are_honored(self, config):
+        """Explicit shifted position_ids must change the output vs default arange."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+        B, L = 1, 8
+        input_ids = torch.randint(2, config.vocab_size, (B, L))
+        default = torch.arange(L).unsqueeze(0)
+        shifted = default + 5
+        collapsed = torch.zeros(1, L, dtype=torch.long)
+        with torch.no_grad():
+            out_default = model(input_ids=input_ids).logits
+            out_explicit_default = model(
+                input_ids=input_ids, position_ids=default
+            ).logits
+            out_shifted = model(input_ids=input_ids, position_ids=shifted).logits
+            out_collapsed = model(input_ids=input_ids, position_ids=collapsed).logits
+        # Explicit arange == implicit arange
+        assert torch.allclose(out_default, out_explicit_default, atol=1e-6)
+        # RoPE is relative: a uniform shift preserves pairwise offsets, so a
+        # shifted arange must still match — proving the ids reach RoPE intact.
+        assert torch.allclose(out_default, out_shifted, atol=1e-5)
+        # Collapsed positions change relative structure -> output must differ
+        assert not torch.allclose(out_default, out_collapsed, atol=1e-4)
+
     def test_forward_use_cache_returns_past_key_values(self, config):
         from unturtle.models.backbones.dream import DreamModel
 
@@ -290,6 +427,33 @@ class TestDreamGenerationUtils:
             _ = model.generate(inputs=inputs, generation_config=generation_config)
 
         assert 3 in model.forward_lengths
+
+    def test_left_padded_generation_smoke(self, config):
+        """Left-padded batch generation exercises the tok_idx position_ids path.
+
+        _sample computes tok_idx from the padding mask (RoPE fix under left
+        padding) and passes it as position_ids; the base model must honor it.
+        """
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+        inputs = torch.tensor([[0, 0, 2, 3], [4, 5, 6, 7]])
+        attention_mask = torch.tensor([[0, 0, 1, 1], [1, 1, 1, 1]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            out = model.generate(
+                inputs=inputs,
+                attention_mask=attention_mask,
+                generation_config=generation_config,
+            )
+        assert out.shape == (2, 8)
+        assert not torch.any(out == config.mask_token_id)
 
     def test_dream_generate_accepts_algorithm(self, config):
         from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel

--- a/unturtle/models/backbones/dream/modeling_dream.py
+++ b/unturtle/models/backbones/dream/modeling_dream.py
@@ -1005,7 +1005,10 @@ class DreamBaseModel(DreamPreTrainedModel):
 
 
 class DreamModel(DreamGenerationMixin, DreamPreTrainedModel):
-    _tied_weights_keys = ["lm_head.weight"]
+    # transformers 5.x expects a {target: source} dict here (a list crashes
+    # _get_tied_weight_keys → save_pretrained). Tying itself is still gated by
+    # config.tie_word_embeddings (False by default for Dream).
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
 
     def __init__(self, config):
         super().__init__(config)

--- a/unturtle/models/backbones/dream/modeling_dream.py
+++ b/unturtle/models/backbones/dream/modeling_dream.py
@@ -312,6 +312,27 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
+def _apply_eager_attention_mask(
+    attn_weights: torch.Tensor, attention_mask
+) -> torch.Tensor:
+    """Apply the mask produced by ``DreamModel.forward`` to eager attention scores.
+
+    ``DreamModel.forward`` normalizes 2-D padding masks into either the string
+    sentinel ``"full"`` (all-ones mask — nothing to mask) or a bool ``[B, 1, L, L]``
+    keep-mask; pre-expanded additive float 4-D masks pass through unchanged.
+    Mirrors ``DreamSdpaAttention``, which forwards only tensor masks to SDPA
+    (bool keep-masks are handled natively there).
+    """
+    if attention_mask is None or not isinstance(attention_mask, torch.Tensor):
+        # None or the "full" sentinel: nothing to mask.
+        return attn_weights
+    mask = attention_mask[:, :, :, : attn_weights.shape[-1]]
+    if mask.dtype == torch.bool:
+        # keep-mask: True = attend, False = masked out
+        return attn_weights.masked_fill(~mask, torch.finfo(attn_weights.dtype).min)
+    return attn_weights + mask
+
+
 class DreamAttention(nn.Module):
     """
     Multi-headed attention from 'Attention Is All You Need' paper. Modified to use sliding window attention: Longformer
@@ -453,9 +474,7 @@ class DreamAttention(nn.Module):
         attn_weights = torch.matmul(
             query_states, key_states.transpose(2, 3)
         ) / math.sqrt(self.head_dim)
-        if attention_mask is not None:  # no matter the length, we just slice it
-            causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
-            attn_weights = attn_weights + causal_mask
+        attn_weights = _apply_eager_attention_mask(attn_weights, attention_mask)
 
         # upcast attention to fp32
         attn_weights = nn.functional.softmax(
@@ -883,19 +902,23 @@ class DreamBaseModel(DreamPreTrainedModel):
         past_seen_tokens = (
             past_key_values[0][0].shape[1] if past_key_values is not None else 0
         )
-        if not dual_cache:
-            position_ids = torch.arange(
-                past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
-            ).unsqueeze(0)
-        else:
-            if past_key_values is not None:
+        if position_ids is None:
+            # Default arange positions. Callers (e.g. DreamGenerationMixin._sample
+            # under left padding) may pass explicit position_ids, which are honored.
+            if not dual_cache:
                 position_ids = torch.arange(
-                    past_seen_tokens, device=inputs_embeds.device
+                    past_seen_tokens + inputs_embeds.shape[1],
+                    device=inputs_embeds.device,
                 ).unsqueeze(0)
             else:
-                position_ids = torch.arange(
-                    inputs_embeds.shape[1], device=inputs_embeds.device
-                ).unsqueeze(0)
+                if past_key_values is not None:
+                    position_ids = torch.arange(
+                        past_seen_tokens, device=inputs_embeds.device
+                    ).unsqueeze(0)
+                else:
+                    position_ids = torch.arange(
+                        inputs_embeds.shape[1], device=inputs_embeds.device
+                    ).unsqueeze(0)
 
         hidden_states = inputs_embeds
         attn_key_values = [] if use_cache else None
@@ -921,6 +944,9 @@ class DreamBaseModel(DreamPreTrainedModel):
             )
 
             if self.gradient_checkpointing and self.training:
+                # dual_cache / replace_position are inference-only (None/False
+                # during training); DreamDecoderLayer.forward accepts only 8
+                # positionals, so they must not be passed positionally here.
                 layer_outputs = self._gradient_checkpointing_func(
                     decoder_layer.__call__,
                     hidden_states,
@@ -931,8 +957,6 @@ class DreamBaseModel(DreamPreTrainedModel):
                     use_cache,
                     cache_position,
                     position_embeddings,
-                    dual_cache,
-                    replace_position,
                 )
             else:
                 layer_outputs = decoder_layer(
@@ -1222,9 +1246,7 @@ def DreamAttention_fast_forward(
     attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(
         self.head_dim
     )
-    if attention_mask is not None:
-        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
-        attn_weights = attn_weights + causal_mask
+    attn_weights = _apply_eager_attention_mask(attn_weights, attention_mask)
 
     attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(
         query_states.dtype


### PR DESCRIPTION
Closes #38.

## What
- **Gradient checkpointing (critical)**: the GC branch passed 10 positionals into `DreamDecoderLayer.forward` (8 positionals + `**kwargs`) → guaranteed `TypeError` under `DiffusionTrainer` with `gradient_checkpointing=True`. Now passes only the 8 real positionals; `dual_cache`/`replace_position` are inference-only and default correctly during training.
- **Attention mask (high)**: `DreamModel.forward` normalizes 2-D masks into a bool `[B,1,L,L]` keep-mask or the `"full"` string sentinel, but the eager path and `DreamAttention_fast_forward` did `attn_weights + mask` — `TypeError` on `"full"`, and bool masks added +1/+0 instead of -inf, so **padding was silently attended**. New shared `_apply_eager_attention_mask` helper: sentinel → no-op, bool → `masked_fill(~mask, finfo.min)`, additive float 4-D unchanged (mirrors `DreamSdpaAttention`).
- **position_ids (high)**: `DreamBaseModel.forward` unconditionally recomputed arange positions, discarding the `tok_idx` left-padding RoPE correction from `DreamGenerationMixin._sample`. Supplied `position_ids` are now honored; all cached/dual-cache paths (which pass None) are unchanged.

Bidirectional attention (`is_causal=False`) is preserved throughout.

## Test plan
- [x] 8 new regression tests (GC forward+backward + numeric equivalence, padded-batch eager/SDPA masking, "full" sentinel, position_ids honored, left-padded generation smoke)
- [x] `tests/models/test_dream.py -m "not slow"`: 36 passed; Dream-adjacent suites: 104 passed; ruff clean