### PR TITLE
🐛 fix(generation): cached block-decode could commit the mask token itself (#47)

### DIFF
--- a/tests/models/test_llada.py
+++ b/tests/models/test_llada.py
@@ -978,6 +978,47 @@ class TestLLaDABlockDecode:
             output_with_cache[:, prompt_len:] == tiny_config.mask_token_id
         ), "Block-decode should produce no remaining mask tokens in generated region"
 
+    def test_block_decode_never_commits_mask_token(self, tiny_model, tiny_config):
+        """Sequential block-decode places zero mass on the mask token (MDLM SUBS).
+
+        A random tied-embedding model argmax-predicts its own input token, which
+        at masked positions is ``mask_token_id`` itself.  Without suppressing the
+        mask logit, the loop "commits" the mask sentinel, the block never
+        completes, and the output stays fully masked.  Greedy decoding makes this
+        deterministic regardless of RNG or init statistics.
+        """
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        B, prompt_len = 1, 6
+        max_new = 8
+        torch.manual_seed(0)
+        input_ids = torch.randint(0, tiny_config.vocab_size, (B, prompt_len))
+
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=max_new,
+            steps=4,
+            alg="origin",
+            mask_token_id=tiny_config.mask_token_id,
+            use_cache=True,
+            use_replace_cache=False,
+            block_length=4,
+            temperature=0.0,  # greedy: argmax would pick mask_token_id if unsuppressed
+        )
+
+        with torch.no_grad():
+            output = tiny_model.generate(
+                inputs=input_ids.clone(),
+                generation_config=gen_config,
+            )
+
+        assert output.shape == (B, prompt_len + max_new)
+        assert torch.equal(output[:, :prompt_len], input_ids)
+        assert not torch.any(output[:, prompt_len:] == tiny_config.mask_token_id), (
+            "Block-decode must never commit the mask token itself"
+        )
+
     def test_parallel_decode_trim_cache_runs(self, tiny_model, tiny_config):
         """LLaDA parallel_decode runs in trim-cache mode."""
         from unturtle.models.generation.diffusion_generation_utils import (

--- a/unturtle/models/generation/block_decode_mixin.py
+++ b/unturtle/models/generation/block_decode_mixin.py
@@ -281,10 +281,11 @@ class BlockDecodeMixin:
 
                 # Get masked positions' logits
                 mask_logits = block_logits[mask_index_block]  # [N_masked, vocab_size]
-                if (
-                    generation_config.parallel_decode
-                    and 0 <= mask_token_id < mask_logits.shape[-1]
-                ):
+                if 0 <= mask_token_id < mask_logits.shape[-1]:
+                    # Masked-diffusion denoising places zero mass on the mask token
+                    # (MDLM SUBS "zero masking probabilities"). Without this, a
+                    # committed token can be the mask sentinel itself, so the block
+                    # never completes and mask tokens leak into the returned output.
                     mask_logits = mask_logits.clone()
                     mask_logits[:, mask_token_id] = torch.finfo(mask_logits.dtype).min
                 _time_end(logits_slice_start, "logits_slice_s")

--- a/unturtle/models/generation/diffusion_generation_utils.py
+++ b/unturtle/models/generation/diffusion_generation_utils.py
@@ -1232,7 +1232,11 @@ class MaskedDiffusionGenerationMixin:
                 # Extract logits for current block
                 block_logits = logits[:, :block_length, :]  # [B, block_length, V]
                 mask_logits = block_logits[mask_index_block]  # [N_masked, V]
-                if parallel_decode and 0 <= mask_token_id < mask_logits.shape[-1]:
+                if 0 <= mask_token_id < mask_logits.shape[-1]:
+                    # Masked-diffusion denoising places zero mass on the mask token
+                    # (MDLM SUBS "zero masking probabilities"). Without this, a
+                    # committed token can be the mask sentinel itself, so the block
+                    # never completes and mask tokens leak into the returned output.
                     mask_logits = mask_logits.clone()
                     mask_logits[:, mask_token_id] = torch.finfo(mask_logits.dtype).min
 


### PR DESCRIPTION
Closes #47.

## Root cause
The block-decode loop was committing tokens all along — but the committed token was `mask_token_id` itself. Chain:

1. transformers 5.13's `post_init()` no longer calls `init_weights()`, so tiny random test models keep torch-default N(0,1) embeddings (measured wte std 0.9997 vs 0.02 with `_init_weights`). This env change flipped the test from pass to fail.
2. With `weight_tying=True`, an untied-init model becomes an input-token echo (`h·e_token ≈ ||e_token||² ≈ 48` dominates): at masked positions the input IS the mask token, so the denoiser predicts `mask_token_id` with p≈1.0 at any temperature.
3. The sequential ("origin") cache path applied mask-logit suppression **only when `parallel_decode`** — so the loop faithfully "unmasked" every position to the mask sentinel, blocks never completed, and the returned canvas stayed all-mask.

## Fix
Remove the `parallel_decode` gate — mask-token logit suppression is now unconditional in both cached block-decode loops (`block_decode_mixin.py` and the shared `MaskedDiffusionGenerationMixin._sample_with_cache`). This matches MDLM's SUBS parameterization ("zero masking probabilities": `logits[..., mask_index] = -inf`, kuleshov-group/mdlm) and the repo's own existing `parallel_decode` precedent. For trained models it is a behavioral no-op (the mask logit is never competitive); it guarantees the `generate()` contract that no mask sentinel appears in output. The no-cache `_sample` paths mirror ML-GSAI `generate.py` line-for-line (which does not suppress) and are untouched.

## Test plan
- [x] new regression `test_block_decode_never_commits_mask_token`: greedy `temperature=0.0` on the origin cache path — deterministically fails on old code regardless of RNG/init statistics (verified by swapping the old gate back in; the pre-existing failing test also fails on old code, passes with the fix)
- [x] full fast suite on GPU: **653 passed, 0 failed** (previously 1 pre-existing failure)
- [x] ruff check + format clean