### PR TITLE
🐛 fix(dream): patched-model cached decode, labels loss guard, pad_token_id None crash (#48/#49 follow-ups)

### DIFF
--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -83,7 +83,7 @@ class TestDreamModel:
         assert out.logits.shape == (B, L, config.vocab_size)
 
     def test_forward_backward(self, config):
-        """Gradients flow through Dream."""
+        """Gradients flow through Dream (unshifted masked CE computed externally)."""
         from unturtle.models.backbones.dream import DreamModel
 
         model = DreamModel(config).cpu()
@@ -91,12 +91,27 @@ class TestDreamModel:
         input_ids = torch.randint(0, config.vocab_size, (B, L))
         labels = torch.randint(0, config.vocab_size, (B, L))
         labels[:, ::2] = -100
-        out = model(input_ids=input_ids, labels=labels)
-        assert out.loss is not None
-        assert not torch.isnan(out.loss)
-        out.loss.backward()
+        out = model(input_ids=input_ids)
+        loss = torch.nn.functional.cross_entropy(
+            out.logits.view(-1, config.vocab_size), labels.view(-1), ignore_index=-100
+        )
+        assert not torch.isnan(loss)
+        loss.backward()
         grads = [p.grad for p in model.parameters() if p.grad is not None]
         assert len(grads) > 0
+
+    def test_forward_labels_raises(self, config):
+        """DreamModel refuses `labels`: the inherited transformers fallback is a
+        shifted causal-LM loss, which is wrong for masked diffusion. Use
+        DiffusionTrainer (or an external unshifted masked CE) instead."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu()
+        B, L = 2, 8
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        labels = torch.randint(0, config.vocab_size, (B, L))
+        with pytest.raises(NotImplementedError, match="DiffusionTrainer"):
+            model(input_ids=input_ids, labels=labels)
 
     def test_gradient_checkpointing_forward_backward(self, config):
         """Training-mode forward+backward with gradient checkpointing must not raise.
@@ -113,12 +128,48 @@ class TestDreamModel:
         input_ids = torch.randint(0, config.vocab_size, (B, L))
         labels = torch.randint(0, config.vocab_size, (B, L))
         labels[:, ::2] = -100
-        out = model(input_ids=input_ids, labels=labels)
-        assert out.loss is not None
-        assert not torch.isnan(out.loss)
-        out.loss.backward()
+        out = model(input_ids=input_ids)
+        loss = torch.nn.functional.cross_entropy(
+            out.logits.view(-1, config.vocab_size), labels.view(-1), ignore_index=-100
+        )
+        assert not torch.isnan(loss)
+        loss.backward()
         grads = [p.grad for p in model.parameters() if p.grad is not None]
         assert len(grads) > 0
+
+    def test_gradient_checkpointing_dual_cache_raises(self, config):
+        """dual_cache is inference-only; combined with training-mode gradient
+        checkpointing it used to be silently dropped — now it must raise."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        model = DreamModel(config).cpu()
+        model.gradient_checkpointing_enable()
+        model.train()
+        input_ids = torch.randint(0, config.vocab_size, (2, 8))
+        with pytest.raises(ValueError, match="dual_cache"):
+            model(input_ids=input_ids, dual_cache=True)
+
+    def test_gradient_checkpointing_matches_plain_forward_with_padding_mask(
+        self, config
+    ):
+        """Checkpointed forward under a 2-D padding mask matches the plain path."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu()
+        model.train()
+        B, L = 2, 8
+        input_ids = torch.randint(2, config.vocab_size, (B, L))
+        attention_mask = torch.ones(B, L, dtype=torch.long)
+        attention_mask[0, -3:] = 0
+        plain = model(
+            input_ids=input_ids, attention_mask=attention_mask
+        ).logits.detach()
+        model.gradient_checkpointing_enable()
+        checkpointed = model(
+            input_ids=input_ids, attention_mask=attention_mask
+        ).logits.detach()
+        assert torch.allclose(plain, checkpointed, atol=1e-6)
 
     def test_gradient_checkpointing_matches_plain_forward(self, config):
         """Checkpointed forward must be numerically identical to the plain path."""
@@ -455,6 +506,30 @@ class TestDreamGenerationUtils:
         assert out.shape == (2, 8)
         assert not torch.any(out == config.mask_token_id)
 
+    def test_generate_without_pad_token_id(self, config):
+        """Regression (#48): `generate` must not crash when pad_token_id is None.
+
+        The padding-detection check used to evaluate
+        ``torch.any(input_ids == None)`` -> TypeError. The original Dream guard
+        only runs the check when a pad token is actually set.
+        """
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=None,
+            eos_token_id=None,
+        )
+        with torch.no_grad():
+            out = model.generate(inputs=inputs, generation_config=generation_config)
+        assert out.shape == (1, 8)
+        assert not torch.any(out == config.mask_token_id)
+
     def test_dream_generate_accepts_algorithm(self, config):
         from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
 
