### PR TITLE
🐛 fix(grpo): eval-clobber, non-PEFT KL, wd1 group guard, scale_rewards (#48/#49 follow-ups)

### DIFF
--- a/tests/diffusion/test_grpo_trainer.py
+++ b/tests/diffusion/test_grpo_trainer.py
@@ -579,7 +579,8 @@ def _make_buffering_trainer(steps_per_generation: int, num_iterations: int):
     return tr
 
 
-def test_prepare_inputs_slices_cached_logps_along_batch_dim_and_compute_loss_runs():
+@pytest.mark.parametrize("beta", [0.0, 0.04])
+def test_prepare_inputs_slices_cached_logps_along_batch_dim_and_compute_loss_runs(beta):
     """Bug regression: ``old/ref_per_token_logps`` are ``[num_iterations, B_gen, Lc]``.
 
     ``split_tensor_dict`` slices dim 0 (the iterations dim for these tensors), so
@@ -587,12 +588,19 @@ def test_prepare_inputs_slices_cached_logps_along_batch_dim_and_compute_loss_run
     Also checks ``compute_loss`` consumes each micro-batch with the correct GRPO
     iteration index (one advance per full pass over the buffer, not per micro-batch)
     and threads the buffer row window into ``_get_per_token_logps``.
+
+    ``beta=0.04`` additionally exercises the KL path over the sliced
+    ``ref_per_token_logps[this_itr_idx]``. Also regression for eval-rollout
+    clobbering: ``mask_seeds`` travel with the buffered inputs, so overwriting
+    the trainer attribute (as an eval rollout does) must not change the seeds
+    used by ``compute_loss``.
     """
     pytest.importorskip("trl")
     from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
 
     S, num_iterations, B_gen, Lc = 2, 2, 4, 4
     cs = B_gen // S  # micro-batch size
+    expected_seeds = [11, 22]
 
     # Distinctive per-(iteration, row) values so slices are checkable.
     full_old = (
@@ -601,14 +609,14 @@ def test_prepare_inputs_slices_cached_logps_along_batch_dim_and_compute_loss_run
         )
         * 1e-3
     )
-    full_ref = full_old + 100.0
+    full_ref = full_old + 0.5  # small offset: keeps exp(ref - logps) finite
 
     rollout_calls = 0
 
     def fake_generate_and_score(_inputs: object) -> dict:
         nonlocal rollout_calls
         rollout_calls += 1
-        tr._diffu_mask_seeds = [11, 22]
+        tr._diffu_mask_seeds = list(expected_seeds)
         return {
             "prompt_ids": torch.zeros(B_gen, 4, dtype=torch.long),
             "prompt_mask": torch.ones(B_gen, 4, dtype=torch.long),
@@ -617,9 +625,11 @@ def test_prepare_inputs_slices_cached_logps_along_batch_dim_and_compute_loss_run
             "old_per_token_logps": full_old.clone(),
             "ref_per_token_logps": full_ref.clone(),
             "advantages": torch.zeros(B_gen),
+            "mask_seeds": list(expected_seeds),
         }
 
     tr = _make_buffering_trainer(S, num_iterations)
+    tr.beta = beta
     tr._generate_and_score_completions = fake_generate_and_score  # type: ignore[method-assign]
 
     logps_calls: list[dict] = []
@@ -650,6 +660,11 @@ def test_prepare_inputs_slices_cached_logps_along_batch_dim_and_compute_loss_run
         micro_idx = t % S
         expected_itr = t // S
 
