### PR TITLE
🐛 fix(generation): cached decode honors alg, Dream trim first-token, BD3LM pad-row NaN guard (#48/#49 follow-ups)

### DIFF
--- a/tests/models/test_generation_followups.py
+++ b/tests/models/test_generation_followups.py
@@ -1,0 +1,557 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regressions for generation follow-ups (#48/#49).
+
+Covers:
+1. BlockDecodeMixin non-parallel cache path honors ``alg`` via
+   confidence-ordered transfer (was: always origin-style random Bernoulli).
+2. Dream trim-mode block decode forwards from the model's query start
+   (``current_block_start - 1``) so right-shifted logits predict the block's
+   first token, matching the dual-cache path.
+3. ``alg='entropy'`` + threshold-based ``parallel_decode`` warns about
+   degeneration (neg-entropy confidences <= 0 never reach a [0, 1] threshold).
+4. BD3LM capability probes are explicit (signature-based) — genuine forward
+   errors propagate instead of silently switching the numerics path.
+5. ``prepare_for_sampling`` pad query rows are numerically safe (no all-False
+   attention rows -> NaN softmax hazard).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from unturtle.models.generation.block_decode_mixin import BlockDecodeMixin
+from unturtle.models.generation.diffusion_generation_utils import (
+    MaskedDiffusionGenerationConfig,
+    MaskedDiffusionGenerationMixin,
+    prepare_for_sampling,
+)
+from unturtle.models.generation.masked_diffusion_block_mixin import (
+    MaskedDiffusionBlockGenerationMixin,
+    _forward_accepts_kwargs,
+)
+
+
+class _ScriptedBlockDecodeModel(BlockDecodeMixin):
+    """Deterministic fake model for BlockDecodeMixin loop tests.
+
+    Forwards are suffix windows of an 8-token canvas.  Logits are sharply
+    peaked (high max-prob confidence) at absolute position ``sharp_pos`` and
+    nearly flat elsewhere, and the favored token id changes on every forward
+    call, so the final sequence records *which call* committed each position.
+    """
+
+    VOCAB = 16
+    MASK_ID = 15
+    MAX_LEN = 8
+
+    def __init__(self, sharp_pos: int = 6):
+        self.config = SimpleNamespace(mask_token_id=self.MASK_ID)
+        self.sharp_pos = sharp_pos
+        self.calls = 0
+
+    def _model_forward_with_cache(
+        self,
+        input_ids,
+        attention_mask,
+        past_key_values,
+        use_cache,
+        replace_position=None,
+    ):
+        B, L = input_ids.shape
+        favored = 2 + self.calls  # call 0 -> 2, call 1 -> 3, ...
+        self.calls += 1
+        logits = torch.zeros(B, L, self.VOCAB)
+        for i in range(L):
+            abs_pos = self.MAX_LEN - L + i  # suffix window -> absolute position
+            logits[:, i, favored] = 10.0 if abs_pos == self.sharp_pos else 1.0
+        cache = ((torch.zeros(B, 1, L, 1), torch.zeros(B, 1, L, 1)),)
+        return SimpleNamespace(logits=logits, past_key_values=cache)
+
+
+class TestBlockDecodeConfidenceOrderedTransfer:
+    """#48 item 1: non-parallel cache path must honor ``alg`` by selecting the
+    per-step transfer set via top confidence (Fast-dLLM non-threshold ordering,
+    dev/repos/fast-dllm/v1/dream/model/generation_utils_block.py L526-559, and
+    the repo's own no-cache ``_sample`` non-origin branch), keeping the
+    schedule-driven per-step counts."""
+
+    def _run(self, alg: str) -> torch.Tensor:
+        model = _ScriptedBlockDecodeModel(sharp_pos=6)
+        cfg = MaskedDiffusionGenerationConfig(
+            max_length=8,
+            steps=2,
+            alg=alg,
+            mask_token_id=model.MASK_ID,
+            use_cache=True,
+            use_replace_cache=False,
+            block_length=4,
+            temperature=0.0,
+        )
+        torch.manual_seed(0)
+        input_ids = torch.full((1, 4), 9, dtype=torch.long)
+        out = model._block_decode_loop(
+            input_ids=input_ids, attention_mask=None, generation_config=cfg
+        )
+        assert out.shape == (1, 8)
+        return out[0, 4:]
+
+    def test_maskgit_plus_transfers_top_confidence_first(self):
+        # Single block of 4, steps_per_block=2: step 0 transfers
+        # int(4 * (1 - s/t)) = 1 token; forward calls are:
+        #   call 0 = initial cache build, call 1 = step 0, call 2 = step 1.
+        # Confidence ordering must commit the sharp position (abs 6) at step 0
+        # (token 3) and the remaining three positions at the final step
+        # (token 4).  The old code picked a random Bernoulli subset and
+        # discarded the confidences entirely.
+        gen = self._run("maskgit_plus")
+        assert gen.tolist() == [4, 4, 3, 4], (
+            f"expected the top-confidence position (abs 6) to be committed at "
+            f"step 0 and the rest at the final step, got {gen.tolist()}"
+        )
+
+    def test_entropy_transfers_top_confidence_first(self):
+        # Sharp logits also maximize negative entropy, so the same ordering
+        # must hold for alg='entropy' (confidences <= 0 but comparable).
+        gen = self._run("entropy")
+        assert gen.tolist() == [4, 4, 3, 4]
+
+    def test_origin_keeps_random_transfer(self):
+        # 'origin' remains random Bernoulli: over many seeds the committed
+        # pattern must NOT always equal the confidence-ordered one.
+        patterns = set()
+        for seed in range(8):
+            model = _ScriptedBlockDecodeModel(sharp_pos=6)
+            cfg = MaskedDiffusionGenerationConfig(
+                max_length=8,
+                steps=2,
+                alg="origin",
+                mask_token_id=model.MASK_ID,
+                use_cache=True,
+                use_replace_cache=False,
+                block_length=4,
+                temperature=0.0,
+            )
+            torch.manual_seed(seed)
+            out = model._block_decode_loop(
+                input_ids=torch.full((1, 4), 9, dtype=torch.long),
+                attention_mask=None,
+                generation_config=cfg,
+            )
+            patterns.add(tuple(out[0, 4:].tolist()))
+        assert len(patterns) > 1, "origin transfer should stay stochastic"
+
+
+class TestDreamTrimModeQueryStart:
+    """#48 item 2: trim mode must forward from the model's query start.
+
+    Dream's logits are right-shifted, so predicting the block's first token
+    needs position ``current_block_start - 1`` in the query window (the same
+    hook the dual-cache path already uses).  Fast-dLLM's non-dual path
+    compensates differently — it commits the block's first token from the
+    initial full forward (dev/repos/fast-dllm/v1/dream/model/
+    generation_utils_block.py L451-456) — while unturtle aligns trim mode with
+    its dual mode via ``_get_block_decode_query_start``.
+    """
+
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.backbones.dream import DreamConfig
+
+        return DreamConfig(
+            vocab_size=64,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+            pad_token_id=0,
+            mask_token_id=1,
+            use_cache=False,
+        )
+
+    def test_trim_mode_includes_previous_token_in_query_window(self, config):
+        from unturtle.models.backbones.dream import DreamGenerationConfig, DreamModel
+
+        class SpyDreamModel(DreamModel):
+            def __init__(self, cfg):
+                super().__init__(cfg)
+                self.denoise_calls = []
+
+            def _model_forward_with_cache(
+                self,
+                input_ids,
+                attention_mask,
+                past_key_values,
+                use_cache,
+                replace_position=None,
+            ):
+                if past_key_values is not None:
+                    cache_len = past_key_values[0][0].shape[-2]
+                    self.denoise_calls.append((input_ids.shape[1], cache_len))
+                return super()._model_forward_with_cache(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    past_key_values=past_key_values,
+                    use_cache=use_cache,
+                    replace_position=replace_position,
+                )
+
+        torch.manual_seed(0)
+        model = SpyDreamModel(config).cpu().eval()
+        prompt_len, max_new, block_length = 4, 4, 2
+        max_length = prompt_len + max_new
+        inputs = torch.tensor([[2, 3, 4, 5]])
+        generation_config = DreamGenerationConfig(
+            max_new_tokens=max_new,
+            steps=4,
+            block_length=block_length,
+            use_cache=True,
+            use_replace_cache=False,
+            mask_token_id=config.mask_token_id,
+            pad_token_id=config.pad_token_id,
+        )
+        with torch.no_grad():
+            out = model.generate(inputs=inputs, generation_config=generation_config)
+
+        assert out.shape == (1, max_length)
+        assert not torch.any(out == config.mask_token_id)
+        assert torch.equal(out[:, :prompt_len], inputs)
+
+        assert model.denoise_calls, "expected cached denoise forwards"
+        # Each denoise forward must start one position BEFORE the current
+        # block (query_start = block_start - 1) so the right-shifted logits
+        # cover the block's first token; the trimmed cache ends exactly at
+        # query_start.  Old code forwarded from block_start with cache length
+        # block_start (window one token shorter, cache one token longer).
+        valid_windows = set()
+        for block_idx in range(max_new // block_length):
+            block_start = prompt_len + block_idx * block_length
+            query_start = block_start - 1
+            valid_windows.add((max_length - query_start, query_start))
+        assert set(model.denoise_calls) <= valid_windows, (
+            f"denoise forwards {set(model.denoise_calls)} must forward from "
+            f"query_start = block_start - 1 with cache trimmed to query_start "
+            f"(expected within {valid_windows})"
+        )
+
+    def test_llada_trim_mode_query_window_unchanged(self):
+        """LLaDA (query_start == block_start) must keep the old windows."""
+        from unturtle.models.backbones.llada import LLaDAConfig, LLaDAModelLM
+
+        config = LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            mlp_ratio=4,
+            max_sequence_length=64,
+            attention_dropout=0.0,
+            residual_dropout=0.0,
+            embedding_dropout=0.0,
+            rope=True,
+            block_type="llama",
+            activation_type="silu",
+            init_device="cpu",
+            mask_token_id=511,
+        )
+        torch.manual_seed(42)
+        model = LLaDAModelLM(config).eval()
+
+        denoise_calls = []
+        original = model._model_forward_with_cache
+
+        def spy(*args, **kwargs):
+            pkv = kwargs.get("past_key_values")
+            ids = kwargs.get("input_ids")
+            if pkv is not None:
+                denoise_calls.append((ids.shape[1], pkv[0][0].shape[-2]))
+            return original(*args, **kwargs)
+
+        model._model_forward_with_cache = spy
+
+        prompt_len, max_new, block_length = 4, 4, 2
+        max_length = prompt_len + max_new
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=max_new,
+            steps=4,
+            alg="origin",
+            mask_token_id=config.mask_token_id,
+            use_cache=True,
+            use_replace_cache=False,
+            block_length=block_length,
+        )
+        with torch.no_grad():
+            out = model.generate(
+                inputs=torch.randint(0, 500, (1, prompt_len)),
+                generation_config=gen_config,
+            )
+        assert out.shape == (1, max_length)
+        valid_windows = set()
+        for block_idx in range(max_new // block_length):
+            block_start = prompt_len + block_idx * block_length
+            valid_windows.add((max_length - block_start, block_start))
+        assert denoise_calls and set(denoise_calls) <= valid_windows
+
+
+class _TinyA2DFactory:
+    MASK_ID = 100
+    PAD_ID = 0
+
+    @classmethod
+    def build(cls):
+        from unturtle.models.conversion.a2d.tiny_a2d import (
+            TinyA2DLlamaConfig,
+            TinyA2DLlamaLMHeadModel,
+        )
+
+        config = TinyA2DLlamaConfig(
+            vocab_size=128,
+            hidden_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            intermediate_size=128,
+            max_position_embeddings=256,
+            mask_token_id=cls.MASK_ID,
+            pad_token_id=cls.PAD_ID,
+        )
+        model = TinyA2DLlamaLMHeadModel(config)
+        model.eval()
+        return model
+
+
+class TestEntropyThresholdWarning:
+    """#48 item 3: alg='entropy' + threshold-based parallel decode must warn.
+
+    Neg-entropy confidences are <= 0 and never reach a threshold in [0, 1], so
+    every step falls back to the single max-confidence token.  Fast-dLLM's
+    threshold mode only ever uses max-probability confidence
+    (dev/repos/fast-dllm/v1/dream/model/generation_utils_block.py L495-524).
+    """
+
+    def test_block_decode_loop_warns(self):
+        model = _ScriptedBlockDecodeModel()
+        cfg = MaskedDiffusionGenerationConfig(
+            max_length=8,
+            steps=2,
+            alg="entropy",
+            mask_token_id=model.MASK_ID,
+            use_cache=True,
+            use_replace_cache=False,
+            parallel_decode=True,
+            confidence_threshold=0.9,
+            block_length=4,
+            temperature=0.0,
+        )
+        with pytest.warns(UserWarning, match="negative-entropy"):
+            model._block_decode_loop(
+                input_ids=torch.full((1, 4), 9, dtype=torch.long),
+                attention_mask=None,
+                generation_config=cfg,
+            )
+
+    def test_shared_sample_with_cache_warns(self):
+        model = _TinyA2DFactory.build()
+        cfg = MaskedDiffusionGenerationConfig(
+            max_new_tokens=4,
+            max_length=8,
+            steps=2,
+            alg="entropy",
+            mask_token_id=_TinyA2DFactory.MASK_ID,
+            use_cache=True,
+            parallel_decode=True,
+            confidence_threshold=0.9,
+            block_length=4,
+            temperature=0.0,
+        )
+        input_ids = torch.randint(1, 90, (1, 4))
+        with pytest.warns(UserWarning, match="negative-entropy"), torch.no_grad():
+            MaskedDiffusionGenerationMixin._sample_with_cache(
+                model, input_ids, None, cfg
+            )
+
+    def test_max_prob_threshold_does_not_warn(self):
+        import warnings as _warnings
+
+        model = _ScriptedBlockDecodeModel()
+        cfg = MaskedDiffusionGenerationConfig(
+            max_length=8,
+            steps=2,
+            alg="maskgit_plus",
+            mask_token_id=model.MASK_ID,
+            use_cache=True,
+            use_replace_cache=False,
+            parallel_decode=True,
+            confidence_threshold=0.5,
+            block_length=4,
+            temperature=0.0,
+        )
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error", UserWarning)
+            model._block_decode_loop(
+                input_ids=torch.full((1, 4), 9, dtype=torch.long),
+                attention_mask=None,
+                generation_config=cfg,
+            )
+
+
+class TestBD3LMCapabilityProbe:
+    """#48 item 4: capability probes must be explicit and one-time; genuine
+    runtime errors in the forward must propagate instead of silently switching
+    the BD3LM numerics path to the full-sequence fallback."""
+
+    def test_forward_accepts_kwargs_signature_probe(self):
+        class NoKwargs(torch.nn.Module):
+            def forward(self, input_ids, attention_mask=None):
+                return input_ids
+
+        class WithPositionIds(torch.nn.Module):
+            def forward(self, input_ids, attention_mask=None, position_ids=None):
+                return input_ids
+
+        class VarKwargs(torch.nn.Module):
+            def forward(self, input_ids, **kwargs):
+                return input_ids
+
+        no_kwargs = NoKwargs()
+        assert _forward_accepts_kwargs(no_kwargs, ("position_ids",)) is False
+        assert _forward_accepts_kwargs(WithPositionIds(), ("position_ids",)) is True
+        assert _forward_accepts_kwargs(VarKwargs(), ("position_ids", "use_cache"))
+        # Result is cached per instance.
+        assert ("position_ids",) in no_kwargs._bd3lm_forward_kwarg_support
+
+    def test_runtime_error_in_kv_path_propagates(self, monkeypatch):
+        model = _TinyA2DFactory.build()
+        original_forward = model.forward
+
+        def exploding_forward(*args, **kwargs):
+            if kwargs.get("past_key_values") is not None:
+                raise RuntimeError("boom: genuine failure in cached forward")
+            return original_forward(*args, **kwargs)
+
+        # Instance-level patch: the signature probe inspects
+        # type(model).forward, so the KV path stays enabled.
+        monkeypatch.setattr(model, "forward", exploding_forward)
+
+        prompt = torch.randint(1, 90, (1, 4))
+        # Old code swallowed this RuntimeError via `except (TypeError,
+        # RuntimeError)` and silently fell back to the full-seq path.
+        with pytest.raises(RuntimeError, match="boom"), torch.no_grad():
+            model.generate(
+                prompt,
+                algorithm="bd3lm",
+                bd3lm_block_size=4,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=_TinyA2DFactory.MASK_ID,
+                pad_token_id=_TinyA2DFactory.PAD_ID,
+            )
+
+    def test_model_without_cache_kwargs_uses_full_seq_path(self):
+        """Models whose forward lacks the KV-cache kwargs must keep working
+        (previously via caught TypeError, now via the signature probe)."""
+
+        class NoCacheModel(MaskedDiffusionBlockGenerationMixin, torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(
+                    mask_token_id=1, pad_token_id=0, eos_token_id=None
+                )
+                torch.manual_seed(0)
+                self.emb = torch.nn.Embedding(32, 8)
+                self.head = torch.nn.Linear(8, 32)
+
+            def forward(self, input_ids, attention_mask=None, position_ids=None):
+                return SimpleNamespace(logits=self.head(self.emb(input_ids)))
+
+        model = NoCacheModel().eval()
+        cfg = MaskedDiffusionGenerationConfig(
+            use_block_diffusion=True,
+            bd3lm_block_size=4,
+            max_new_tokens=4,
+            steps=2,
+            temperature=0.0,
+            mask_token_id=1,
+            pad_token_id=0,
+        )
+        with torch.no_grad():
+            out = model._sample_block_diffusion(torch.tensor([[5, 6, 7]]), cfg)
+        assert out.shape == (1, 7)  # 3 prompt + 4 generated (left-pad stripped)
+        assert not torch.any(out[:, 3:] == 1), "all masks must be committed"
+
+
+class TestBD3LMPadRowSafety:
+    """#48 item 5: the BD3LM loop must never feed SDPA an attention mask with
+    all-False query rows (pad positions -> NaN softmax hazard with eager/math
+    SDPA).  ``prepare_for_sampling`` itself keeps pad rows all-False (its unit
+    contract); the loop applies ``_pad_safe_attention_mask`` — run_attention's
+    ``no_allowed`` pattern (unturtle/utils/attention_dispatch.py) — at every
+    call site."""
+
+    def test_pad_safe_attention_mask_flips_all_false_rows(self):
+        from unturtle.models.generation.masked_diffusion_block_mixin import (
+            _pad_safe_attention_mask,
+        )
+
+        pad_id = 0
+        x = torch.tensor([[pad_id, pad_id, 5, 6, 7, 8, 9, 10]])
+        attn_mask, _ = prepare_for_sampling(x, block_size=4, pad_token_id=pad_id)
+        # Precondition (prepare_for_sampling contract): pad rows all-False.
+        assert not attn_mask[0, 0, 0].any() and not attn_mask[0, 0, 1].any()
+
+        safe = _pad_safe_attention_mask(attn_mask)
+        # Pad query rows now attend everywhere (harmless; outputs never read).
+        assert safe[0, 0, 0].all() and safe[0, 0, 1].all()
+        # Every query row has at least one allowed key (no NaN softmax rows).
+        assert safe.any(dim=-1).all()
+        # Valid rows are bit-unchanged.
+        assert torch.equal(safe[0, 0, 2:], attn_mask[0, 0, 2:])
+
+    def test_bd3lm_non_multiple_prompt_produces_finite_logits(self, monkeypatch):
+        """Non-multiple-of-block prompt forces an internal left-pad; every
+        4-D mask reaching the model must be pad-row-safe and the whole bd3lm
+        path must see finite logits (no NaN leak from pad rows)."""
+        model = _TinyA2DFactory.build()
+        original_forward = model.forward
+
+        def asserting_forward(*args, **kwargs):
+            am = kwargs.get("attention_mask")
+            if am is not None and am.ndim == 4 and am.dtype == torch.bool:
+                assert am.any(dim=-1).all(), (
+                    "all-False attention rows reached the model (NaN hazard)"
+                )
+            out = original_forward(*args, **kwargs)
+            assert torch.isfinite(out.logits).all(), "NaN/Inf logits in bd3lm path"
+            return out
+
+        monkeypatch.setattr(model, "forward", asserting_forward)
+
+        prompt = torch.randint(1, 90, (2, 3))  # 3 % block_size(4) != 0 -> left pad
+        with torch.no_grad():
+            out = model.generate(
+                prompt,
+                algorithm="bd3lm",
+                bd3lm_block_size=4,
+                max_new_tokens=4,
+                steps=2,
+                temperature=0.0,
+                mask_token_id=_TinyA2DFactory.MASK_ID,
+                pad_token_id=_TinyA2DFactory.PAD_ID,
+            )
+        assert out.shape == (2, 7)
+        assert not torch.any(out[:, 3:] == _TinyA2DFactory.MASK_ID)

--- a/tests/models/test_llada.py
+++ b/tests/models/test_llada.py
@@ -1181,3 +1181,103 @@ class TestLLaDABlockDecode:
         assert not torch.allclose(q1, q3, atol=1e-6), (
             "block_end_index=12 should produce different positions"
         )
+
+
+class TestLLaDABlockDecodePaddedBatchMask:
+    """#49: trim-mode block-decode must pass the FULL-length 2-D padding mask
+    to the inner forward — slicing it to the suffix drops exactly the
+    prompt-padding info and desyncs the mask from the KV length (LLaDA variant
+    of the TinyA2D regression in test_a2d.py::TestBlockDecodePaddedBatchMask)."""
+
+    @pytest.fixture
+    def tiny_config(self):
+        from unturtle.models.backbones.llada import LLaDAConfig
+
+        return LLaDAConfig(
+            d_model=64,
+            n_heads=4,
+            n_layers=2,
+            vocab_size=512,
+            mlp_ratio=4,
+            max_sequence_length=64,
+            attention_dropout=0.0,
+            residual_dropout=0.0,
+            embedding_dropout=0.0,
+            rope=True,
+            block_type="llama",
+            activation_type="silu",
+            init_device="cpu",
+            mask_token_id=511,
+            pad_token_id=2,
+        )
+
+    @pytest.fixture
+    def tiny_model(self, tiny_config):
+        from unturtle.models.backbones.llada import LLaDAModelLM
+
+        torch.manual_seed(42)
+        return LLaDAModelLM(tiny_config).eval()
+
+    def test_padded_batch_2d_mask_keeps_full_key_length(
+        self, tiny_model, tiny_config, monkeypatch
+    ):
+        from unturtle.models.generation.diffusion_generation_utils import (
+            MaskedDiffusionGenerationConfig,
+        )
+
+        torch.manual_seed(0)
+        B, prompt_len, max_new = 2, 6, 8
+        total_len = prompt_len + max_new
+        input_ids = torch.randint(3, 500, (B, prompt_len))
+        # Row 1 is left-padded by 2 positions.
+        attention_mask = torch.ones(B, prompt_len, dtype=torch.long)
+        input_ids[1, :2] = 2
+        attention_mask[1, :2] = 0
+
+        recorded = []
+        original = tiny_model._model_forward_with_cache
+
+        def spy(*args, **kwargs):
+            am = kwargs.get("attention_mask")
+            ids = kwargs.get("input_ids")
+            pkv = kwargs.get("past_key_values")
+            recorded.append(
+                (
+                    None if am is None else tuple(am.shape),
+                    None if ids is None else ids.shape[1],
+                    pkv is not None,
+                )
+            )
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(tiny_model, "_model_forward_with_cache", spy)
+
+        gen_config = MaskedDiffusionGenerationConfig(
+            max_new_tokens=max_new,
+            steps=4,
+            alg="origin",
+            use_cache=True,
+            use_replace_cache=False,  # trim mode
+            block_length=4,
+            mask_token_id=tiny_config.mask_token_id,
+            temperature=0.0,
+        )
+        with torch.no_grad():
+            output = tiny_model.generate(
+                inputs=input_ids,
+                attention_mask=attention_mask,
+                generation_config=gen_config,
+            )
+
+        assert output.shape == (B, total_len)
+        assert torch.equal(output[:, :prompt_len], input_ids)
+
+        # Every trim-mode denoise forward (cached, suffix input) must receive
+        # the full-length 2-D mask covering all keys, not just the suffix.
+        cached_calls = [r for r in recorded if r[2] and r[0] is not None]
+        assert cached_calls, "expected cached denoise forwards with a mask"
+        for mask_shape, q_len, _ in cached_calls:
+            assert mask_shape == (B, total_len), (
+                f"2-D mask must span all {total_len} keys (got {mask_shape}, "
+                f"q_len={q_len}) — prompt-padding columns were sliced off"
+            )

--- a/unturtle/models/generation/block_decode_mixin.py
+++ b/unturtle/models/generation/block_decode_mixin.py
@@ -23,6 +23,7 @@ Subclasses implement model-specific forward wrappers while inheriting common blo
 
 import math
 import time
+import warnings
 from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import torch
@@ -63,7 +64,7 @@ class BlockDecodeMixin:
                 - steps: Total denoising steps
                 - mask_token_id: Token ID for [MASK]
                 - use_replace_cache: If True, use replace_position mode (default: False)
-                - alg: Algorithm ('origin' only in Phase M.1)
+                - alg: Algorithm ('origin', 'maskgit_plus', 'topk_margin', 'entropy')
                 - temperature, top_p, top_k: Sampling parameters
 
         Returns:
@@ -71,7 +72,6 @@ class BlockDecodeMixin:
 
         Raises:
             ValueError: If gen_length % block_length != 0
-            NotImplementedError: If alg != 'origin' (Phase M.1 limitation)
         """
         # Extract config (Fast-dLLM Dream style: use max_length, compute gen_length)
         max_length = generation_config.max_length
@@ -87,10 +87,26 @@ class BlockDecodeMixin:
             )
         use_replace_cache = getattr(generation_config, "use_replace_cache", False)
         alg = generation_config.alg
+        alg_temp = getattr(generation_config, "alg_temp", None)
         temperature = getattr(generation_config, "temperature", 1.0)
         top_p = getattr(generation_config, "top_p", None)
         top_k = getattr(generation_config, "top_k", None)
         eps = getattr(generation_config, "eps", 0.001)
+
+        if generation_config.parallel_decode and alg == "entropy":
+            # Fast-dLLM's threshold mode uses max-probability confidence only
+            # (dev/repos/fast-dllm/v1/dream/model/generation_utils_block.py L495-524).
+            # Negative-entropy confidences are <= 0 and can never reach a
+            # confidence_threshold in [0, 1], so threshold selection always takes
+            # the single max-confidence fallback token.
+            warnings.warn(
+                "alg='entropy' uses negative-entropy confidences (<= 0), which never "
+                "reach a confidence_threshold in [0, 1]; threshold-based parallel "
+                "decode degenerates to one token per step (the max-confidence "
+                "fallback). Use alg='maskgit_plus' or 'topk_margin' with "
+                "parallel_decode, or disable parallel_decode for entropy ordering.",
+                UserWarning,
+            )
 
         output_timing = getattr(generation_config, "output_timing", False)
         timing: Optional[Dict[str, Any]] = None
@@ -169,6 +185,17 @@ class BlockDecodeMixin:
             current_block_start = prompt_len + block_idx * block_length
             current_block_end = current_block_start + block_length
 
+            # Model-specific query start (constant per block). Dream's
+            # right-shifted logits need position current_block_start - 1 in the
+            # query window to predict the block's first token (its hook returns
+            # current_block_start - 1); LLaDA / TinyA2D return
+            # current_block_start, keeping their paths unchanged.
+            query_start = self._get_block_decode_query_start(
+                current_block_start=current_block_start,
+                current_block_end=current_block_end,
+                use_replace_cache=use_replace_cache,
+            )
+
             # Step 1: Initial forward (full sequence) to build cache
             initial_cache_start = _time_start()
             outputs = self._model_forward_with_cache(
@@ -187,10 +214,18 @@ class BlockDecodeMixin:
                 # Dual cache mode: keep full cache, will use replace_position later
                 cache_for_denoise = past_key_values
             else:
-                # Trim mode: keep only previous blocks
+                # Trim mode: keep only the positions before the query window.
+                # For models with query_start == current_block_start this keeps
+                # exactly the previous blocks (Fast-dLLM non-dual trimming,
+                # dev/repos/fast-dllm/v1/dream/model/generation_utils_block.py
+                # L459-465); for Dream (query_start == current_block_start - 1)
+                # the overlapping position is recomputed by the forward instead.
                 from .cache_utils import trim_kv_cache
 
-                cache_for_denoise = trim_kv_cache(past_key_values, current_block_start)
+                if query_start > 0:
+                    cache_for_denoise = trim_kv_cache(past_key_values, query_start)
+                else:
+                    cache_for_denoise = None
             _time_end(cache_prep_start, "cache_prep_s")
 
             # Step 3: Denoising loop for current block
@@ -220,11 +255,6 @@ class BlockDecodeMixin:
                 if use_replace_cache:
                     # Dual mode: forward the current block while replacing the
                     # corresponding absolute positions in the full cache.
-                    query_start = self._get_block_decode_query_start(
-                        current_block_start=current_block_start,
-                        current_block_end=current_block_end,
-                        use_replace_cache=use_replace_cache,
-                    )
                     x_forward = x[:, query_start:current_block_end]
                     if attention_mask is not None and attention_mask.ndim >= 3:
                         attn_forward = attention_mask[
@@ -237,10 +267,12 @@ class BlockDecodeMixin:
                     replace_position = torch.zeros_like(x, dtype=torch.bool)
                     replace_position[:, current_block_start:current_block_end] = True
                 else:
-                    # Trim mode: forward from current_block_start onwards
-                    x_forward = x[:, current_block_start:]
+                    # Trim mode: forward from the model's query start onwards
+                    # (query_start == current_block_start for LLaDA/TinyA2D;
+                    # current_block_start - 1 for Dream's right-shifted logits).
+                    x_forward = x[:, query_start:]
                     if attention_mask is not None and attention_mask.ndim >= 3:
-                        attn_forward = attention_mask[:, :, current_block_start:, :]
+                        attn_forward = attention_mask[:, :, query_start:, :]
                     else:
                         # 2-D padding masks describe the KEYS, which span the full
                         # sequence here (trimmed cache prefix + suffix). Slicing off
@@ -276,8 +308,14 @@ class BlockDecodeMixin:
                             :, current_block_start:current_block_end, :
                         ]
                 else:
-                    # Incremental forward: first block_length tokens are current block
-                    block_logits = logits[:, :block_length, :]
+                    # Incremental forward: the window starts at query_start, so
+                    # the current block begins at offset
+                    # current_block_start - query_start (0 for LLaDA/TinyA2D;
+                    # 1 for Dream, whose right-shift postprocess moves the
+                    # position current_block_start - 1 prediction onto the
+                    # block's first token).
+                    offset = current_block_start - query_start
+                    block_logits = logits[:, offset : offset + block_length, :]
 
                 # Get masked positions' logits
                 mask_logits = block_logits[mask_index_block]  # [N_masked, vocab_size]
@@ -290,45 +328,26 @@ class BlockDecodeMixin:
                     mask_logits[:, mask_token_id] = torch.finfo(mask_logits.dtype).min
                 _time_end(logits_slice_start, "logits_slice_s")
 
-                # Sample tokens with confidence
+                # Sample tokens with confidence (alg selects the confidence
+                # measure, matching the no-cache `_sample` dispatch).
                 sampling_start = _time_start()
-                if generation_config.parallel_decode:
-                    if alg == "maskgit_plus":
-                        sampled_confidence, sampled = sample_tokens(
-                            mask_logits,
-                            temperature=temperature,
-                            top_p=top_p,
-                            top_k=top_k,
-                            confidence_type="max_prob",
-                        )
-                    elif alg == "topk_margin":
-                        sampled_confidence, sampled = sample_tokens(
-                            mask_logits,
-                            temperature=temperature,
-                            top_p=top_p,
-                            top_k=top_k,
-                            confidence_type="margin",
-                        )
-                    elif alg == "entropy":
-                        sampled_confidence, sampled = sample_tokens(
-                            mask_logits,
-                            temperature=temperature,
-                            top_p=top_p,
-                            top_k=top_k,
-                            confidence_type="neg_entropy",
-                        )
-                    else:
-                        raise RuntimeError(
-                            f"Unknown alg: {alg!r}. Choose from 'origin', 'maskgit_plus', 'topk_margin', 'entropy'."
-                        )
-                else:
-                    sampled_confidence, sampled = sample_tokens(
-                        mask_logits,
-                        temperature=temperature,
-                        top_p=top_p,
-                        top_k=top_k,
-                        confidence_type="max_prob",
+                confidence_type_by_alg = {
+                    "origin": "max_prob",
+                    "maskgit_plus": "max_prob",
+                    "topk_margin": "margin",
+                    "entropy": "neg_entropy",
+                }
+                if alg not in confidence_type_by_alg:
+                    raise RuntimeError(
+                        f"Unknown alg: {alg!r}. Choose from 'origin', 'maskgit_plus', 'topk_margin', 'entropy'."
                     )
+                sampled_confidence, sampled = sample_tokens(
+                    mask_logits,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    confidence_type=confidence_type_by_alg[alg],
+                )
                 _time_end(sampling_start, "sampling_s")
 
                 transfer_start = _time_start()
@@ -352,8 +371,8 @@ class BlockDecodeMixin:
                         current_block[selected_mask] = sampled[
                             selected_mask[mask_index_block]
                         ]
-                else:
-                    # Phase M.1: Sequential decoding (origin algorithm)
+                elif alg == "origin":
+                    # Sequential decoding (origin algorithm): random transfer.
                     # Timestep transition
                     t = timesteps[step_idx]
                     s = timesteps[step_idx + 1]
@@ -376,6 +395,54 @@ class BlockDecodeMixin:
 
                     # Update sequence
                     x[:, current_block_start:current_block_end] = x0_block
+                else:
+                    # Confidence-ordered transfer: keep the schedule-driven
+                    # per-step count but pick positions by top confidence,
+                    # matching the no-cache `_sample` semantics
+                    # (diffusion_generation_utils.py, non-origin branch) and
+                    # Fast-dLLM's non-threshold ordering
+                    # (dev/repos/fast-dllm/v1/dream/model/generation_utils_block.py
+                    # L526-559: topk / alg_temp-multinomial over confidence).
+                    t = timesteps[step_idx]
+                    s = timesteps[step_idx + 1]
+                    num_mask_token = mask_index_block.sum() / mask_index_block.shape[0]
+                    n_transfer = (
+                        int(num_mask_token * (1 - s / t))
+                        if step_idx < steps_per_block - 1
+                        else int(num_mask_token)
+                    )
+
+                    if n_transfer > 0:
+                        full_confidence = torch.full_like(
+                            x[:, current_block_start:current_block_end],
+                            -torch.inf,
+                            dtype=logits.dtype,
+                        )
+                        full_confidence[mask_index_block] = sampled_confidence
+
+                        if alg_temp is None or alg_temp == 0:
+                            _, transfer_index = torch.topk(full_confidence, n_transfer)
+                        else:
+                            full_confidence = full_confidence / alg_temp
+                            full_confidence = F.softmax(full_confidence, dim=-1)
+                            transfer_index = torch.multinomial(
+                                full_confidence, num_samples=n_transfer
+                            )
+
+                        sampled_block = torch.full_like(
+                            x[:, current_block_start:current_block_end],
+                            mask_token_id,
+                            dtype=torch.long,
+                        )
+                        sampled_block[mask_index_block] = sampled
+                        row_idx = (
+                            torch.arange(x.size(0), device=device)
+                            .unsqueeze(1)
+                            .expand_as(transfer_index)
+                        )
+                        x[:, current_block_start:current_block_end][
+                            row_idx, transfer_index
+                        ] = sampled_block[row_idx, transfer_index]
 
                 _time_end(transfer_start, "threshold_transfer_s")
                 step_idx += 1

--- a/unturtle/models/generation/diffusion_generation_utils.py
+++ b/unturtle/models/generation/diffusion_generation_utils.py
@@ -401,6 +401,11 @@ def prepare_for_sampling(
 
     attn_mask = (bid_k <= bid_q) & valid_q & valid_k  # [B, 1, T, T]
 
+    # NOTE: padding query rows are all-False here (pads neither query nor
+    # serve as keys).  Consumers that feed this mask to SDPA must make those
+    # rows safe first — the BD3LM loop applies
+    # ``masked_diffusion_block_mixin._pad_safe_attention_mask`` (run_attention's
+    # ``no_allowed`` pattern) to avoid NaN softmax rows.
     return attn_mask, position_ids
 
 
@@ -1124,6 +1129,19 @@ class MaskedDiffusionGenerationMixin:
             raise ValueError(
                 "`parallel_decode=True` does not support `alg='origin'`. "
                 "Use one of 'maskgit_plus', 'topk_margin', or 'entropy'."
+            )
+        if parallel_decode and alg == "entropy":
+            # Fast-dLLM's threshold mode uses max-probability confidence only
+            # (dev/repos/fast-dllm/v1/dream/model/generation_utils_block.py
+            # L495-524); negative-entropy confidences are <= 0 and never reach a
+            # confidence_threshold in [0, 1].
+            warnings.warn(
+                "alg='entropy' uses negative-entropy confidences (<= 0), which never "
+                "reach a confidence_threshold in [0, 1]; threshold-based parallel "
+                "decode degenerates to one token per step (the max-confidence "
+                "fallback). Use alg='maskgit_plus' or 'topk_margin' with "
+                "parallel_decode, or disable parallel_decode for entropy ordering.",
+                UserWarning,
             )
 
         if mask_token_id is None:

--- a/unturtle/models/generation/masked_diffusion_block_mixin.py
+++ b/unturtle/models/generation/masked_diffusion_block_mixin.py
@@ -20,6 +20,7 @@ BD3LM block-diffusion generation is added via _sample_block_diffusion()
 (use_block_diffusion=True).
 """
 
+import inspect
 import math
 from types import SimpleNamespace
 
@@ -49,9 +50,54 @@ def _snapshot_prefix_cache(past_key_values):
         return past_key_values
     if hasattr(past_key_values, "layers"):
         return tuple((layer.keys, layer.values) for layer in past_key_values.layers)
-    raise TypeError(
-        f"Unsupported cache type for BD3LM prefix snapshot: {type(past_key_values).__name__}"
-    )
+    # Opaque/unsupported cache type: return None so the BD3LM loop uses the
+    # full-sequence path (explicit routing, replacing the old behavior where
+    # a TypeError raised here was swallowed by a broad ``except TypeError``).
+    return None
+
+
+def _pad_safe_attention_mask(attn_mask: torch.Tensor) -> torch.Tensor:
+    """Flip all-False query rows (pad positions) to all-True.
+
+    ``prepare_for_sampling`` gives pad query positions no allowed keys, which
+    yields NaN softmax rows under eager/math SDPA, and the NaNs can propagate
+    into valid rows through later layers' K/V projections.  Follow
+    run_attention's ``no_allowed`` pattern
+    (unturtle/utils/attention_dispatch.py: ``no_allowed = ~local_mask.any(
+    dim=-1, keepdim=True); local_mask = local_mask | no_allowed``): pad rows
+    attend everywhere harmlessly — their outputs are never read.
+    """
+    no_allowed = ~attn_mask.any(dim=-1, keepdim=True)
+    return attn_mask | no_allowed
+
+
+def _forward_accepts_kwargs(model, names: tuple) -> bool:
+    """Probe once whether ``model.forward`` accepts all keyword args in ``names``.
+
+    Explicit capability probe replacing the former broad ``except TypeError`` /
+    ``except (TypeError, RuntimeError)`` around forward calls, which also
+    swallowed genuine failures and silently changed the numerics path.  The
+    result is cached per model instance, and forwards with ``**kwargs`` are
+    treated as accepting everything (matching their previous no-TypeError
+    behavior).  Genuine runtime errors in the forward now propagate.
+    """
+    cache = getattr(model, "_bd3lm_forward_kwarg_support", None)
+    if cache is None:
+        cache = {}
+        model._bd3lm_forward_kwarg_support = cache
+    if names not in cache:
+        try:
+            params = inspect.signature(type(model).forward).parameters
+        except (TypeError, ValueError):
+            # Signature not introspectable — assume the kwargs are accepted
+            # (any real incompatibility will surface as a loud TypeError).
+            cache[names] = True
+        else:
+            has_var_kw = any(
+                p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+            )
+            cache[names] = has_var_kw or all(n in params for n in names)
+    return cache[names]
 
 
 def _rewrap_prefix_cache(past_key_values, device):
@@ -189,6 +235,12 @@ class MaskedDiffusionBlockGenerationMixin(
                 "before calling `generate(algorithm='bd3lm')`."
             )
 
+        # Known limitation: padding is inferred purely from pad_id token values
+        # (both here for the internal left-pad and in prepare_for_sampling),
+        # not from an attention_mask.  Genuine pad_id tokens inside the prompt
+        # would be treated as padding.  prepare_for_sampling keeps pad rows
+        # numerically safe (no all-False attention rows), but the inference
+        # itself is intentionally not redesigned here.
         pad_id = generation_config.pad_token_id
         if pad_id is None:
             pad_id = getattr(self.config, "pad_token_id", None)
@@ -249,25 +301,33 @@ class MaskedDiffusionBlockGenerationMixin(
 
             # Build block-causal attention mask + logical position IDs for prefix
             prefix_attn, prefix_pos = prepare_for_sampling(x, block_size, pad_id)
+            prefix_attn = _pad_safe_attention_mask(prefix_attn)
 
-            # Try to obtain KV cache for prefix; fall back to full-seq silently
+            # Obtain KV cache for the prefix when the model's forward supports
+            # the KV-cache kwargs; otherwise use the full-seq path.  The
+            # capability is probed once via the forward signature
+            # (`_forward_accepts_kwargs`) instead of catching TypeError, so
+            # genuine failures inside the forward propagate.
             cond_past = None
             cond_prefix_last_logits = None
             uncond_past = None
             uncond_prefix_last_logits = None
 
-            try:
+            supports_kv_cache = _forward_accepts_kwargs(
+                self,
+                ("attention_mask", "position_ids", "use_cache", "past_key_values"),
+            )
+            if supports_kv_cache:
                 out_prefix = self(
                     x,
                     attention_mask=prefix_attn,
                     position_ids=prefix_pos,
                     use_cache=True,
                 )
-                if (
-                    hasattr(out_prefix, "past_key_values")
-                    and out_prefix.past_key_values is not None
-                ):
-                    cond_past = _snapshot_prefix_cache(out_prefix.past_key_values)
+                cond_past = _snapshot_prefix_cache(
+                    getattr(out_prefix, "past_key_values", None)
+                )
+                if cond_past is not None:
                     cond_prefix_last_logits = out_prefix.logits[:, -1:, :]
 
                 if cfg_scale > 0.0:
@@ -279,14 +339,11 @@ class MaskedDiffusionBlockGenerationMixin(
                         position_ids=prefix_pos,
                         use_cache=True,
                     )
-                    if (
-                        hasattr(out_un, "past_key_values")
-                        and out_un.past_key_values is not None
-                    ):
-                        uncond_past = _snapshot_prefix_cache(out_un.past_key_values)
+                    uncond_past = _snapshot_prefix_cache(
+                        getattr(out_un, "past_key_values", None)
+                    )
+                    if uncond_past is not None:
                         uncond_prefix_last_logits = out_un.logits[:, -1:, :]
-            except TypeError:
-                cond_past = None
 
             # Append masked block
             new_block = torch.full(
@@ -311,6 +368,7 @@ class MaskedDiffusionBlockGenerationMixin(
             effective_steps = num_transfer_tokens.shape[1]
 
             full_attn, full_pos = prepare_for_sampling(x, block_size, pad_id)
+            full_attn = _pad_safe_attention_mask(full_attn)
             attn_block = full_attn[:, :, T_prefix:T_total, :]
             pos_block = full_pos[:, T_prefix:T_total]
 
@@ -324,47 +382,47 @@ class MaskedDiffusionBlockGenerationMixin(
                     break
 
                 if use_kv_cache:
-                    try:
-                        cond_out = self(
+                    # Capability was probed via `_forward_accepts_kwargs` above:
+                    # no try/except here — genuine forward errors propagate
+                    # instead of silently switching to the full-seq path.
+                    cond_out = self(
+                        x_block,
+                        attention_mask=attn_block,
+                        position_ids=pos_block,
+                        past_key_values=_rewrap_prefix_cache(cond_past, x_block.device),
+                        use_cache=False,
+                    )
+                    cond_logits = cond_out.logits
+
+                    if cfg_scale > 0.0 and uncond_past is not None:
+                        uncond_out = self(
                             x_block,
                             attention_mask=attn_block,
                             position_ids=pos_block,
                             past_key_values=_rewrap_prefix_cache(
-                                cond_past, x_block.device
+                                uncond_past, x_block.device
                             ),
                             use_cache=False,
                         )
-                        cond_logits = cond_out.logits
-
-                        if cfg_scale > 0.0 and uncond_past is not None:
-                            uncond_out = self(
-                                x_block,
-                                attention_mask=attn_block,
-                                position_ids=pos_block,
-                                past_key_values=_rewrap_prefix_cache(
-                                    uncond_past, x_block.device
-                                ),
-                                use_cache=False,
-                            )
-                            logits_block = uncond_out.logits + (cfg_scale + 1.0) * (
-                                cond_logits - uncond_out.logits
-                            )
-                        else:
-                            logits_block = cond_logits
-
-                    except (TypeError, RuntimeError):
-                        use_kv_cache = False
-                        cond_past = None
+                        logits_block = uncond_out.logits + (cfg_scale + 1.0) * (
+                            cond_logits - uncond_out.logits
+                        )
+                    else:
+                        logits_block = cond_logits
 
                 if not use_kv_cache:
+                    supports_position_ids = _forward_accepts_kwargs(
+                        self, ("position_ids",)
+                    )
                     full_attn_step, full_pos_step = prepare_for_sampling(
                         x, block_size, pad_id
                     )
-                    try:
+                    full_attn_step = _pad_safe_attention_mask(full_attn_step)
+                    if supports_position_ids:
                         out = self(
                             x, attention_mask=full_attn_step, position_ids=full_pos_step
                         )
-                    except TypeError:
+                    else:
                         out = self(x, attention_mask=full_attn_step)
 
                     if right_shift_logits and T_prefix > 0:
@@ -377,13 +435,13 @@ class MaskedDiffusionBlockGenerationMixin(
                     if cfg_scale > 0.0:
                         un_x = x.clone()
                         un_x[unmasked_index] = mask_id
-                        try:
+                        if supports_position_ids:
                             un_out = self(
                                 un_x,
                                 attention_mask=full_attn_step,
                                 position_ids=full_pos_step,
                             )
-                        except TypeError:
+                        else:
                             un_out = self(un_x, attention_mask=full_attn_step)
                         un_logits = un_out.logits[:, T_prefix:T_total, :]
                         if right_shift_logits and T_prefix > 0:


### PR DESCRIPTION
Refs #48, #49.

## What
- **`alg` honored in the non-parallel cache path (⚠️ benchmark-relevant)**: cached block-decode with `alg` in {maskgit_plus, topk_margin, entropy} previously *silently degraded* to origin-style random transfer. Now it does confidence-ordered transfer with the schedule-driven counts, ported from the repo's own no-cache `_sample` and Fast-dLLM's non-threshold ordering. **`alg="origin"` (the default) is bit-identical to before**, but historical `use_cache=True` benchmark numbers taken with a non-origin alg are not comparable to new (now-correct) runs.
- **Dream trim-mode first token**: trim mode now honors `_get_block_decode_query_start` (`max(0, block_start-1)` for Dream), so the block's first token is predicted from position block_start−1 as the right-shift requires — previously the first logit was duplicated. LLaDA/TinyA2D (offset 0) provably unchanged (window-equality regression included).
- **BD3LM pad-row NaN guard**: all-False attention rows (left-pad / post-EOS pad blocks) are flipped to all-True (run_attention's `no_allowed` pattern) at all three `prepare_for_sampling` call sites; finite-logits regression on a non-block-aligned prompt.
- **Explicit capability probes**: signature-based probing replaces `except TypeError/RuntimeError` around model forwards — genuine CUDA/shape failures now propagate instead of silently switching numerics paths.
- **entropy + threshold parallel decode**: clear `UserWarning` (neg-entropy confidences ≤0 can never pass a [0,1] threshold; matches Fast-dLLM, whose threshold mode is max-prob only).
- **LLaDA trim-mode padded-batch mask regression** (#49) added.

## Review
Reference-aligned review: transfer schedule/ordering verified line-by-line against Fast-dLLM `generation_utils_block.py` L526-559 and the in-repo no-cache branch; origin-path RNG call sequence unchanged; Dream offset math verified incl. the block-0 `query_start=0` guard.

## Test plan
- [x] new tests/models/test_generation_followups.py (13) + LLaDA padded-mask class; fails-on-old-code verified per fix
- [x] tests/models/ + tests/diffusion/: 507 passed; ruff clean