@@ -508,6 +583,27 @@ class TestDreamFastRoPE:
             pad_token_id=0,
             mask_token_id=1,
         )
+
+    @staticmethod
+    def _install_fast_forward(model):
+        """Install apply_qkv/apply_o stubs and the fast attention forward on
+        every layer (CPU-safe simulation of what _patch_dream_peft injects)."""
+        import types
+
+        from unturtle.fast_diffusion_model import (
+            _original_apply_o,
+            _original_apply_qkv,
+        )
+        from unturtle.models.backbones.dream.modeling_dream import (
+            DreamAttention_fast_forward,
+        )
+
+        for layer in model.model.layers:
+            attn = layer.self_attn
+            if not hasattr(attn, "apply_qkv"):
+                attn.apply_qkv = _original_apply_qkv
+                attn.apply_o = _original_apply_o
+            attn.forward = types.MethodType(DreamAttention_fast_forward, attn)
 
     def test_fast_forward_importable(self):
         from unturtle.models.backbones.dream.modeling_dream import (
@@ -888,6 +984,67 @@ class TestDreamFastRoPE:
             out = model(input_ids=input_ids)
         assert out.logits.shape == (B, L, config.vocab_size)
         assert not torch.isnan(out.logits).any()
+
+    def test_fast_forward_bool_padding_keep_mask(self, config):
+        """Fast forward masks padding via the shared bool [B,1,L,L] keep-mask
+        path (_apply_eager_attention_mask). Non-pad positions must match an
+        unpadded run and differ from an unmasked padded run."""
+        from unturtle.models.backbones.dream import DreamModel
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+        self._install_fast_forward(model)
+
+        L_real, L_pad = 6, 8
+        real_ids = torch.randint(2, config.vocab_size, (1, L_real))
+        padded_ids = torch.full((1, L_pad), config.pad_token_id, dtype=torch.long)
+        padded_ids[:, :L_real] = real_ids
+        attention_mask = torch.zeros(1, L_pad, dtype=torch.long)
+        attention_mask[:, :L_real] = 1
+
+        with torch.no_grad():
+            ref = model(input_ids=real_ids).logits
+            masked = model(input_ids=padded_ids, attention_mask=attention_mask).logits
+            unmasked = model(input_ids=padded_ids).logits
+
+        assert torch.allclose(ref, masked[:, :L_real], atol=1e-5), (
+            f"max_diff={(ref - masked[:, :L_real]).abs().max().item():.2e}"
+        )
+        assert not torch.allclose(ref, unmasked[:, :L_real], atol=1e-5)
+
+    @pytest.mark.parametrize("use_replace_cache", [False, True])
+    def test_patched_model_cached_generate(self, config, use_replace_cache):
+        """Regression (#48): the fast forward used to raise TypeError on Dream's
+        tuple caches, so generate(use_cache=True) crashed on a patched model.
+        It now delegates to the standard attention forward, so cached block
+        decode works and matches the unpatched model exactly."""
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=4,
+            steps=4,
+            block_length=2,
+            use_cache=True,
+            use_replace_cache=use_replace_cache,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        inputs = torch.tensor([[2, 3, 4, 5]])
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+
+        torch.manual_seed(42)
+        with torch.no_grad():
+            ref = model.generate(inputs=inputs, generation_config=generation_config)
+
+        self._install_fast_forward(model)
+        torch.manual_seed(42)
+        with torch.no_grad():
+            patched = model.generate(inputs=inputs, generation_config=generation_config)
+
+        assert torch.equal(ref, patched)
+        assert not torch.any(patched == config.mask_token_id)
 
 
 class TestDreamSavePretrained:

--- a/unturtle/models/backbones/dream/generation_utils.py
+++ b/unturtle/models/backbones/dream/generation_utils.py
@@ -436,7 +436,7 @@ class DreamGenerationMixin(BlockDecodeMixin):
                 UserWarning,
             )
         if (
-            hasattr(generation_config, "pad_token_id")
+            getattr(generation_config, "pad_token_id", None) is not None
             and torch.any(input_ids == generation_config.pad_token_id)
             and attention_mask is None
         ):

--- a/unturtle/models/backbones/dream/modeling_dream.py
+++ b/unturtle/models/backbones/dream/modeling_dream.py
@@ -893,8 +893,15 @@ class DreamBaseModel(DreamPreTrainedModel):
             )
             use_cache = False
 