+        # Eval-rollout clobber simulation: an eval `_generate_and_score_completions`
+        # overwrites the trainer attribute mid-cycle. Buffered inputs must be immune.
+        tr._diffu_mask_seeds = [999, 998]
+        assert inputs["mask_seeds"] == expected_seeds
+
         # Cached log-probs: iterations preserved on dim 0, batch sliced on dim 1.
         for key, full in (
             ("old_per_token_logps", full_old),
@@ -667,9 +682,10 @@ def test_prepare_inputs_slices_cached_logps_along_batch_dim_and_compute_loss_run
         assert torch.isfinite(loss)
 
         # compute_loss must use the seed of the current GRPO iteration
-        # (advancing once per full pass over the buffer) and pass the window.
+        # (advancing once per full pass over the buffer) and pass the window —
+        # sourced from the buffered inputs, not the (clobbered) trainer attribute.
         call = logps_calls[-1]
-        assert call["seeds"] == [tr._diffu_mask_seeds[expected_itr]], f"micro-step {t}"
+        assert call["seeds"] == [expected_seeds[expected_itr]], f"micro-step {t}"
         assert call["total_rows"] == B_gen
         assert call["row_offset"] == micro_idx * cs
 
@@ -780,3 +796,231 @@ def test_trl_split_tensor_dict_empty_second_chunk_for_iteration_sized_list():
     chunks = split_tensor_dict(batch, num_chunks=2)
     assert chunks[0]["mask_seeds"] == [101, 202]
     assert chunks[1]["mask_seeds"] == []
+
+
+def test_wd1pp_buffered_chunks_survive_eval_rollout_clobber():
+    """wd1++: ``mask_seeds`` and the denoise trajectory travel with the buffered
+    chunks, so an eval rollout that resets/overwrites the trainer attributes
+    mid-generation-cycle must not affect train-time ``compute_loss``."""
+    pytest.importorskip("trl")
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    B_gen, S = 4, 2
+    xl = torch.cat(
+        [torch.zeros(2, 6, dtype=torch.long), torch.ones(2, 6, dtype=torch.long)], dim=0
+    )
+    traj = [(xl, xl.clone())]
+
+    def fake_generate_and_score(_inputs: object) -> dict:
+        tr._diffu_mask_seeds = [7]
+        tr._wd1pp_trajectory = traj
+        return {
+            "prompt_ids": torch.zeros(B_gen, 2, dtype=torch.long),
+            "completion_ids": torch.zeros(B_gen, 4, dtype=torch.long),
+            "completion_mask": torch.ones(B_gen, 4, dtype=torch.float),
+            "old_per_token_logps": [],
+            "ref_per_token_logps": [],
+            "advantages": torch.tensor([1.0, -1.0, 0.5, -0.5]),
+            "mask_seeds": [7],
+            "wd1pp_trajectory": traj,
+        }
+
+    tr = _make_buffering_trainer(steps_per_generation=S, num_iterations=1)
+    tr.args.diffu_policy_objective = "wd1++"
+    tr.args.wd1_psi = 1.0
+    tr._generate_and_score_completions = fake_generate_and_score  # type: ignore[method-assign]
+    tr._wd1pp_trajectory = None
+
+    seen: list[tuple[float, int]] = []
+
+    def _capture(_m, xl_s, _x0, _ltk, seed):
+        seen.append((float(xl_s[:, 0].float().mean().item()), int(seed)))
+        return torch.ones(xl_s.size(0))
+
+    tr._wd1pp_completion_logp_sum = _capture  # type: ignore[method-assign]
+
+    for _t in range(S):
+        inputs = DiffuGRPOTrainer._prepare_inputs(tr, {})
+        # Full (unsliced) per-rollout artifacts on every chunk.
+        assert inputs["mask_seeds"] == [7]
+        assert inputs["wd1pp_trajectory"] is traj
+        # Eval rollout lands mid-cycle: trainer attributes clobbered.
+        tr._diffu_mask_seeds = [999]
+        tr._wd1pp_trajectory = None
+        loss = DiffuGRPOTrainer.compute_loss(tr, nn.Identity(), inputs)
+        assert torch.isfinite(loss)
+
+    # Chunk 0 saw trajectory rows 0:2 (zeros), chunk 1 rows 2:4 (ones); both
+    # used the buffered seed 7, not the clobbered trainer attribute.
+    assert seen == [(0.0, 7), (1.0, 7)]
+
+
+# ---------------------------------------------------------------------------
+# Reference log-probs: PEFT adapter vs TRL ref_model (beta != 0)
+# ---------------------------------------------------------------------------
+
+
+def _make_ref_logps_trainer(model: nn.Module):
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    tr = DiffuGRPOTrainer.__new__(DiffuGRPOTrainer)
+    tr.model = model
+    tr.num_iterations = 1
+    tr.accelerator = SimpleNamespace(unwrap_model=lambda m: m)
+    calls: list[nn.Module] = []
+
+    def spy_get_per_token_logps(model_arg, input_ids, logits_to_keep, mask_seeds):
+        calls.append(model_arg)
+        n_it, b, _l = input_ids.shape
+        return torch.zeros(n_it, b, logits_to_keep)
+
+    tr._get_per_token_logps = spy_get_per_token_logps  # type: ignore[method-assign]
+    return tr, calls
+
+
+def test_compute_ref_logps_prefers_peft_disable_adapter():
+    """A policy with ``disable_adapter`` acts as its own reference (d1/TRL PEFT path)."""
+    pytest.importorskip("trl")
+    from contextlib import contextmanager
+
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    entered: list[bool] = []
+
+    class _PeftLike(nn.Module):
+        @contextmanager
+        def disable_adapter(self):
+            entered.append(True)
+            yield
+
+    model = _PeftLike()
+    tr, calls = _make_ref_logps_trainer(model)
+    tr.ref_model = None
+    ids = torch.zeros(2, 6, dtype=torch.long)
+    out = DiffuGRPOTrainer._compute_ref_per_token_logps(tr, ids, 4, [7])
+    assert out.shape == (1, 2, 4)
+    assert entered == [True]
+    assert calls == [model]
+
+
+def test_compute_ref_logps_uses_trl_ref_model_for_full_finetune():
+    """Regression (#48): full-finetune policy (no ``disable_adapter``) must use
+    TRL's ``self.ref_model`` instead of raising ``AttributeError``."""
+    pytest.importorskip("trl")
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    model = nn.Identity()
+    ref_model = nn.Identity()
+    tr, calls = _make_ref_logps_trainer(model)
+    tr.ref_model = ref_model
+    ids = torch.zeros(2, 6, dtype=torch.long)
+    out = DiffuGRPOTrainer._compute_ref_per_token_logps(tr, ids, 4, [7])
+    assert out.shape == (1, 2, 4)
+    assert len(calls) == 1
+    assert calls[0] is ref_model
+
+
+def test_compute_ref_logps_raises_without_adapter_or_ref_model():
+    pytest.importorskip("trl")
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    tr, calls = _make_ref_logps_trainer(nn.Identity())
+    tr.ref_model = None
+    ids = torch.zeros(2, 6, dtype=torch.long)
+    with pytest.raises(ValueError, match="reference policy"):
+        DiffuGRPOTrainer._compute_ref_per_token_logps(tr, ids, 4, [7])
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# wd1 / wd1++ group alignment guard (#48)
+# ---------------------------------------------------------------------------
+
+
+def test_wd1_compute_loss_rejects_partial_reward_groups():
+    """Micro-batch not divisible by ``num_generations`` must fail fast with an
+    actionable error (not a raw reshape error / silent partial-group softmax)."""
+    pytest.importorskip("trl")
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    tr = DiffuGRPOTrainer.__new__(DiffuGRPOTrainer)
+    tr.args = SimpleNamespace(
+        steps_per_generation=1, diffu_policy_objective="wd1", wd1_psi=1.0
+    )
+    tr.num_iterations = 1
+    tr.num_generations = 2
+    tr.beta = 0.0
+    tr._step = 1
+    tr._diffu_mask_seeds = [3]
+    tr.control = SimpleNamespace(should_evaluate=False)
+    tr._metrics = {"train": {"kl": [], "clip_ratio": []}}
+    tr.accelerator = SimpleNamespace(gather_for_metrics=lambda x: x)
+
+    inputs = {
+        "prompt_ids": torch.zeros(3, 2, dtype=torch.long),
+        "completion_ids": torch.zeros(3, 4, dtype=torch.long),
+        "completion_mask": torch.ones(3, 4, dtype=torch.float),
+        "advantages": torch.tensor([1.0, -1.0, 0.5]),  # 3 % num_generations != 0
+    }
+    with pytest.raises(ValueError, match="whole reward groups"):
+        DiffuGRPOTrainer.compute_loss(tr, nn.Identity(), inputs)
+
+
+# ---------------------------------------------------------------------------
+# Advantage scaling (TRL scale_rewards semantics, #48)
+# ---------------------------------------------------------------------------
+
+
+def _make_advantage_trainer(scale_rewards):
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    tr = DiffuGRPOTrainer.__new__(DiffuGRPOTrainer)
+    tr.num_generations = 2
+    tr.args = SimpleNamespace(scale_rewards=scale_rewards)
+    return tr
+
+
+class TestComputeGroupAdvantages:
+    rewards = torch.tensor([1.0, 3.0, 2.0, 2.0])
+
+    def test_none_is_d1_mean_centering_only(self):
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        tr = _make_advantage_trainer("none")
+        adv, std = DiffuGRPOTrainer._compute_group_advantages(tr, self.rewards)
+        assert torch.allclose(adv, torch.tensor([-1.0, 1.0, 0.0, 0.0]))
+        # std still computed for logging (group std)
+        assert torch.allclose(std, torch.tensor([2.0, 2.0, 0.0, 0.0]).sqrt())
+
+    def test_false_maps_to_none(self):
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        tr = _make_advantage_trainer(False)
+        adv, _ = DiffuGRPOTrainer._compute_group_advantages(tr, self.rewards)
+        assert torch.allclose(adv, torch.tensor([-1.0, 1.0, 0.0, 0.0]))
+
+    def test_group_scaling_divides_by_group_std(self):
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        tr = _make_advantage_trainer("group")
+        adv, std = DiffuGRPOTrainer._compute_group_advantages(tr, self.rewards)
+        g_std = torch.tensor([2.0]).sqrt().item()
+        expected = torch.tensor([-1.0 / (g_std + 1e-4), 1.0 / (g_std + 1e-4), 0.0, 0.0])
+        assert torch.allclose(adv, expected)
+
+    def test_batch_scaling_divides_by_batch_std(self):
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        tr = _make_advantage_trainer("batch")
+        adv, std = DiffuGRPOTrainer._compute_group_advantages(tr, self.rewards)
+        b_std = self.rewards.std().item()
+        expected = torch.tensor([-1.0, 1.0, 0.0, 0.0]) / (b_std + 1e-4)
+        assert torch.allclose(adv, expected)
+        assert torch.allclose(std, torch.full((4,), b_std))
+
+    def test_invalid_value_rejected(self):
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        tr = _make_advantage_trainer("bogus")
+        with pytest.raises(ValueError, match="scale_rewards"):
+            DiffuGRPOTrainer._compute_group_advantages(tr, self.rewards)

--- a/unturtle/diffusion/grpo_trainer.py
+++ b/unturtle/diffusion/grpo_trainer.py
@@ -326,6 +326,13 @@ class DiffuGRPOTrainer(GRPOTrainer):
                 # micro-batch below. They are ``[]`` when unused.
                 old_logps = generation_batch.pop("old_per_token_logps", [])
                 ref_logps = generation_batch.pop("ref_per_token_logps", [])
+                # Per-rollout artifacts that must NOT go through ``split_tensor_dict``
+                # (it slices list values along the batch dim, emptying them for later
+                # chunks). Attach the full objects to every buffered chunk instead, so
+                # an eval rollout landing mid-cycle cannot clobber them on the trainer
+                # (see d1, which stores ``mask_seeds`` in the inputs dict).
+                rollout_mask_seeds = generation_batch.pop("mask_seeds", None)
+                rollout_wd1pp_traj = generation_batch.pop("wd1pp_trajectory", None)
                 total_rows = generation_batch["prompt_ids"].shape[0]
                 chunk_size = total_rows // self.args.steps_per_generation
                 generation_batch = split_pixel_values_by_grid(generation_batch)
@@ -351,6 +358,10 @@ class DiffuGRPOTrainer(GRPOTrainer):
                     # ``torch.rand((B_gen, L))`` draw (see ``_forward_process``).
                     batch["buffer_row_offset"] = row_offset
                     batch["buffer_total_rows"] = total_rows
+                    if rollout_mask_seeds is not None:
+                        batch["mask_seeds"] = rollout_mask_seeds
+                    if rollout_wd1pp_traj is not None:
+                        batch["wd1pp_trajectory"] = rollout_wd1pp_traj
                     buffered.append(batch)
                 self._buffered_inputs = buffered
             inputs = self._buffered_inputs[self._step % self.args.steps_per_generation]
@@ -780,6 +791,24 @@ class DiffuGRPOTrainer(GRPOTrainer):
         w_minus = torch.softmax(-psi * adv, dim=-1)
         return (w_minus - w_plus).reshape(-1)
 
+    def _validate_wd1_group_alignment(self, advantages: torch.Tensor) -> None:
+        """wd1/wd1++ group softmax needs whole reward groups per micro-batch.
+
+        After ``steps_per_generation`` micro-batch splitting, a chunk that does not
+        contain a multiple of ``num_generations`` rows would either fail the raw
+        reshape in :meth:`_wd1_completion_coef` or silently softmax over partial /
+        straddled groups. Fail fast with an actionable message instead.
+        """
+        g = self.num_generations
+        if advantages.numel() % g != 0:
+            raise ValueError(
+                "wd1/wd1++ objectives require each micro-batch to contain whole "
+                f"reward groups: got {advantages.numel()} completions with "
+                f"num_generations={g}. Configure generation_batch_size / "
+                "steps_per_generation so that (rollout batch // steps_per_generation) "
+                "is divisible by num_generations."
+            )
+
     # ------------------------------------------------------------------
     # Loss computation
     # ------------------------------------------------------------------
@@ -837,16 +866,24 @@ class DiffuGRPOTrainer(GRPOTrainer):
         # ``_prepare_inputs``); ``None`` when inputs were not buffered/split.
         buffer_total_rows = inputs.get("buffer_total_rows")
         buffer_row_offset = inputs.get("buffer_row_offset", 0)
+        # Mask seeds travel with the inputs (buffered chunk or eval dict) so an eval
+        # rollout landing mid-generation-cycle cannot clobber them (d1 pattern);
+        # fall back to the trainer attribute for back-compat.
+        seeds = inputs.get("mask_seeds") or self._diffu_mask_seeds
+
+        if objective in ("wd1", "wd1++"):
+            self._validate_wd1_group_alignment(advantages)
 
         if objective == "wd1++":
             logits_to_keep = completion_ids.size(1)
-            seeds = self._diffu_mask_seeds
             if not seeds or this_itr_idx >= len(seeds):
                 raise RuntimeError(
                     "DiffuGRPOTrainer: missing mask seeds for this step — internal buffering error."
                 )
             this_seed = seeds[this_itr_idx]
-            traj = self._wd1pp_trajectory
+            # Same clobber-protection as ``mask_seeds``: prefer the trajectory
+            # reference captured at buffering time.
+            traj = inputs.get("wd1pp_trajectory") or self._wd1pp_trajectory
             if not traj:
                 raise RuntimeError(
                     "DiffuGRPOTrainer: wd1++ missing denoise trajectory — internal rollout error."
@@ -904,7 +941,6 @@ class DiffuGRPOTrainer(GRPOTrainer):
         input_ids = torch.cat([prompt_ids, completion_ids], dim=1)
         logits_to_keep = completion_ids.size(1)
 
-        seeds = self._diffu_mask_seeds
         if not seeds or this_itr_idx >= len(seeds):
             raise RuntimeError(
                 "DiffuGRPOTrainer: missing mask seeds for this step — internal buffering error."
@@ -1000,6 +1036,76 @@ class DiffuGRPOTrainer(GRPOTrainer):
     # ------------------------------------------------------------------
     # Rollout generation and scoring
     # ------------------------------------------------------------------
+
+    def _compute_ref_per_token_logps(
+        self,
+        prompt_completion_ids: torch.Tensor,
+        logits_to_keep: int,
+        mask_seeds: list[int],
+    ) -> torch.Tensor:
+        """Reference-policy log-probs for the KL term (``beta != 0``).
+
+        Mirrors TRL 0.24 ``GRPOTrainer``: a PEFT policy disables its adapter to
+        act as its own reference (d1's assumption); otherwise TRL's
+        ``self.ref_model`` — constructed in ``GRPOTrainer.__init__`` for non-PEFT
+        policies when ``beta != 0`` — is used. Raises a clear error when neither
+        is available instead of an ``AttributeError`` on ``disable_adapter``.
+        """
+        ids_expanded = prompt_completion_ids.unsqueeze(0).expand(
+            self.num_iterations, -1, -1
+        )
+        unwrapped = self.accelerator.unwrap_model(self.model)
+        if hasattr(unwrapped, "disable_adapter"):
+            with unwrapped.disable_adapter():
+                return self._get_per_token_logps(
+                    self.model, ids_expanded, logits_to_keep, mask_seeds
+                )
+        if getattr(self, "ref_model", None) is not None:
+            return self._get_per_token_logps(
+                self.ref_model, ids_expanded, logits_to_keep, mask_seeds
+            )
+        raise ValueError(
+            "DiffuGRPOTrainer: beta != 0 requires a reference policy — either a "
+            "PEFT adapter on the policy model (so it can be disabled to act as the "
+            "reference) or a TRL-constructed `ref_model`. Neither is available; "
+            "pass a peft_config or set beta=0."
+        )
+
+    def _compute_group_advantages(
+        self, rewards: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Group-relative advantages with TRL 0.24 ``scale_rewards`` semantics.
+
+        d1 mean-centers only; TRL additionally divides by ``std + 1e-4`` unless
+        ``scale_rewards`` resolves to ``"none"`` (``"group"`` is TRL's default;
+        ``"batch"`` uses the whole-batch std). Pass ``scale_rewards=False`` /
+        ``"none"`` for d1-style mean-only advantages.
+
+        Returns:
+            ``(advantages, std_rewards)`` — both flat ``[B]``; ``std_rewards`` is
+            the tensor used for scaling and for the std metrics.
+        """
+        g = self.num_generations
+        mean_rewards = rewards.view(-1, g).mean(dim=1).repeat_interleave(g)
+        advantages = rewards - mean_rewards
+        scale = getattr(
+            self, "scale_rewards", getattr(self.args, "scale_rewards", "group")
+        )
+        # GRPOConfig.__post_init__ already coerces bools; keep the mapping for
+        # bare instances constructed without TRL's __init__.
+        scale = {True: "group", False: "none"}.get(scale, scale)
+        if scale in ("group", "none"):
+            std_rewards = rewards.view(-1, g).std(dim=1).repeat_interleave(g)
+        elif scale == "batch":
+            std_rewards = rewards.std().expand_as(rewards)
+        else:
+            raise ValueError(
+                f"Invalid scale_rewards value: {scale!r}. "
+                "Must be 'group', 'batch', or 'none'."
+            )
+        if scale != "none":
+            advantages = advantages / (std_rewards + 1e-4)
+        return advantages, std_rewards
 
     def _generate_and_score_completions(
         self,
@@ -1153,13 +1259,9 @@ class DiffuGRPOTrainer(GRPOTrainer):
                 )
 
             if self.beta != 0.0:
-                with self.accelerator.unwrap_model(self.model).disable_adapter():
-                    ids_expanded = prompt_completion_ids.unsqueeze(0).expand(
-                        self.num_iterations, -1, -1
-                    )
-                    all_ref_logps = self._get_per_token_logps(
-                        self.model, ids_expanded, logits_to_keep, mask_seeds
-                    )
+                all_ref_logps = self._compute_ref_per_token_logps(
+                    prompt_completion_ids, logits_to_keep, mask_seeds
+                )
 
         # Decode and score completions
         completions_text = self.processing_class.batch_decode(
@@ -1205,12 +1307,8 @@ class DiffuGRPOTrainer(GRPOTrainer):
             rewards_per_func * self.reward_weights.to(device).unsqueeze(0)
         ).nansum(dim=1)
 
-        # Advantage normalisation (group-relative)
-        mean_rewards = rewards.view(-1, self.num_generations).mean(dim=1)
-        std_rewards = rewards.view(-1, self.num_generations).std(dim=1)
-        mean_rewards = mean_rewards.repeat_interleave(self.num_generations)
-        std_rewards = std_rewards.repeat_interleave(self.num_generations)
-        advantages = rewards - mean_rewards
+        # Advantage normalisation (group-relative, TRL scale_rewards semantics)
+        advantages, std_rewards = self._compute_group_advantages(rewards)
 
         process_slice = slice(
             self.accelerator.process_index * len(prompts),
@@ -1287,7 +1385,7 @@ class DiffuGRPOTrainer(GRPOTrainer):
                 except ImportError:
                     pass
 
-        return {
+        out = {
             "prompt_ids": prompt_ids,
             "prompt_mask": prompt_mask,
             "completion_ids": completion_ids,
@@ -1295,4 +1393,10 @@ class DiffuGRPOTrainer(GRPOTrainer):
             "old_per_token_logps": all_old_logps,
             "ref_per_token_logps": all_ref_logps,
             "advantages": advantages,
+            # Travels with the inputs (d1 pattern); ``_prepare_inputs`` pops it
+            # before ``split_tensor_dict`` and re-attaches the full list per chunk.
+            "mask_seeds": mask_seeds,
         }
+        if use_wd1pp:
+            out["wd1pp_trajectory"] = self._wd1pp_trajectory
+        return out


### PR DESCRIPTION
Refs #48, #49.

## What
- **Eval-rollout clobbering**: `mask_seeds` and the wd1++ trajectory now travel inside the buffered per-micro-batch inputs (d1-aligned — d1 stores mask_seeds in the inputs dict), so an eval rollout mid-generation-cycle can no longer silently re-mask remaining train micro-batches with eval seeds or crash wd1++.
- **beta≠0 without PEFT**: new `_compute_ref_per_token_logps` — PEFT `disable_adapter()` → TRL's `ref_model` (TRL 0.24 creates it exactly for this case) → clear `ValueError`. Previously full-finetune + KL crashed with AttributeError.
- **wd1/wd1++ group alignment**: first-use validation raising an actionable error when micro-batches don't contain whole reward groups (previously raw reshape error or silent partial-group softmax).
- **`scale_rewards` implemented (⚠️ default behavior change)**: advantages were previously mean-centered only while the `DiffuGRPOConfig` docstring already promised TRL semantics. Now `"group"` (TRL default) / `"batch"` / `"none"` are implemented, verified numerically against TRL 0.24. **Users training with defaults silently get group-std-scaled advantages after this merge**; pass `scale_rewards="none"` (or `False`) for the previous d1-style mean-centering. Docs and code now agree.

## Review
Reference-aligned review (d1 + TRL 0.24 sources): all MERGE-READY; scale_rewards math verified `allclose` against TRL's exact expressions; clobber fix verified to survive simulated eval rollouts; no regression on the #45 buffering fixes (tests extended with beta>0).

## Test plan
- [x] tests/diffusion/test_grpo_trainer.py: 35 passed (11 new/extended)
- [x] tests/diffusion/: all green; ruff clean