### PR TITLE
🐛 fix(grpo): TRL buffering broke cached logps / iteration index / mask RNG for steps_per_generation > 1 (#40)

### DIFF
--- a/tests/diffusion/test_grpo_trainer.py
+++ b/tests/diffusion/test_grpo_trainer.py
@@ -554,6 +554,213 @@ def test_diffu_prepare_inputs_buffers_microbatches_and_regenerates_rollouts():
     assert tr._diffu_mask_seeds == [201, 202]
 
 
+def _make_buffering_trainer(steps_per_generation: int, num_iterations: int):
+    """Bare trainer wired for ``_prepare_inputs`` + ``compute_loss`` buffering tests."""
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    tr = DiffuGRPOTrainer.__new__(DiffuGRPOTrainer)
+    m = nn.Module()
+    m.train()
+    tr.model = m
+    tr._step = 0
+    tr._buffered_inputs = None
+    tr.args = SimpleNamespace(
+        steps_per_generation=steps_per_generation,
+        num_iterations=num_iterations,
+        diffu_policy_objective="grpo",
+    )
+    tr.num_iterations = num_iterations
+    tr.num_generations = 2
+    tr.beta = 0.0
+    tr.control = SimpleNamespace(should_evaluate=False)
+    tr.accelerator = SimpleNamespace(gather_for_metrics=lambda x: x)
+    tr._metrics = {"train": {"kl": [], "clip_ratio": []}}
+    tr._diffu_mask_seeds = []
+    return tr
+
+
+def test_prepare_inputs_slices_cached_logps_along_batch_dim_and_compute_loss_runs():
+    """Bug regression: ``old/ref_per_token_logps`` are ``[num_iterations, B_gen, Lc]``.
+
+    ``split_tensor_dict`` slices dim 0 (the iterations dim for these tensors), so
+    ``_prepare_inputs`` must instead attach the dim-1 (batch) slice per micro-batch.
+    Also checks ``compute_loss`` consumes each micro-batch with the correct GRPO
+    iteration index (one advance per full pass over the buffer, not per micro-batch)
+    and threads the buffer row window into ``_get_per_token_logps``.
+    """
+    pytest.importorskip("trl")
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    S, num_iterations, B_gen, Lc = 2, 2, 4, 4
+    cs = B_gen // S  # micro-batch size
+
+    # Distinctive per-(iteration, row) values so slices are checkable.
+    full_old = (
+        torch.arange(num_iterations * B_gen * Lc, dtype=torch.float32).view(
+            num_iterations, B_gen, Lc
+        )
+        * 1e-3
+    )
+    full_ref = full_old + 100.0
+
+    rollout_calls = 0
+
+    def fake_generate_and_score(_inputs: object) -> dict:
+        nonlocal rollout_calls
+        rollout_calls += 1
+        tr._diffu_mask_seeds = [11, 22]
+        return {
+            "prompt_ids": torch.zeros(B_gen, 4, dtype=torch.long),
+            "prompt_mask": torch.ones(B_gen, 4, dtype=torch.long),
+            "completion_ids": torch.zeros(B_gen, Lc, dtype=torch.long),
+            "completion_mask": torch.ones(B_gen, Lc, dtype=torch.long),
+            "old_per_token_logps": full_old.clone(),
+            "ref_per_token_logps": full_ref.clone(),
+            "advantages": torch.zeros(B_gen),
+        }
+
+    tr = _make_buffering_trainer(S, num_iterations)
+    tr._generate_and_score_completions = fake_generate_and_score  # type: ignore[method-assign]
+
+    logps_calls: list[dict] = []
+
+    def spy_get_per_token_logps(
+        _model,
+        input_ids,
+        logits_to_keep,
+        mask_seeds,
+        buffer_total_rows=None,
+        buffer_row_offset=0,
+    ):
+        logps_calls.append(
+            {
+                "seeds": list(mask_seeds),
+                "total_rows": buffer_total_rows,
+                "row_offset": buffer_row_offset,
+            }
+        )
+        n_it, b, _l = input_ids.shape
+        return torch.zeros(n_it, b, logits_to_keep)
+
+    tr._get_per_token_logps = spy_get_per_token_logps  # type: ignore[method-assign]
+
+    # One full generate_every cycle = S * num_iterations micro-steps.
+    for t in range(S * num_iterations):
+        inputs = DiffuGRPOTrainer._prepare_inputs(tr, {})
+        micro_idx = t % S
+        expected_itr = t // S
+
+        # Cached log-probs: iterations preserved on dim 0, batch sliced on dim 1.
+        for key, full in (
+            ("old_per_token_logps", full_old),
+            ("ref_per_token_logps", full_ref),
+        ):
+            got = inputs[key]
+            assert got.shape == (num_iterations, cs, Lc), key
+            assert torch.equal(got, full[:, micro_idx * cs : (micro_idx + 1) * cs]), key
+
+        # Buffer row window for train-time mask reproduction.
+        assert inputs["buffer_total_rows"] == B_gen
+        assert inputs["buffer_row_offset"] == micro_idx * cs
+
+        loss = DiffuGRPOTrainer.compute_loss(tr, tr.model, inputs)
+        assert torch.isfinite(loss)
+
+        # compute_loss must use the seed of the current GRPO iteration
+        # (advancing once per full pass over the buffer) and pass the window.
+        call = logps_calls[-1]
+        assert call["seeds"] == [tr._diffu_mask_seeds[expected_itr]], f"micro-step {t}"
+        assert call["total_rows"] == B_gen
+        assert call["row_offset"] == micro_idx * cs
+
+    assert rollout_calls == 1
+    assert len(logps_calls) == S * num_iterations
+
+
+def test_prepare_inputs_keeps_empty_cached_logps_lists():
+    """``old/ref_per_token_logps`` are ``[]`` when unused — chunks must keep them ``[]``."""
+    pytest.importorskip("trl")
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    def fake_generate_and_score(_inputs: object) -> dict:
+        tr._diffu_mask_seeds = [7]
+        return {
+            "prompt_ids": torch.zeros(4, 4, dtype=torch.long),
+            "completion_ids": torch.zeros(4, 4, dtype=torch.long),
+            "completion_mask": torch.ones(4, 4, dtype=torch.long),
+            "old_per_token_logps": [],
+            "ref_per_token_logps": [],
+            "advantages": torch.zeros(4),
+        }
+
+    tr = _make_buffering_trainer(steps_per_generation=2, num_iterations=1)
+    tr._generate_and_score_completions = fake_generate_and_score  # type: ignore[method-assign]
+
+    for _t in range(2):
+        inputs = DiffuGRPOTrainer._prepare_inputs(tr, {})
+        assert inputs["old_per_token_logps"] == []
+        assert inputs["ref_per_token_logps"] == []
+
+
+def test_forward_process_window_reproduces_rollout_mask():
+    """Windowed draw: rand((total_rows, L)) sliced at the row offset matches the
+    rows of the full-batch draw under the same seed (Bug: micro-batches after the
+    first were re-masked differently than their cached old/ref log-probs)."""
+    from unturtle.diffusion import DiffuGRPOConfig, DiffuGRPOTrainer
+
+    cfg = DiffuGRPOConfig(
+        output_dir="/tmp/t",
+        per_device_train_batch_size=1,
+        num_generations=2,
+        generation_batch_size=2,
+        p_mask_prompt=0.5,
+    )
+
+    class _Stub:
+        args = cfg
+
+    stub = _Stub()
+    L = 16
+    batch = torch.arange(1, 4 * L + 1).view(4, L)
+    prompt_index = torch.zeros(L, dtype=torch.bool)
+    prompt_index[:8] = True
+
+    # Rollout-time draw over the full [4, L] batch.
+    noisy_full, p_full = DiffuGRPOTrainer._forward_process(
+        stub, batch, prompt_index, mask_id=999, seed=42
+    )
+    # Train-time draw over the second micro-batch (rows 2:4) with the window.
+    noisy_win, p_win = DiffuGRPOTrainer._forward_process(
+        stub,
+        batch[2:4],
+        prompt_index,
+        mask_id=999,
+        seed=42,
+        total_rows=4,
+        row_offset=2,
+    )
+    assert torch.equal(noisy_win, noisy_full[2:4])
+    assert torch.equal(p_win, p_full[2:4])
+
+    # Without the window (legacy behavior) rows 0:2 of the full draw are
+    # reproduced instead — i.e. the wrong mask for rows 2:4.
+    noisy_plain, _ = DiffuGRPOTrainer._forward_process(
+        stub, batch[2:4], prompt_index, mask_id=999, seed=42
+    )
+    masked_pattern_plain = noisy_plain == 999
+    masked_pattern_rows01 = (noisy_full == 999)[0:2]
+    assert torch.equal(masked_pattern_plain, masked_pattern_rows01)
+
+    # S=1 bit-identity: total_rows == b, offset 0 must equal the plain draw.
+    noisy_a, _ = DiffuGRPOTrainer._forward_process(
+        stub, batch, prompt_index, mask_id=999, seed=42
+    )
+    noisy_b, _ = DiffuGRPOTrainer._forward_process(
+        stub, batch, prompt_index, mask_id=999, seed=42, total_rows=4, row_offset=0
+    )
+    assert torch.equal(noisy_a, noisy_b)
+
+
 def test_trl_split_tensor_dict_empty_second_chunk_for_iteration_sized_list():
     """TRL slices every sequence-like value by batch chunk — not ``num_iterations``.
 

--- a/unturtle/diffusion/grpo_trainer.py
+++ b/unturtle/diffusion/grpo_trainer.py
@@ -319,13 +319,40 @@ class DiffuGRPOTrainer(GRPOTrainer):
                 generation_batch = self._generate_and_score_completions(
                     generation_batch
                 )
+                # ``old/ref_per_token_logps`` are ``[num_iterations, B_gen, Lc]`` —
+                # iterations on dim 0, batch on dim 1. TRL's ``split_tensor_dict``
+                # slices every tensor along dim 0 (the batch dim for everything
+                # else), so pop them and re-attach the correct dim-1 slice per
+                # micro-batch below. They are ``[]`` when unused.
+                old_logps = generation_batch.pop("old_per_token_logps", [])
+                ref_logps = generation_batch.pop("ref_per_token_logps", [])
+                total_rows = generation_batch["prompt_ids"].shape[0]
+                chunk_size = total_rows // self.args.steps_per_generation
                 generation_batch = split_pixel_values_by_grid(generation_batch)
                 generation_batches = split_tensor_dict(
                     generation_batch, self.args.steps_per_generation
                 )
-                self._buffered_inputs = [
-                    unsplit_pixel_values_by_grid(batch) for batch in generation_batches
-                ]
+                buffered = []
+                for i, batch in enumerate(generation_batches):
+                    batch = unsplit_pixel_values_by_grid(batch)
+                    row_offset = i * chunk_size
+                    batch["old_per_token_logps"] = (
+                        old_logps[:, row_offset : row_offset + chunk_size]
+                        if isinstance(old_logps, torch.Tensor)
+                        else old_logps
+                    )
+                    batch["ref_per_token_logps"] = (
+                        ref_logps[:, row_offset : row_offset + chunk_size]
+                        if isinstance(ref_logps, torch.Tensor)
+                        else ref_logps
+                    )
+                    # Row window of this micro-batch within the rollout batch, so
+                    # train-time re-masking can reproduce the generation-time
+                    # ``torch.rand((B_gen, L))`` draw (see ``_forward_process``).
+                    batch["buffer_row_offset"] = row_offset
+                    batch["buffer_total_rows"] = total_rows
+                    buffered.append(batch)
+                self._buffered_inputs = buffered
             inputs = self._buffered_inputs[self._step % self.args.steps_per_generation]
             # Matches TRL ``GRPOTrainer._prepare_inputs`` (one increment per micro-batch).
             self._step += 1
@@ -538,6 +565,8 @@ class DiffuGRPOTrainer(GRPOTrainer):
         prompt_index: torch.Tensor,
         mask_id: int,
         seed: Optional[int] = None,
+        total_rows: Optional[int] = None,
+        row_offset: int = 0,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Apply stochastic masking to a token sequence.
 
@@ -553,6 +582,14 @@ class DiffuGRPOTrainer(GRPOTrainer):
             prompt_index:  Bool mask ``[L]`` — True for prompt positions.
             mask_id:       Mask token id.
             seed:          Random seed for reproducibility across iterations.
+            total_rows:    When ``batch`` is a micro-batch slice of a larger
+                           rollout batch, the rollout batch size ``B_gen``. The
+                           random draw is then ``torch.rand((total_rows, L))``
+                           sliced at ``[row_offset:row_offset+B]`` so the mask
+                           matches the one drawn at rollout time for these rows.
+                           ``None`` keeps the plain ``torch.rand((B, L))`` draw.
+            row_offset:    Row offset of ``batch`` within the rollout batch
+                           (only meaningful with ``total_rows``).
 
         Returns:
             ``(noisy_batch, p_mask)`` — masked sequence and per-position
@@ -563,7 +600,14 @@ class DiffuGRPOTrainer(GRPOTrainer):
 
         b, l = batch.shape
         t_p = torch.full((b,), self.args.p_mask_prompt, device=batch.device)
-        rng = torch.rand((b, l), device=batch.device)
+        if total_rows is None or total_rows == b:
+            # Identical to torch.rand((total_rows, l)) sliced with offset 0 when
+            # total_rows == b — S=1 behavior is bit-exact with the legacy draw.
+            rng = torch.rand((b, l), device=batch.device)
+        else:
+            rng = torch.rand((total_rows, l), device=batch.device)[
+                row_offset : row_offset + b
+            ]
 
         is_mask_prompt = prompt_index.unsqueeze(0) & (rng < t_p.unsqueeze(1))
         is_mask_completion = ~prompt_index.unsqueeze(0)
@@ -644,6 +688,8 @@ class DiffuGRPOTrainer(GRPOTrainer):
         input_ids: torch.Tensor,
         logits_to_keep: int,
         mask_seeds: list[int],
+        buffer_total_rows: Optional[int] = None,
+        buffer_row_offset: int = 0,
     ) -> torch.Tensor:
         """Compute per-token log p_θ(x_0 | x_t) for GRPO.
 
@@ -656,6 +702,12 @@ class DiffuGRPOTrainer(GRPOTrainer):
             input_ids:      ``[num_iterations, B, L]`` — repeated full sequences.
             logits_to_keep: Number of completion tokens (``L_completion``).
             mask_seeds:     One seed per GRPO iteration.
+            buffer_total_rows: Rollout batch size ``B_gen`` when ``input_ids``
+                            holds a micro-batch slice of a buffered rollout;
+                            forwarded to :meth:`_forward_process` so the
+                            per-seed mask matches the rollout-time draw.
+            buffer_row_offset: Row offset of the micro-batch within the
+                            rollout batch (with ``buffer_total_rows``).
 
         Returns:
             ``[num_iterations, B, L_completion]`` float32 log-probs.
@@ -671,7 +723,12 @@ class DiffuGRPOTrainer(GRPOTrainer):
         all_noisy, all_original = [], []
         for i, seed in enumerate(mask_seeds):
             noisy, _ = self._forward_process(
-                input_ids[i], prompt_index, self.args.mask_id, seed
+                input_ids[i],
+                prompt_index,
+                self.args.mask_id,
+                seed,
+                total_rows=buffer_total_rows,
+                row_offset=buffer_row_offset,
             )
             all_noisy.append(noisy)
             all_original.append(input_ids[i])
@@ -770,9 +827,19 @@ class DiffuGRPOTrainer(GRPOTrainer):
 
         objective = getattr(self.args, "diffu_policy_objective", "grpo")
 
+        # ``_prepare_inputs`` increments ``_step`` once per micro-batch BEFORE
+        # ``compute_loss``; the GRPO iteration index advances once per full pass
+        # over the ``steps_per_generation`` buffered micro-batches.
+        this_itr_idx = (
+            (self._step - 1) // self.args.steps_per_generation
+        ) % self.num_iterations
+        # Row window of this micro-batch within the rollout batch (set by
+        # ``_prepare_inputs``); ``None`` when inputs were not buffered/split.
+        buffer_total_rows = inputs.get("buffer_total_rows")
+        buffer_row_offset = inputs.get("buffer_row_offset", 0)
+
         if objective == "wd1++":
             logits_to_keep = completion_ids.size(1)
-            this_itr_idx = self._step % self.args.num_iterations
             seeds = self._diffu_mask_seeds
             if not seeds or this_itr_idx >= len(seeds):
                 raise RuntimeError(
@@ -811,7 +878,12 @@ class DiffuGRPOTrainer(GRPOTrainer):
                 input_ids_kl = torch.cat([prompt_ids, completion_ids], dim=1)
                 input_ids_3d_kl = input_ids_kl.unsqueeze(0)
                 per_token_logps_kl = self._get_per_token_logps(
-                    model, input_ids_3d_kl, logits_to_keep, [this_seed]
+                    model,
+                    input_ids_3d_kl,
+                    logits_to_keep,
+                    [this_seed],
+                    buffer_total_rows=buffer_total_rows,
+                    buffer_row_offset=buffer_row_offset,
                 ).squeeze(0)
                 ref_per_token_logps = inputs["ref_per_token_logps"][
                     this_itr_idx
@@ -832,7 +904,6 @@ class DiffuGRPOTrainer(GRPOTrainer):
         input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
         logits_to_keep = completion_ids.size(1)
 
-        this_itr_idx = self._step % self.args.num_iterations
         seeds = self._diffu_mask_seeds
         if not seeds or this_itr_idx >= len(seeds):
             raise RuntimeError(
@@ -842,7 +913,12 @@ class DiffuGRPOTrainer(GRPOTrainer):
         input_ids_3d = input_ids.unsqueeze(0)  # [1, B, L]
 
         per_token_logps = self._get_per_token_logps(
-            model, input_ids_3d, logits_to_keep, this_seed
+            model,
+            input_ids_3d,
+            logits_to_keep,
+            this_seed,
+            buffer_total_rows=buffer_total_rows,
+            buffer_row_offset=buffer_row_offset,
         )
         per_token_logps = per_token_logps.squeeze(0)  # [B, Lc]
 


### PR DESCRIPTION
Closes #40.

## What
- **Wrong split dim (critical)**: `old/ref_per_token_logps` are `[num_iterations, B_gen, Lc]` but went through TRL's `split_tensor_dict` (slices dim 0 = iterations). They are now popped before the split and each micro-batch chunk gets the correct batch slice `logps[:, i*cs:(i+1)*cs]`; empty-list (unused) values pass through unchanged.
- **Iteration index**: `this_itr_idx = self._step % num_iterations` advanced per micro-batch and was off by one (`_step` pre-incremented in `_prepare_inputs`). Now `((_step - 1) // steps_per_generation) % num_iterations`, advancing once per pass over the buffer — matching d1's per-iteration re-masking semantics (wd1++ `buf_idx` unchanged, already correct).
- **Mask RNG reproduction**: rollout draws `rand((B_gen, L))` per seed; train-time re-masking drew `rand((B_micro, L))` — only the first micro-batch's rows matched, silently biasing PPO ratios/KL. Chunks now carry `buffer_row_offset`/`buffer_total_rows`, threaded into `_forward_process`, which draws the full-batch shape and slices the window. S=1 behavior is bit-identical.

## Test plan
- [x] 3 new regressions: S=2/I=2 full-cycle buffering (shapes, exact dim-1 slices, iteration-seed spy through compute_loss), empty-logps passthrough, and window-vs-full-batch mask bit-equality (also demonstrating the old draw reproduced the wrong rows)
- [x] `tests/diffusion/` full: 206 passed; ruff clean