-        if inputs_embeds is None:
-            inputs_embeds = self.embed_tokens(input_ids)
+        if self.gradient_checkpointing and self.training and dual_cache:
+            # dual_cache / replace_position are inference-only kwargs; the
+            # checkpointed layer call cannot forward them (DreamDecoderLayer
+            # accepts only 8 positionals), so fail loudly instead of silently
+            # dropping the cache-replacement semantics.
+            raise ValueError(
+                "dual_cache=True is inference-only and cannot be combined with "
+                "gradient checkpointing during training."
+            )
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
@@ -1128,7 +1135,21 @@ class DreamModel(DreamGenerationMixin, DreamPreTrainedModel):
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits, labels, self.vocab_size, **loss_kwargs)
+            # The original Dream reference (dev/repos/dllm/dllm/pipelines/dream/
+            # models/modeling_dream.py) inherits transformers' fallback
+            # ForCausalLMLoss here, which SHIFTS labels — a causal-LM objective
+            # that is incorrect for Dream's masked-diffusion semantics (loss on
+            # masked positions, unshifted; the Dream shift operation is applied
+            # to logits by the trainer, not by shifting labels). Rather than
+            # silently computing a wrong loss, refuse `labels`.
+            raise NotImplementedError(
+                "DreamModel.forward does not compute a loss from `labels`: the "
+                "inherited transformers loss is a shifted causal-LM loss, which is "
+                "wrong for masked diffusion. Train Dream with "
+                "unturtle.diffusion.DiffusionTrainer (it supplies the "
+                "masked-diffusion objective from the logits), or compute a masked "
+                "cross-entropy from `outputs.logits` yourself."
+            )
 
         if not return_dict:
             output = (logits,) + outputs[1:]
@@ -1208,7 +1229,32 @@ def DreamAttention_fast_forward(
     The rest of the forward pass is unchanged.
 
     Injected by ``FastDiffusionModel._patch_dream_peft`` when the model is on CUDA.
+
+    Cache-enabled block decode (Dream's tuple KV caches, ``dual_cache`` /
+    ``replace_position``) is not implemented by this fast path; those calls are
+    delegated to the standard (unpatched) attention forward.  Patching is done
+    at instance level (``self_attn.forward = MethodType(...)``), so
+    ``type(self).forward`` is always the original class implementation.
     """
+    dual_cache = kwargs.get("dual_cache", False)
+    replace_position = kwargs.get("replace_position")
+    if use_cache or past_key_value is not None or dual_cache:
+        # Delegate cached generation to the standard Dream attention forward,
+        # which owns tuple-cache concat / dual-cache replace semantics.
+        return type(self).forward(
+            self,
+            hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            replace_position=replace_position,
+            dual_cache=dual_cache,
+        )
+
     bsz, q_len, _ = hidden_states.size()
 
     query_states, key_states, value_states = self.apply_qkv(self, hidden_states)
@@ -1231,17 +1277,6 @@ def DreamAttention_fast_forward(
     query_states, key_states = _apply_dream_rope(
         query_states, key_states, cos, sin, bsz, q_len
     )
-
-    if past_key_value is not None:
-        if not hasattr(past_key_value, "update"):
-            raise TypeError(
-                "DreamAttention_fast_forward expects a cache object with update(); tuple-based block-decode caches "
-                "should use the standard Dream attention path."
-            )
-        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-        key_states, value_states = past_key_value.update(
-            key_states, value_states, self.layer_idx, cache_kwargs
-        )
 
     key_states = repeat_kv(key_states, self.num_key_value_groups)
     value_states = repeat_kv(value_states, self.num_key_value_groups)


### PR DESCRIPTION
Refs #48, #49.

## What
- **Cache-enabled block decode on CUDA/PEFT-patched models**: `DreamAttention_fast_forward` no longer raises on tuple caches — it delegates cached forwards to the original class implementation (`type(self).forward`; patching is instance-level `MethodType`, so no recursion), forwarding `dual_cache`/`replace_position` instead of swallowing them. Previously `generate(use_cache=True)` on a patched Dream always crashed.
- **`forward(labels=...)`**: raises `NotImplementedError` pointing to `DiffusionTrainer` — the inherited transformers fallback was a *shifted causal-LM* loss, silently wrong for masked diffusion (the original Dream reference carries the same latent bug; Dream's shift is applied to logits by the trainer).
- **`generate` with `pad_token_id=None`**: guard fixes `torch.any(input_ids == None)` TypeError.
- **Cleanups (#49)**: duplicate `inputs_embeds` block removed; `dual_cache=True` + gradient-checkpointing-training now raises instead of silently dropping.

## Review + GPU verification
Reference-checked against the vendored original Dream (dev/repos/dllm) and Fast-dLLM fork. GPU0: real `get_peft_model`-patched CUDA Dream — cached generate (trim + dual-cache) now runs and is bit-exact vs the unpatched model; Triton fast path unchanged for non-cache forwards.

## Test plan
- [x] tests/models/test_dream.py: 44 passed (8 new); tests/test_fast_diffusion_model.py green; ruff clean