### PR TITLE
🐛 fix(cli/eval): 20-token generation-eval truncation + scheduler/mask-id plumbing to collators (#41)

### DIFF
--- a/tests/eval/test_evaluators.py
+++ b/tests/eval/test_evaluators.py
@@ -49,14 +49,30 @@ class TinyDiffusionModel(torch.nn.Module):
         super().__init__()
         self.calls = 0
         self.last_attention_mask = None
+        self.last_generation_config = None
+        self.last_generate_kwargs: dict | None = None
         self.dummy = torch.nn.Parameter(torch.zeros(1))
         self.config = type("Config", (), {"mask_token_id": mask_token_id})()
 
-    def generate(self, input_ids, max_length=None, attention_mask=None, **_kwargs):
+    def generate(
+        self,
+        input_ids,
+        max_length=None,
+        attention_mask=None,
+        generation_config=None,
+        **kwargs,
+    ):
         self.calls += 1
         self.last_attention_mask = (
             attention_mask.clone() if attention_mask is not None else None
         )
+        self.last_generation_config = generation_config
+        self.last_generate_kwargs = dict(kwargs)
+        if generation_config is not None and max_length is None:
+            if getattr(generation_config, "max_new_tokens", None) is not None:
+                max_length = input_ids.shape[1] + generation_config.max_new_tokens
+            elif getattr(generation_config, "max_length", None) is not None:
+                max_length = generation_config.max_length
         out = input_ids.clone()
         target_length = max_length or out.shape[1]
         if target_length > out.shape[1]:
@@ -214,6 +230,70 @@ class TestGenerationEvaluator:
         assert metrics["gen_token_accuracy"] == 1.0
         assert model.last_attention_mask is not None
         assert model.last_attention_mask.tolist() == [[1, 1]]
+
+    def test_config_without_length_uses_reference_length_per_example(self):
+        # Regression: a MaskedDiffusionGenerationConfig without max_new_tokens
+        # used to fall through to its default max_length=20, truncating
+        # generation.  The evaluator must derive the per-example reference
+        # length instead — on a copy, without mutating the shared config.
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        config = MaskedDiffusionGenerationConfig(steps=8, mask_token_id=4)
+        dataset = [{"input_ids": [1, 2, 3, 0], "references": [7, 7, 7]}]
+        metrics = evaluator.evaluate(dataset, generation_config=config)
+
+        received = model.last_generation_config
+        assert received is not None
+        assert received is not config  # per-example copy, shared config untouched
+        assert received.max_new_tokens == 3  # reference length, not default 20
+        assert config.max_new_tokens is None
+        assert metrics["gen_exact_match"] == 1.0
+
+    def test_config_with_explicit_max_new_tokens_is_passed_through(self):
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        config = MaskedDiffusionGenerationConfig(
+            steps=8, mask_token_id=4, max_new_tokens=5
+        )
+        dataset = [{"input_ids": [1, 2, 3, 0], "references": [7]}]
+        evaluator.evaluate(dataset, generation_config=config)
+
+        assert model.last_generation_config is config
+        assert model.last_generation_config.max_new_tokens == 5
+
+    def test_explicit_algorithm_is_pinned_alongside_config(self):
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        config = MaskedDiffusionGenerationConfig(steps=8, mask_token_id=4)
+        dataset = [{"input_ids": [1, 2, 3, 0], "references": [7]}]
+        evaluator.evaluate(dataset, generation_config=config, algorithm="mdlm")
+
+        assert model.last_generate_kwargs is not None
+        assert model.last_generate_kwargs.get("algorithm") == "mdlm"
+
+    def test_dict_config_behavior_unchanged(self):
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        dataset = [{"input_ids": [1, 2, 3, 0], "references": [7, 7]}]
+        evaluator.evaluate(dataset, generation_config={"steps": 8})
+
+        # Dict configs are expanded into kwargs; reference-length max_length
+        # is injected when absent, and algorithm stays pinned to "mdlm".
+        assert model.last_generation_config is None
+        assert model.last_generate_kwargs.get("steps") == 8
+        assert model.last_generate_kwargs.get("algorithm") == "mdlm"
 
     def test_generation_handles_left_padding(self):
         model = TinyDiffusionModel()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -24,7 +24,7 @@ from typer import Exit
 from unturtle.cli.commands.eval import _prepare_eval_dataset
 from unturtle.cli.commands.export import list_checkpoints
 from unturtle.cli.commands.train import _resolve_model_class, train
-from unturtle.cli.config import load_config
+from unturtle.cli.config import build_masked_diffusion_collator, load_config
 
 CONFIG_DIR = Path(__file__).resolve().parents[1] / "examples" / "configs"
 EXAMPLE_CONFIGS = [
@@ -203,6 +203,42 @@ def test_example_yaml_configs_work_with_train_dry_run(config_name, capsys):
     captured = capsys.readouterr()
     assert "model:" in captured.out
     assert "training:" in captured.out
+
+
+def test_build_masked_diffusion_collator_wires_scheduler_and_epsilon(tokenizer):
+    # Regression: `unturtle train/eval --alpha-scheduler cosine` used to build
+    # the collator with the default linear scheduler (alpha_scheduler never
+    # reached the noising collator).
+    from unturtle.diffusion.schedulers import CosineAlphaScheduler
+
+    collator = build_masked_diffusion_collator(
+        tokenizer,
+        alpha_scheduler="cosine",
+        time_epsilon=5e-3,
+        completion_only=False,
+    )
+
+    assert isinstance(collator.scheduler, CosineAlphaScheduler)
+    assert collator.time_epsilon == 5e-3
+    assert collator.completion_only is False
+    assert collator.mask_token_id == tokenizer.mask_token_id
+
+
+def test_build_masked_diffusion_collator_explicit_mask_id_wins(tokenizer):
+    collator = build_masked_diffusion_collator(tokenizer, mask_token_id=9)
+    assert collator.mask_token_id == 9
+
+
+def test_build_masked_diffusion_collator_falls_back_to_model_config(tokenizer):
+    # Regression: `unturtle eval --eval-type diffusion` on a tokenizer without
+    # mask_token_id must fall back to model.config.mask_token_id (real
+    # checkpoints may carry the mask id only on the model config).
+    tokenizer.mask_token = None
+    tokenizer.mask_token_id = None
+    model = type("Model", (), {"config": type("Config", (), {"mask_token_id": 42})()})()
+
+    collator = build_masked_diffusion_collator(tokenizer, model=model)
+    assert collator.mask_token_id == 42
 
 
 def test_list_checkpoints_reports_unreadable_trainer_state(tmp_path, capsys):

--- a/unturtle/cli/commands/eval.py
+++ b/unturtle/cli/commands/eval.py
@@ -146,6 +146,14 @@ def eval_cmd(
     num_steps: int = typer.Option(
         128, "--num-steps", help="Denoising steps for generation eval."
     ),
+    max_new_tokens: Optional[int] = typer.Option(
+        None,
+        "--max-new-tokens",
+        help=(
+            "Maximum generated tokens per example for generation eval. "
+            "Default: derive from each example's reference length."
+        ),
+    ),
     mask_token_id: Optional[int] = typer.Option(
         None, "--mask-token-id", help="Mask token ID override."
     ),
@@ -186,7 +194,7 @@ def eval_cmd(
 
     try:
         from unturtle import FastDiffusionModel
-        from unturtle.diffusion import MaskedDiffusionDataCollator
+        from unturtle.cli.config import build_masked_diffusion_collator
         from unturtle.eval import GenerationEvaluator, MaskedDiffusionEvaluator
         from unturtle.models.generation.diffusion_generation_utils import (
             MaskedDiffusionGenerationConfig,
@@ -239,13 +247,25 @@ def eval_cmd(
     all_metrics: dict = {}
     failures: list[str] = []
 
+    # Resolve mask token ID once for both eval branches:
+    # CLI override → tokenizer → model.config (real checkpoints may carry the
+    # mask id only on the model config).
+    resolved_mask_id = mask_token_id
+    if resolved_mask_id is None:
+        resolved_mask_id = getattr(tokenizer, "mask_token_id", None)
+    if resolved_mask_id is None:
+        resolved_mask_id = getattr(loaded_model.config, "mask_token_id", None)
+
     # --- Diffusion eval ---
     if eval_type in ("diffusion", "both"):
         typer.echo("Running diffusion eval...", err=True)
         try:
-            collator = MaskedDiffusionDataCollator(
-                tokenizer=tokenizer,
+            collator = build_masked_diffusion_collator(
+                tokenizer,
+                model=loaded_model,
+                alpha_scheduler=alpha_scheduler,
                 completion_only=completion_only,
+                mask_token_id=resolved_mask_id,
             )
             evaluator = MaskedDiffusionEvaluator(
                 model=loaded_model,
@@ -269,12 +289,6 @@ def eval_cmd(
     if eval_type in ("generation", "both"):
         typer.echo("Running generation eval...", err=True)
 
-        # Resolve mask token ID
-        resolved_mask_id = mask_token_id
-        if resolved_mask_id is None:
-            resolved_mask_id = getattr(tokenizer, "mask_token_id", None)
-        if resolved_mask_id is None:
-            resolved_mask_id = getattr(loaded_model.config, "mask_token_id", None)
         if resolved_mask_id is None:
             typer.echo(
                 "Error: cannot resolve mask_token_id for generation eval.",
@@ -283,11 +297,16 @@ def eval_cmd(
             failures.append("generation")
         else:
             try:
+                # When --max-new-tokens is omitted the config carries no
+                # explicit length and GenerationEvaluator derives a
+                # per-example max_length from the reference length (instead
+                # of the config default max_length=20, prompt included).
                 gen_config = MaskedDiffusionGenerationConfig(
                     steps=num_steps,
                     mask_token_id=resolved_mask_id,
                     temperature=temperature,
                     alg=alg,
+                    max_new_tokens=max_new_tokens,
                 )
                 gen_evaluator = GenerationEvaluator(
                     model=loaded_model,
@@ -297,6 +316,7 @@ def eval_cmd(
                     eval_ds,
                     generation_config=gen_config,
                     max_examples=max_examples,
+                    algorithm="mdlm",
                 )
                 all_metrics.update(gen_metrics)
             except Exception as e:

--- a/unturtle/cli/commands/train.py
+++ b/unturtle/cli/commands/train.py
@@ -282,10 +282,15 @@ def train(
                 typer.echo(f"Error: invalid training arguments — {e}", err=True)
                 raise typer.Exit(code=1)
 
-            from unturtle.diffusion import MaskedDiffusionDataCollator
+            from unturtle.cli.config import build_masked_diffusion_collator
 
-            collator = MaskedDiffusionDataCollator(
-                tokenizer=tokenizer,
+            # Mirror DiffusionTrainer's own collator construction so
+            # --alpha-scheduler / --time-epsilon reach the noising process.
+            collator = build_masked_diffusion_collator(
+                tokenizer,
+                model=model,
+                alpha_scheduler=cfg.diffusion.alpha_scheduler,
+                time_epsilon=cfg.diffusion.time_epsilon,
                 completion_only=cfg.diffusion.completion_only,
             )
             trainer = DiffusionTrainer(

--- a/unturtle/cli/config.py
+++ b/unturtle/cli/config.py
@@ -428,6 +428,49 @@ class Config(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Shared CLI object builders
+# ---------------------------------------------------------------------------
+
+
+def build_masked_diffusion_collator(
+    tokenizer,
+    model=None,
+    *,
+    alpha_scheduler: str = "linear",
+    time_epsilon: float = 1e-3,
+    completion_only: bool = True,
+    mask_token_id: Optional[int] = None,
+):
+    """Build a ``MaskedDiffusionDataCollator`` the way ``DiffusionTrainer`` does.
+
+    Mirrors the collator injection in :class:`~unturtle.diffusion.DiffusionTrainer`
+    (``trainer.py``): the alpha scheduler is instantiated from its name via
+    :func:`~unturtle.diffusion.make_alpha_scheduler`, ``time_epsilon`` is passed
+    through, and ``mask_token_id`` falls back to ``tokenizer.mask_token_id`` then
+    ``model.config.mask_token_id`` (real checkpoints may only carry the mask id
+    on the model config).
+
+    Used by ``unturtle train`` and ``unturtle eval`` when constructing the
+    collator explicitly, so ``--alpha-scheduler`` / ``--time-epsilon`` /
+    ``--mask-token-id`` are honored instead of silently using defaults.
+    """
+    from unturtle.diffusion import MaskedDiffusionDataCollator, make_alpha_scheduler
+
+    if mask_token_id is None:
+        mask_token_id = getattr(tokenizer, "mask_token_id", None)
+    if mask_token_id is None:
+        mask_token_id = getattr(getattr(model, "config", None), "mask_token_id", None)
+
+    return MaskedDiffusionDataCollator(
+        tokenizer=tokenizer,
+        scheduler=make_alpha_scheduler(alpha_scheduler),
+        mask_token_id=mask_token_id,
+        time_epsilon=time_epsilon,
+        completion_only=completion_only,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Config loader
 # ---------------------------------------------------------------------------
 

--- a/unturtle/eval/generation.py
+++ b/unturtle/eval/generation.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 import torch
@@ -79,37 +80,72 @@ class GenerationEvaluator(BaseEvaluator):
 
         return input_ids, None, attention_mask
 
+    @staticmethod
+    def _config_has_explicit_length(generation_config: Any) -> bool:
+        """Return True if a generation-config *object* carries a user-set length.
+
+        A config is considered length-less when ``max_new_tokens`` is unset and
+        ``max_length`` still equals the class default (20 for HF
+        ``GenerationConfig`` and subclasses).  Such configs would silently
+        truncate at ``prompt + generation == 20`` tokens, so the evaluator
+        substitutes the per-example reference length instead.
+        """
+        if getattr(generation_config, "max_new_tokens", None) is not None:
+            return True
+        max_length = getattr(generation_config, "max_length", None)
+        if max_length is None:
+            return False
+        try:
+            default_max_length = type(generation_config)().max_length
+        except Exception:
+            default_max_length = 20
+        return max_length != default_max_length
+
     def _generate_one(
         self,
         prompt_ids: torch.Tensor,
         generation_config: Any | None,
         reference_ids: torch.Tensor | None,
         attention_mask: torch.Tensor | None,
+        algorithm: str | None = None,
     ) -> torch.Tensor:
         prompt_ids = prompt_ids.unsqueeze(0).to(self.device)
+        target_len = int(reference_ids.numel()) if reference_ids is not None else 1
         generation_kwargs: dict[str, Any] = {}
         if generation_config is not None:
             if isinstance(generation_config, dict):
                 generation_kwargs.update(generation_config)
+            elif self._config_has_explicit_length(generation_config):
+                generation_kwargs["generation_config"] = generation_config
             else:
+                # Config object without an explicit user length: its default
+                # max_length (20) would silently cap generation.  Override with
+                # the per-example reference length via max_new_tokens on a
+                # copy — never mutate the shared config.
+                generation_config = copy.deepcopy(generation_config)
+                generation_config.max_new_tokens = target_len
                 generation_kwargs["generation_config"] = generation_config
 
         if (
             "max_length" not in generation_kwargs
             and "generation_config" not in generation_kwargs
         ):
-            target_len = int(reference_ids.numel()) if reference_ids is not None else 1
             generation_kwargs["max_length"] = prompt_ids.shape[1] + target_len
         if attention_mask is not None:
             generation_kwargs["attention_mask"] = attention_mask.unsqueeze(0).to(
                 self.device
             )
 
-        # Pin algorithm="mdlm" when no generation_config is supplied so the
-        # no-cache MDLM path (pre-unification default) is preserved and recorded
-        # DecodingConfigs stay accurate.  Callers that pass a generation_config
-        # object keep auto semantics — the config carries its own algorithm intent.
-        if "generation_config" not in generation_kwargs:
+        # Pin the decoding algorithm when the caller asks for one (e.g. the CLI
+        # pins "mdlm" for the configs it builds), or — as before — when no
+        # generation_config is supplied, so the no-cache MDLM path
+        # (pre-unification default) is preserved and recorded DecodingConfigs
+        # stay accurate.  Callers that pass a generation_config without an
+        # explicit algorithm keep auto semantics — the config carries its own
+        # algorithm intent.
+        if algorithm is not None:
+            generation_kwargs["algorithm"] = algorithm
+        elif "generation_config" not in generation_kwargs:
             generation_kwargs["algorithm"] = "mdlm"
         sequences = self.model.generate(prompt_ids, **generation_kwargs)
 
@@ -122,6 +158,7 @@ class GenerationEvaluator(BaseEvaluator):
         dataset: Any,
         generation_config: Any | None = None,
         max_examples: int | None = None,
+        algorithm: str | None = None,
     ) -> dict[str, float]:
         total_examples = 0
         exact_matches = 0
@@ -137,7 +174,11 @@ class GenerationEvaluator(BaseEvaluator):
                     self._extract_prompt_and_reference(example)
                 )
                 generated = self._generate_one(
-                    prompt_ids, generation_config, reference_ids, attention_mask
+                    prompt_ids,
+                    generation_config,
+                    reference_ids,
+                    attention_mask,
+                    algorithm=algorithm,
                 )
 
                 if reference_ids is None or reference_ids.numel() == 0:


### PR DESCRIPTION
Closes #41.

## What
- **Generation eval truncation (high)**: the CLI built `MaskedDiffusionGenerationConfig` with no lengths → default `max_length=20` total, collapsing metrics on real data. `GenerationEvaluator._generate_one` now detects configs without an explicit user length, deep-copies per example, and sets `max_new_tokens = reference_length` (shared config never mutated); `evaluate()` gained an optional `algorithm` param and the CLI pins `algorithm="mdlm"` as documented. New `--max-new-tokens` eval option for explicit control. Dict-config and no-config behaviors unchanged.
- **Scheduler plumbing (high)**: `train`/`eval` built `MaskedDiffusionDataCollator` explicitly, so `--alpha-scheduler cosine`/`time_epsilon` never reached forward-noising (silently linear). New shared `build_masked_diffusion_collator()` in `cli/config.py` mirrors `DiffusionTrainer`'s own collator wiring and is used by both commands.
- **Mask-id resolution (medium)**: resolution (CLI override → tokenizer → `model.config.mask_token_id`) is hoisted above both eval branches and passed into the collator, so `--eval-type diffusion --mask-token-id N` works on tokenizers without a mask token (documented real-checkpoint gotcha).

## Test plan
- [x] 7 new tests (reference-length override on a copy, explicit max_new_tokens passthrough, mdlm pin, dict-config unchanged; collator factory scheduler/mask-id wiring incl. model.config fallback)
- [x] `tests/test_cli_smoke.py tests/eval`: 80 passed; ruff clean