### PR TITLE
🐛 fix(kernels/trainer): bidirectional-safe attention dispatch, CPU loss parity, CART membership (#48/#49 follow-ups)

### DIFF
--- a/tests/diffusion/test_dream_training_features.py
+++ b/tests/diffusion/test_dream_training_features.py
@@ -469,3 +469,96 @@ class TestCARTInBuildLossWeights:
         w = self._build_cart_weights(B, L, diffusion_mask, cart_p=0.8)
         # All positions are masked (clean_mask = all False), so all weights are 0
         assert torch.all(w == 0.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CART clean-context membership: padding + packed-sample boundaries (#48)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCARTCleanContextMembership:
+    """Padding and packed neighbours must never count as clean context."""
+
+    def _weights(self, diffusion_mask, attention_mask=None, seq_lengths=None, L=None):
+        from types import SimpleNamespace
+
+        from unturtle.diffusion import DiffusionTrainer
+
+        L = L if L is not None else diffusion_mask.shape[1]
+        fake_self = SimpleNamespace(_loss_weight_type="cart", _cart_p=0.8)
+        logits = torch.zeros(diffusion_mask.shape[0], L, 4)
+        timesteps = torch.full((diffusion_mask.shape[0],), 0.5)
+        return DiffusionTrainer._build_loss_weights(
+            fake_self,
+            timesteps,
+            logits,
+            diffusion_mask,
+            attention_mask=attention_mask,
+            seq_lengths=seq_lengths,
+        )
+
+    def test_padding_does_not_count_as_clean_context(self):
+        """Identical sample padded to two lengths must get identical CART weights."""
+        s = 6  # real sample length
+        diff = torch.tensor([[False, True, False, True, True, False]])
+
+        for pad in (0, 4, 10):
+            L = s + pad
+            diffusion_mask = torch.zeros(1, L, dtype=torch.bool)
+            diffusion_mask[0, :s] = diff[0]
+            attention_mask = torch.zeros(1, L, dtype=torch.long)
+            attention_mask[0, :s] = 1
+
+            w = self._weights(diffusion_mask, attention_mask=attention_mask)
+            if pad == 0:
+                w_ref = w
+            else:
+                assert torch.allclose(w[0, :s], w_ref[0, :s], atol=1e-6), (
+                    f"CART weights changed when padding {s}->{L}"
+                )
+                # No loss weight outside the real sample.
+                assert torch.all(w[0, s:] == 0.0)
+
+    def test_packed_row_matches_unpacked_samples(self):
+        """A packed two-sample row must reproduce each sample's unpacked weights."""
+        torch.manual_seed(0)
+        s1, s2 = 5, 7
+        d1 = torch.rand(s1) > 0.5
+        d2 = torch.rand(s2) > 0.5
+        # Ensure a masked position adjacent to the s1/s2 boundary to make
+        # cross-sample leakage observable.
+        d1[-1] = True
+        d2[0] = False
+
+        L = s1 + s2
+        packed_diff = torch.cat([d1, d2]).unsqueeze(0)
+        packed_attn = torch.ones(1, L, dtype=torch.long)
+        seq_lengths = [torch.tensor([s1, s2], dtype=torch.int32)]
+
+        w_packed = self._weights(
+            packed_diff, attention_mask=packed_attn, seq_lengths=seq_lengths
+        )
+
+        # Unpacked references (each padded to L so the weight matrix matches).
+        for offset, slen, d in ((0, s1, d1), (s1, s2, d2)):
+            diffusion_mask = torch.zeros(1, L, dtype=torch.bool)
+            diffusion_mask[0, :slen] = d
+            attention_mask = torch.zeros(1, L, dtype=torch.long)
+            attention_mask[0, :slen] = 1
+            w_single = self._weights(diffusion_mask, attention_mask=attention_mask)
+
+            assert torch.allclose(
+                w_packed[0, offset : offset + slen], w_single[0, :slen], atol=1e-6
+            ), f"packed weights diverge from unpacked for segment at {offset}"
+
+    def test_cross_sample_leakage_regression(self):
+        """A masked token at a packed boundary must ignore the neighbour sample."""
+        # Sample A: all clean (2 tokens). Sample B: all masked (2 tokens).
+        diffusion_mask = torch.tensor([[False, False, True, True]])
+        seq_lengths = [torch.tensor([2, 2], dtype=torch.int32)]
+        w = self._weights(diffusion_mask, seq_lengths=seq_lengths)
+
+        # Sample B has zero clean context within its own segment -> zero weight.
+        assert torch.all(w[0, 2:] == 0.0), (
+            "masked tokens must not receive weight from the neighbouring packed sample"
+        )

--- a/tests/diffusion/test_masked_diffusion_loss.py
+++ b/tests/diffusion/test_masked_diffusion_loss.py
@@ -434,3 +434,82 @@ class TestFusedMaskedDiffusionLoss:
         assert logits.grad is not None
         assert torch.isfinite(logits.grad).all(), "Non-finite gradients"
         assert logits.grad.abs().sum() > 0, "All-zero gradients"
+
+    def test_cpu_fallback_applies_scaling_and_softcapping(self):
+        """The non-CUDA path must honor logit_scaling / logit_softcapping.
+
+        Hand-computed reference mirroring the Triton kernel order
+        (unsloth kernels/cross_entropy_loss.py): scaling FIRST
+        (``s * x``), THEN softcapping (``t * tanh(x / t)``).
+        """
+        torch.manual_seed(7)
+        B, L, V = 2, 10, 64
+        scaling = 0.125
+        softcap = 30.0
+        logits = torch.randn(B, L, V) * 40.0  # large enough to engage the cap
+        labels = torch.randint(0, V, (B, L))
+        mask = torch.rand(B, L) > 0.4
+
+        got = self.fused(
+            logits,
+            labels,
+            mask,
+            logit_softcapping=softcap,
+            logit_scaling=scaling,
+        )
+
+        # Manual reference
+        transformed = scaling * logits
+        transformed = softcap * torch.tanh(transformed / softcap)
+        masked_labels = labels.clone()
+        masked_labels[~mask] = -100
+        per_token = F.cross_entropy(
+            transformed.view(B * L, V),
+            masked_labels.view(-1),
+            ignore_index=-100,
+            reduction="none",
+        )
+        n_maskable = (labels != -100).sum().clamp_min(1)
+        expected = per_token.sum() / n_maskable
+
+        assert torch.allclose(got, expected, atol=1e-5), (
+            f"softcap+scaling: got={got.item():.6f} expected={expected.item():.6f}"
+        )
+        # Sanity: transformed loss must differ from the untransformed loss.
+        plain = self.fused(logits, labels, mask)
+        assert not torch.allclose(got, plain)
+
+    def test_cpu_fallback_scaling_only_and_softcap_only(self):
+        torch.manual_seed(11)
+        B, L, V = 1, 8, 32
+        logits = torch.randn(B, L, V) * 25.0
+        labels = torch.randint(0, V, (B, L))
+        mask = torch.ones(B, L, dtype=torch.bool)
+
+        def _ref(transform):
+            per_token = F.cross_entropy(
+                transform(logits).view(B * L, V),
+                labels.view(-1),
+                ignore_index=-100,
+                reduction="none",
+            )
+            return per_token.sum() / (labels != -100).sum()
+
+        got_scale = self.fused(logits, labels, mask, logit_scaling=0.5)
+        assert torch.allclose(got_scale, _ref(lambda x: 0.5 * x), atol=1e-5)
+
+        got_cap = self.fused(logits, labels, mask, logit_softcapping=20.0)
+        assert torch.allclose(
+            got_cap, _ref(lambda x: 20.0 * torch.tanh(x / 20.0)), atol=1e-5
+        )
+
+    def test_cpu_fallback_sentinel_on_labels_device(self):
+        """The -100 sentinel must be created on the labels device (MPS/XPU safe)."""
+        B, L, V = 1, 4, 16
+        logits = torch.randn(B, L, V)
+        labels = torch.randint(0, V, (B, L))
+        mask = torch.rand(B, L) > 0.5
+
+        # On CPU this is trivially satisfied; the assertion guards the code path.
+        loss = self.fused(logits, labels, mask)
+        assert torch.isfinite(loss)

--- a/tests/utils/test_attention_masks.py
+++ b/tests/utils/test_attention_masks.py
@@ -17,6 +17,7 @@
 
 import math
 
+import pytest
 import torch
 
 from unturtle.utils import attention_dispatch
@@ -206,6 +207,280 @@ def test_run_attention_xformers_passes_sliding_window(monkeypatch):
 
     assert captured["window"] == sliding_window
     assert isinstance(captured["bias"], _FakeBias)
+
+
+def test_sdpa_packed_bidirectional_mask_has_no_causal_blocks():
+    seq_info = _make_seq_info([5, 3])
+    mask = packing_utils.build_sdpa_packed_bidirectional_attention_mask(
+        seq_info,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+
+    assert mask.shape == (1, 1, 8, 8)
+    # Full bidirectional visibility inside each block (incl. upper triangle).
+    assert torch.all(mask[0, 0, :5, :5] == 0.0)
+    assert torch.all(mask[0, 0, 5:, 5:] == 0.0)
+    # No cross-sample visibility.
+    assert torch.all(mask[0, 0, :5, 5:] == float("-inf"))
+    assert torch.all(mask[0, 0, 5:, :5] == float("-inf"))
+
+
+def test_sdpa_packed_bidirectional_mask_symmetric_sliding_window():
+    packing_utils.clear_packed_caches()
+    seq_info = _make_seq_info([5])
+    mask = packing_utils.build_sdpa_packed_bidirectional_attention_mask(
+        seq_info,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+        sliding_window=2,
+    )
+
+    block = mask[0, 0]
+    # |q - k| < 2 kept, both directions.
+    assert block[2, 1].item() == 0.0
+    assert block[2, 3].item() == 0.0
+    assert block[2, 0].item() == float("-inf")
+    assert block[2, 4].item() == float("-inf")
+
+
+def _bidirectional_config():
+    return attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.SDPA,
+        n_kv_heads=1,
+        n_groups=1,
+        sdpa_kwargs={"is_causal": False},
+        causal=False,
+    )
+
+
+def test_run_attention_bidirectional_packed_mask_is_not_causal(monkeypatch):
+    """causal=False + seq_info + no mask must NOT fall back to the causal packed mask."""
+    packing_utils.clear_packed_caches()
+    seq_info = _make_seq_info([3, 2])
+    captured = {}
+
+    def _fake_sdpa(Q, K, V, **kwargs):
+        captured["mask"] = kwargs.get("attn_mask")
+        captured["is_causal"] = kwargs.get("is_causal")
+        return torch.zeros_like(Q)
+
+    monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
+
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=5,
+        kv_seq_len=5,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+    )
+
+    Q = torch.zeros(1, 1, 5, 1)
+    attention_dispatch.run_attention(
+        config=_bidirectional_config(), context=context, Q=Q, K=Q.clone(), V=Q.clone()
+    )
+
+    mask = captured["mask"]
+    assert mask is not None and mask.shape == (1, 1, 5, 5)
+    assert captured["is_causal"] is False
+    # Upper triangle within each block must be visible (bidirectional).
+    assert mask[0, 0, 0, 2].item() == 0.0
+    assert mask[0, 0, 3, 4].item() == 0.0
+    # Cross-sample must stay blocked.
+    assert mask[0, 0, 0, 3].item() == float("-inf")
+
+
+def test_run_attention_bidirectional_2d_mask_has_no_causal_and(monkeypatch):
+    """causal=False + 2-D padding mask must not AND a causal keep-mask."""
+    captured = {}
+
+    def _fake_sdpa(Q, K, V, **kwargs):
+        captured["mask"] = kwargs.get("attn_mask")
+        return torch.zeros_like(Q)
+
+    monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
+
+    attention_mask = torch.tensor([[1, 1, 1, 0]])  # [B=1, L=4], last is padding
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=None,
+        attention_mask=attention_mask,
+        causal_mask=None,
+    )
+
+    Q = torch.zeros(1, 1, 4, 1)
+    attention_dispatch.run_attention(
+        config=_bidirectional_config(), context=context, Q=Q, K=Q.clone(), V=Q.clone()
+    )
+
+    mask = captured["mask"]
+    assert mask is not None and mask.dtype == torch.bool
+    # All real keys visible from every query — including future positions.
+    assert torch.all(mask[0, 0, :, :3])
+    # Padding key stays hidden.
+    assert not mask[0, 0, 0, 3]
+
+
+def test_run_attention_causal_2d_mask_still_ands_causal(monkeypatch):
+    """Default (causal=True) config keeps the legacy causal AND on 2-D masks."""
+    captured = {}
+
+    def _fake_sdpa(Q, K, V, **kwargs):
+        captured["mask"] = kwargs.get("attn_mask")
+        return torch.zeros_like(Q)
+
+    monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
+
+    config = attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.SDPA,
+        n_kv_heads=1,
+        n_groups=1,
+    )
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=None,
+        attention_mask=torch.ones(1, 4, dtype=torch.long),
+        causal_mask=None,
+    )
+
+    Q = torch.zeros(1, 1, 4, 1)
+    attention_dispatch.run_attention(
+        config=config, context=context, Q=Q, K=Q.clone(), V=Q.clone()
+    )
+
+    mask = captured["mask"]
+    assert not mask[0, 0, 0, 1], "future position must be masked for causal config"
+    assert mask[0, 0, 1, 0]
+
+
+def test_run_attention_bidirectional_no_mask_disables_is_causal(monkeypatch):
+    """causal=False, mask None, q_len == k_len must not default is_causal=True."""
+    captured = {}
+
+    def _fake_sdpa(Q, K, V, **kwargs):
+        captured["is_causal"] = kwargs.get("is_causal")
+        return torch.zeros_like(Q)
+
+    monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
+
+    config = attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.SDPA,
+        n_kv_heads=1,
+        n_groups=1,
+        causal=False,  # no sdpa_kwargs — gate must come from the causal field
+    )
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=None,
+        attention_mask=None,
+        causal_mask=None,
+    )
+
+    Q = torch.zeros(1, 1, 4, 1)
+    attention_dispatch.run_attention(
+        config=config, context=context, Q=Q, K=Q.clone(), V=Q.clone()
+    )
+
+    assert captured["is_causal"] is False
+
+
+def test_run_attention_bidirectional_xformers_packed_falls_back_to_sdpa(monkeypatch):
+    """causal=False must never route packed input through the causal xformers bias."""
+    packing_utils.clear_packed_caches()
+    captured = {}
+
+    def _fake_sdpa(Q, K, V, **kwargs):
+        captured["mask"] = kwargs.get("attn_mask")
+        return torch.zeros_like(Q)
+
+    def _fail_xformers(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("xformers path must not be used for bidirectional packed")
+
+    monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
+    monkeypatch.setattr(
+        attention_dispatch, "xformers_attention", _fail_xformers, raising=False
+    )
+
+    config = attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.XFORMERS,
+        n_kv_heads=1,
+        n_groups=1,
+        causal=False,
+    )
+    seq_info = _make_seq_info([2, 2])
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+    )
+
+    Q = torch.zeros(1, 1, 4, 1)
+    attention_dispatch.run_attention(
+        config=config, context=context, Q=Q, K=Q.clone(), V=Q.clone()
+    )
+
+    mask = captured["mask"]
+    assert mask is not None and mask.shape == (1, 1, 4, 4)
+    assert mask[0, 0, 0, 1].item() == 0.0  # bidirectional inside block
+    assert mask[0, 0, 0, 2].item() == float("-inf")  # blocked across samples
+
+
+def test_run_attention_packed_lengths_exceeding_seq_len_raises(monkeypatch):
+    """#49: packed lengths summing past the actual sequence length must not pass silently."""
+    packing_utils.clear_packed_caches()
+    monkeypatch.setattr(
+        attention_dispatch,
+        "scaled_dot_product_attention",
+        lambda Q, K, V, **kwargs: torch.zeros_like(Q),
+    )
+
+    seq_info = _make_seq_info([4, 3])  # sums to 7 > q_len 5
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=5,
+        kv_seq_len=5,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+    )
+
+    Q = torch.zeros(1, 1, 5, 1)
+    with pytest.raises(ValueError, match="Packed seq_info lengths"):
+        attention_dispatch.run_attention(
+            config=_bidirectional_config(),
+            context=context,
+            Q=Q,
+            K=Q.clone(),
+            V=Q.clone(),
+        )
 
 
 def test_select_attention_backend_uses_sdpa_on_cpu_even_when_fast_paths_installed(

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -140,6 +140,32 @@ def test_mask_packed_sequence_boundaries_across_multiple_rows():
     assert torch.any(flat != -100)
 
 
+def test_mask_packed_sequence_boundaries_warns_when_lengths_overflow(caplog):
+    """#49: lengths summing past the flat buffer must emit a validation warning."""
+    shift_labels = torch.arange(5, dtype=torch.long).view(1, 5)
+    lengths = torch.tensor([3, 4], dtype=torch.int32)  # sums to 7 > 5
+
+    with caplog.at_level("WARNING", logger="unturtle.utils.packing"):
+        changed = mask_packed_sequence_boundaries(shift_labels, lengths)
+
+    assert changed is True  # first boundary (index 2) still applied
+    assert shift_labels.view(-1)[2].item() == -100
+    assert any(
+        "packed seq_lengths sum to 7" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_mask_packed_sequence_boundaries_exact_fit_does_not_warn(caplog):
+    shift_labels = torch.arange(5, dtype=torch.long).view(1, 5)
+    lengths = torch.tensor([3, 2], dtype=torch.int32)
+
+    with caplog.at_level("WARNING", logger="unturtle.utils.packing"):
+        mask_packed_sequence_boundaries(shift_labels, lengths)
+
+    assert not [r for r in caplog.records if "packed seq_lengths" in r.getMessage()]
+
+
 def test_configure_sample_packing():
     config = SimpleNamespace()
     configure_sample_packing(config)

--- a/unturtle/diffusion/block_diffusion_trainer.py
+++ b/unturtle/diffusion/block_diffusion_trainer.py
@@ -152,9 +152,11 @@ class BlockDiffusionTrainer(DiffusionTrainer):
         diffusion_mask: torch.Tensor = inputs.pop("diffusion_mask")  # [B, L]
         timesteps: torch.Tensor = inputs.pop("timesteps")  # [B]
 
-        # --- 2. Extract and discard the original attention_mask ---
-        # The block attention mask replaces it entirely.
-        inputs.pop("attention_mask", None)
+        # --- 2. Extract the original attention_mask ---
+        # The block attention mask replaces it for the forward pass, but CART
+        # loss weighting still needs the real-token mask so padding never
+        # counts as clean context.
+        padding_mask = inputs.pop("attention_mask", None)
 
         # --- 3. Reconstruct x_0 from labels (replace -100 with x_t tokens) ---
         noised_ids: torch.Tensor = inputs.pop("input_ids")  # [B, L]
@@ -208,7 +210,9 @@ class BlockDiffusionTrainer(DiffusionTrainer):
             logits = torch.cat([logits[:, :1], logits[:, :-1]], dim=1).contiguous()
 
         # --- 10. Build per-token loss weights (inherited machinery) ---
-        loss_weights = self._build_loss_weights(timesteps, logits, diffusion_mask)
+        loss_weights = self._build_loss_weights(
+            timesteps, logits, diffusion_mask, attention_mask=padding_mask
+        )
 
         # --- 11. Compute masked diffusion loss ---
         loss = fast_masked_diffusion_loss(

--- a/unturtle/diffusion/trainer.py
+++ b/unturtle/diffusion/trainer.py
@@ -309,6 +309,16 @@ class DiffusionTrainer(UnturtleTrainer):
         diffusion_mask: torch.Tensor = inputs.pop("diffusion_mask")
         timesteps: torch.Tensor = inputs.pop("timesteps")
 
+        # Batch metadata consumed (read-only) by CART loss weighting: real-token
+        # mask and, for packed batches, per-row sample lengths.  Left in
+        # ``inputs`` — the model forward also consumes them.
+        attention_mask = inputs.get("attention_mask")
+        seq_lengths = inputs.get("seq_lengths")
+        if seq_lengths is None:
+            flat_lengths = inputs.get("packed_seq_lengths")
+            if flat_lengths is not None and labels.shape[0] == 1:
+                seq_lengths = [flat_lengths]
+
         outputs = model(**inputs)
         logits: torch.Tensor = outputs.logits  # [B, L, V]
 
@@ -323,7 +333,13 @@ class DiffusionTrainer(UnturtleTrainer):
         if self._right_shift_logits:
             logits = torch.cat([logits[:, :1], logits[:, :-1]], dim=1).contiguous()
 
-        loss_weights = self._build_loss_weights(timesteps, logits, diffusion_mask)
+        loss_weights = self._build_loss_weights(
+            timesteps,
+            logits,
+            diffusion_mask,
+            attention_mask=attention_mask,
+            seq_lengths=seq_lengths,
+        )
 
         loss = fast_masked_diffusion_loss(
             logits=logits,
@@ -344,8 +360,19 @@ class DiffusionTrainer(UnturtleTrainer):
         timesteps: torch.Tensor,
         logits: torch.Tensor,
         diffusion_mask: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        seq_lengths: Any | None = None,
     ) -> torch.Tensor | None:
-        """Return per-token loss weights based on ``loss_weight_type``."""
+        """Return per-token loss weights based on ``loss_weight_type``.
+
+        Args:
+            attention_mask: optional ``[B, L]`` real-token mask.  Used by CART
+                so padding never counts as clean context.
+            seq_lengths: optional per-row packed sample lengths (list of int
+                tensors/lists, one entry per batch row — the structure the
+                packed collator emits as ``seq_lengths``).  Used by CART so
+                clean context never crosses packed-sample boundaries.
+        """
         if self._loss_weight_type == "uniform":
             return None
 
@@ -369,13 +396,41 @@ class DiffusionTrainer(UnturtleTrainer):
             #
             # Reference: dev/repos/Dream/src/trainer/fsdp_sft_trainer.py L91-115, L805-821
             weight_matrix = context_adaptive_reweight(L, cart_p=self._cart_p).to(device)
-            # clean positions: maskable but NOT currently masked
-            # diffusion_mask is True where token is masked
+            # Clean context = REAL tokens that are not currently masked.
+            # Padding (attention_mask == 0) must not contribute geometric
+            # weight, otherwise identical samples padded to different lengths
+            # get different CART weights.
             clean_mask = ~diffusion_mask  # [B, L] — True at clean/unmasked positions
-            # weight[b, n] = sum of geometric weights from clean positions to n
-            weight = clean_mask.float().matmul(weight_matrix)  # [B, L]
-            # masked positions that are themselves clean get zero weight
-            weight = weight.masked_fill(clean_mask, 0.0)
+            if attention_mask is not None:
+                clean_mask = clean_mask & attention_mask.to(
+                    device=clean_mask.device, dtype=torch.bool
+                )
+            clean_f = clean_mask.float()
+            if seq_lengths is not None:
+                # Packed rows: clean context must not cross sample boundaries.
+                # The geometric weight is translation-invariant, so restricting
+                # the matmul to each sample's diagonal block reproduces the
+                # unpacked per-sample weights exactly.
+                weight = torch.zeros(
+                    diffusion_mask.shape, dtype=weight_matrix.dtype, device=device
+                )
+                for b, lengths in enumerate(seq_lengths):
+                    if isinstance(lengths, torch.Tensor):
+                        lengths = lengths.tolist()
+                    offset = 0
+                    for slen in lengths:
+                        end = min(offset + int(slen), L)
+                        if end <= offset:
+                            continue
+                        weight[b, offset:end] = clean_f[b, offset:end].matmul(
+                            weight_matrix[offset:end, offset:end]
+                        )
+                        offset = end
+            else:
+                # weight[b, n] = sum of geometric weights from clean positions to n
+                weight = clean_f.matmul(weight_matrix)  # [B, L]
+            # zero everywhere the diffusion loss is not computed (clean + pad)
+            weight = weight.masked_fill(~diffusion_mask, 0.0)
             return weight  # [B, L]
 
         raise ValueError(

--- a/unturtle/kernels/fast_lora.py
+++ b/unturtle/kernels/fast_lora.py
@@ -133,7 +133,9 @@ class LoRA_QKV_Bias(torch.autograd.Function):
         X, QA, QB, KA, KB, VA, VB = ctx.saved_tensors
         has_Qb, has_Kb, has_Vb = ctx.has_bias
 
-        batch, seq_len, hd = X.shape
+        # X may be 3-D [batch, seq_len, hd] or 2-D [total_tokens, hd]
+        # (forward accepts both); mirror the same reshape bookkeeping here.
+        orig_shape = X.shape
         dQ = dQ.reshape(-1, dQ.shape[-1])
         dK = dK.reshape(-1, dK.shape[-1])
         dV = dV.reshape(-1, dV.shape[-1])
@@ -185,7 +187,7 @@ class LoRA_QKV_Bias(torch.autograd.Function):
         # KW, KW_quant, KA, KB, KS, KBias,
         # VW, VW_quant, VA, VB, VS, VBias, inplace
         return (
-            dX.view(batch, seq_len, hd),
+            dX.view(orig_shape),
             None,
             None,
             d_QA.t(),

--- a/unturtle/kernels/fused_masked_diffusion_loss.py
+++ b/unturtle/kernels/fused_masked_diffusion_loss.py
@@ -115,14 +115,22 @@ def fused_masked_diffusion_loss(
             logit_scaling,
         )  # [B*L], float32
     else:
-        # CPU fallback — identical semantics to fast_masked_diffusion_loss.
+        # Non-CUDA fallback — mirrors the Triton kernel's semantics exactly:
+        # logit scaling (Cohere: s * x) is applied BEFORE softcapping
+        # (Gemma-2: t * tanh(x / t)).  See unsloth
+        # kernels/cross_entropy_loss.py (_cross_entropy_forward).
         fused_labels = torch.where(
             flat_mask,
             flat_labels,
-            torch.tensor(-100, dtype=torch.long),
+            _get_neg100(flat_labels.device),
         )
+        ce_logits = logits.view(B * L, V)
+        if logit_scaling != 0:
+            ce_logits = ce_logits * logit_scaling
+        if logit_softcapping != 0:
+            ce_logits = logit_softcapping * torch.tanh(ce_logits / logit_softcapping)
         per_token_loss = F.cross_entropy(
-            logits.view(B * L, V),
+            ce_logits,
             fused_labels,
             ignore_index=-100,
             reduction="none",

--- a/unturtle/models/conversion/a2d/tiny_a2d/_fast_forward.py
+++ b/unturtle/models/conversion/a2d/tiny_a2d/_fast_forward.py
@@ -332,6 +332,9 @@ def TinyA2DAttention_fast_forward(
         flash_dense_kwargs={"causal": False},
         flash_varlen_kwargs={"dropout_p": 0.0, "causal": False},
         sdpa_kwargs={"is_causal": False},
+        # dLLM attention is bidirectional: run_attention must never inject
+        # causal masking (packed fallback mask, 2-D mask expansion, is_causal).
+        causal=False,
     )
     context = AttentionContext(
         bsz=bsz,

--- a/unturtle/utils/attention_dispatch.py
+++ b/unturtle/utils/attention_dispatch.py
@@ -29,6 +29,7 @@ from unsloth.models._utils import HAS_FLASH_ATTENTION, xformers, xformers_attent
 
 from .packing import (
     build_sdpa_packed_attention_mask,
+    build_sdpa_packed_bidirectional_attention_mask,
     build_xformers_block_causal_mask,
 )
 
@@ -65,6 +66,14 @@ class AttentionConfig:
     flash_varlen_kwargs: Optional[dict[str, Any]] = None
     sdpa_kwargs: Optional[dict[str, Any]] = None
     xformers_kwargs: Optional[dict[str, Any]] = None
+    # Whether run_attention may inject *causal* masking on the SDPA path
+    # (packed block mask, 2-D mask expansion, and the is_causal fallback).
+    # Defaults to True to preserve the vendored unsloth (AR) semantics.
+    # Bidirectional dLLM callers MUST set causal=False — with it, run_attention
+    # never constructs a causal mask on their behalf.  Note this flag does NOT
+    # rewrite caller-supplied kwargs (flash_*_kwargs["causal"] /
+    # sdpa_kwargs["is_causal"]); keep those consistent with this field.
+    causal: bool = True
 
 
 @dataclass
@@ -112,6 +121,13 @@ def run_attention(
         FLASH_VARLEN,
         XFORMERS,
     ):
+        backend = SDPA
+
+    if backend == XFORMERS and context.seq_info is not None and not config.causal:
+        # The xformers packed path builds a *causal* block-diagonal bias
+        # (build_xformers_block_causal_mask).  Bidirectional configs must not
+        # receive causal masking, so fall back to the SDPA packed path which
+        # builds a bidirectional block mask below.
         backend = SDPA
 
     flash_dense_kwargs = config.flash_dense_kwargs or {}
@@ -220,12 +236,25 @@ def run_attention(
     local_mask = context.attention_mask
     is_causal_local = False
     if context.seq_info is not None and local_mask is None:
-        local_mask = build_sdpa_packed_attention_mask(
+        packed_mask_builder = (
+            build_sdpa_packed_attention_mask
+            if config.causal
+            else build_sdpa_packed_bidirectional_attention_mask
+        )
+        local_mask = packed_mask_builder(
             context.seq_info,
             dtype=Q.dtype,
             device=Q.device,
             sliding_window=sliding_window,
         )
+        # Debug guard (#49): packed lengths silently summing past the actual
+        # sequence length would otherwise surface as an opaque SDPA shape error.
+        if local_mask.shape[-1] != K.shape[-2]:
+            raise ValueError(
+                f"Packed seq_info lengths sum to {local_mask.shape[-1]} but the "
+                f"key sequence length is {K.shape[-2]}; packed metadata does "
+                "not match the batch."
+            )
     else:
         q_len_local = Q.shape[-2]
         k_len_local = K.shape[-2]
@@ -242,13 +271,23 @@ def run_attention(
                 q_pos = torch.arange(past_len, past_len + q_len_local, device=Q.device)
                 k_pos = torch.arange(k_len_local, device=Q.device)
 
-                causal_keep = k_pos[None, :] <= q_pos[:, None]
-                if sliding_window is not None:
-                    causal_keep &= k_pos[None, :] >= (
-                        q_pos[:, None] - (sliding_window - 1)
+                if config.causal:
+                    pos_keep = k_pos[None, :] <= q_pos[:, None]
+                    if sliding_window is not None:
+                        pos_keep &= k_pos[None, :] >= (
+                            q_pos[:, None] - (sliding_window - 1)
+                        )
+                elif sliding_window is not None:
+                    # Bidirectional: symmetric band, never a causal triangle.
+                    pos_keep = (q_pos[:, None] - k_pos[None, :]).abs() < sliding_window
+                else:
+                    pos_keep = torch.ones(
+                        (q_len_local, k_len_local),
+                        dtype=torch.bool,
+                        device=Q.device,
                     )
 
-                local_mask = causal_keep[None, None, :, :] & key_keep[:, None, None, :]
+                local_mask = pos_keep[None, None, :, :] & key_keep[:, None, None, :]
 
             elif local_mask.dim() == 3:
                 local_mask = local_mask[:, None, :, :]
@@ -265,7 +304,9 @@ def run_attention(
                 no_allowed = ~local_mask.any(dim=-1, keepdim=True)
                 local_mask = local_mask | no_allowed
 
-        is_causal_local = local_mask is None and q_len_local == k_len_local
+        is_causal_local = (
+            config.causal and local_mask is None and q_len_local == k_len_local
+        )
 
     kwargs = dict(sdpa_kwargs)
     kwargs.setdefault("attn_mask", local_mask)
@@ -317,6 +358,7 @@ __all__ = [
     "SDPA",
     "XFORMERS",
     "build_sdpa_packed_attention_mask",
+    "build_sdpa_packed_bidirectional_attention_mask",
     "build_xformers_block_causal_mask",
     "run_attention",
     "select_attention_backend",

--- a/unturtle/utils/packing.py
+++ b/unturtle/utils/packing.py
@@ -44,6 +44,11 @@ _PACKED_INFO_CACHE: dict = {}
 # Cache per device for build_sdpa_packed_attention_mask to avoid repeated D2H sync across layers
 _SDPA_MASK_CACHE: dict = {}
 
+# Cache per device for build_sdpa_packed_bidirectional_attention_mask
+_SDPA_BIDIRECTIONAL_MASK_CACHE: dict = {}
+
+logger = logging.getLogger(__name__)
+
 # Cache per device for build_xformers_block_causal_mask to avoid repeated D2H sync across layers
 _XFORMERS_BLOCK_MASK_CACHE: dict = {}
 
@@ -348,6 +353,65 @@ def build_sdpa_packed_attention_mask(
     return result
 
 
+def build_sdpa_packed_bidirectional_attention_mask(
+    seq_info: Tuple[torch.Tensor, torch.Tensor, int],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+    sliding_window: Optional[int] = None,
+) -> torch.Tensor:
+    """Block-diagonal *bidirectional* SDPA mask for packed dLLM attention.
+
+    Same block-diagonal structure as :func:`build_sdpa_packed_attention_mask`
+    but WITHOUT the causal (upper-triangular) fill inside each block — every
+    token in a packed sample attends to every other token of the same sample.
+    An optional ``sliding_window`` applies a symmetric band
+    (``|q - k| < sliding_window``) inside each block.
+    """
+    seq_lengths, _, _ = seq_info
+
+    params = (dtype, sliding_window)
+    entry = _SDPA_BIDIRECTIONAL_MASK_CACHE.get(device)
+    if (
+        entry is not None
+        and entry["seq_lengths"] is seq_lengths
+        and entry["params"] == params
+    ):
+        return entry["mask"]
+
+    total_tokens = int(seq_lengths.sum().item())
+    mask = torch.full(
+        (total_tokens, total_tokens),
+        float("-inf"),
+        dtype=dtype,
+        device=device,
+    )
+    offset = 0
+    for length in seq_lengths.tolist():
+        length = int(length)
+        if length <= 0:
+            continue
+        block = torch.zeros((length, length), dtype=dtype, device=device)
+        if (
+            sliding_window is not None
+            and sliding_window > 0
+            and length > sliding_window
+        ):
+            idx = torch.arange(length, device=device)
+            dist = (idx.unsqueeze(1) - idx.unsqueeze(0)).abs()
+            block = block.masked_fill(dist >= sliding_window, float("-inf"))
+        mask[offset : offset + length, offset : offset + length] = block
+        offset += length
+
+    result = mask.unsqueeze(0).unsqueeze(0)
+    _SDPA_BIDIRECTIONAL_MASK_CACHE[device] = {
+        "seq_lengths": seq_lengths,
+        "params": params,
+        "mask": result,
+    }
+    return result
+
+
 def _normalize_packed_lengths(
     seq_lengths: Any,
     *,
@@ -382,6 +446,14 @@ def mask_packed_sequence_boundaries(
     boundary_positions = torch.cumsum(lengths, dim=0) - 1
     valid = boundary_positions < total_tokens
     if not torch.all(valid):
+        # Debug guard (#49): packed lengths silently summing past the flat
+        # buffer means the collator metadata and the batch disagree.
+        logger.warning(
+            "mask_packed_sequence_boundaries: packed seq_lengths sum to %d but "
+            "only %d tokens are available; boundaries past the buffer are ignored.",
+            int(boundary_positions[-1].item()) + 1,
+            total_tokens,
+        )
         boundary_positions = boundary_positions[valid]
     if boundary_positions.numel() == 0:
         return False
@@ -393,6 +465,7 @@ def clear_packed_caches():
     """Release cached masks/metadata to free device memory."""
     _PACKED_INFO_CACHE.clear()
     _SDPA_MASK_CACHE.clear()
+    _SDPA_BIDIRECTIONAL_MASK_CACHE.clear()
     _XFORMERS_BLOCK_MASK_CACHE.clear()
 
 
@@ -405,6 +478,7 @@ __all__ = [
     "get_packed_info_from_kwargs",
     "build_xformers_block_causal_mask",
     "build_sdpa_packed_attention_mask",
+    "build_sdpa_packed_bidirectional_attention_mask",
     "mask_packed_sequence_boundaries",
     "clear_packed_caches",
 ]


### PR DESCRIPTION
Refs #48, #49.

## What
- **attention_dispatch causal gating**: new `AttentionConfig.causal` field (default True preserves every existing call site byte-for-byte — only one production constructor exists and it now sets `causal=False`). Bidirectional configs can no longer get causal masking injected at any of the three fallback sites; packed+no-mask builds a new bidirectional block-diagonal mask (`build_sdpa_packed_bidirectional_attention_mask`, symmetric sliding window); xformers packed path (inherently causal bias) falls back to SDPA when bidirectional; built-mask-vs-key-length mismatch now raises an actionable ValueError.
- **Fused-loss CPU fallback parity**: applies `logit_scaling` then `logit_softcapping` (exact order of unsloth's Triton kernel — verified against source; GPU parity 6.022698 vs 6.022699) and builds the −100 sentinel on the labels device (MPS/XPU-safe).
- **`LoRA_QKV_Bias` 2-D backward**: `orig_shape` bookkeeping; forward already accepted 2-D, backward crashed. GPU0-verified (grads match 3-D reference, inplace both ways).
- **CART clean-context membership**: padding and packed-neighbor tokens no longer count as clean context — clean mask ANDs `attention_mask`, packed rows compute per-sample diagonal blocks (translation-invariance makes this exactly equal to unpacked; CPU-verified). Wired through both `DiffusionTrainer` and `BlockDiffusionTrainer`.
- **Packed-length overflow guards** (#49): warning when claimed lengths exceed the buffer.

## Review
Training-side reference review: all areas MERGE-READY; causal-gating default-preservation confirmed by grepping all AttentionConfig constructions; CART translation-invariance and pad-exclusion verified by independent CPU repros; no regression on the merged #44/#45 fixes.

## Test plan
- [x] tests/utils 24 passed; tests/diffusion 223 passed; tests/models/test_a2d.py green; ruff clean