### PR TITLE
🐛 fix(eval/cli): merged-16bit dequant, harness decode pinning, boxed parsing, load kwargs, CLI validation (#48/#49 follow-ups)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,9 @@ cd "$(dirname "$0")"
 # version differs from the venv's interpreter ("No virtual environment found
 # for Python X.Y.Z"). This script manages its own venv, so drop the pin and
 # target .venv explicitly.
+if [[ -n "${UV_PYTHON:-}" ]]; then
+    echo "note: ignoring user-level UV_PYTHON=${UV_PYTHON} — this script manages its own venv (.venv, python \${PYTHON_VERSION:-3.12})"
+fi
 unset UV_PYTHON UV_PROJECT_ENVIRONMENT 2>/dev/null || true
 export VIRTUAL_ENV="$PWD/.venv"
 

--- a/tests/eval/test_gsm8k.py
+++ b/tests/eval/test_gsm8k.py
@@ -52,6 +52,29 @@ class TestExtractNumericAnswer:
     def test_boxed_takes_priority_over_bare(self):
         assert extract_numeric_answer(r"99 and \boxed{42}") == 42.0
 
+    # --- non-numeric boxed content: extract the number INSIDE the box -----
+
+    def test_boxed_dollar_sign(self):
+        assert extract_numeric_answer(r"the total is \boxed{$72}") == 72.0
+
+    def test_boxed_trailing_words(self):
+        assert extract_numeric_answer(r"answer: \boxed{72 dollars}") == 72.0
+
+    def test_boxed_dollar_with_commas(self):
+        assert extract_numeric_answer(r"cost \boxed{$1,234}") == 1234.0
+
+    def test_boxed_dollar_negative(self):
+        assert extract_numeric_answer(r"net \boxed{$-5}") == -5.0
+
+    def test_boxed_number_beats_text_before_box(self):
+        # The number inside the box wins over earlier bare numbers.
+        assert extract_numeric_answer(r"first 99 then \boxed{72 dollars}") == 72.0
+
+    def test_boxed_without_any_number_falls_back_before_box(self):
+        # Boxed content with NO number: fall back to text before the marker,
+        # never to text after it.
+        assert extract_numeric_answer(r"we get 17 so \boxed{unknown} 99") == 17.0
+
 
 # ---------------------------------------------------------------------------
 # Stub model — mimics generate behaviour without real weights

--- a/tests/eval/test_harness_adapter.py
+++ b/tests/eval/test_harness_adapter.py
@@ -133,9 +133,18 @@ def test_normalize_until_variants() -> None:
     assert _normalize_until(["a", "b"]) == ["a", "b"]
 
 
-def test_generate_until_respects_max_gen_toks_override(
+def test_generate_until_pins_decoding_config_over_task_max_gen_toks(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """Task-supplied max_gen_toks must NOT override the pinned DecodingConfig.
+
+    The runner records DecodingConfig.max_new_tokens with the score; the decode
+    must match the record (reproducibility contract). A differing task value is
+    ignored with a warning.
+    """
+    import logging
+
     _install_fake_lm_eval(monkeypatch)
     from unturtle.eval.harness.model_adapter import build_harness_lm
 
@@ -148,8 +157,38 @@ def test_generate_until_respects_max_gen_toks_override(
         temperature=0.0,
         use_chat_template=False,
     )
-    lm.generate_until([_FakeInstance("Q", {"until": [], "max_gen_toks": 5})])
-    assert model.calls[-1]["max_length"] == 9
+    with caplog.at_level(logging.WARNING, logger="unturtle.eval.harness.model_adapter"):
+        lm.generate_until([_FakeInstance("Q", {"until": [], "max_gen_toks": 5})])
+    # prompt_len=4 + pinned max_new_tokens=8 — NOT 4 + 5.
+    assert model.calls[-1]["max_length"] == 12
+    assert any(
+        "max_gen_toks" in rec.message and "ignored" in rec.message
+        for rec in caplog.records
+    ), "expected a warning that task max_gen_toks was ignored"
+
+
+def test_generate_until_no_warning_when_max_gen_toks_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
+    _install_fake_lm_eval(monkeypatch)
+    from unturtle.eval.harness.model_adapter import build_harness_lm
+
+    model = _StubModel()
+    lm = build_harness_lm(
+        model=model,
+        tokenizer=_StubTokenizer(),
+        num_steps=4,
+        max_new_tokens=8,
+        temperature=0.0,
+        use_chat_template=False,
+    )
+    with caplog.at_level(logging.WARNING, logger="unturtle.eval.harness.model_adapter"):
+        lm.generate_until([_FakeInstance("Q", {"until": [], "max_gen_toks": 8})])
+    assert model.calls[-1]["max_length"] == 12
+    assert not caplog.records
 
 
 def test_loglikelihood_raises_not_implemented(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -251,3 +251,100 @@ def test_list_checkpoints_reports_unreadable_trainer_state(tmp_path, capsys):
     captured = capsys.readouterr()
     assert "unreadable trainer_state.json" in captured.out
     assert "Warning: failed to read loss" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# CLI override validation — Config.apply_overrides / _SectionConfig
+# ---------------------------------------------------------------------------
+
+
+def test_apply_overrides_invalid_literal_raises_immediately():
+    # setattr used to bypass pydantic validation: an invalid --task/--model-type
+    # only failed late (or silently). validate_assignment must reject it here.
+    from unturtle.cli.config import Config
+
+    cfg = Config()
+    with pytest.raises(ValueError, match=r"--task"):
+        cfg.apply_overrides(task="not-a-task")
+
+    with pytest.raises(ValueError, match=r"--model-type"):
+        cfg.apply_overrides(model_type="not-a-model-type")
+
+
+def test_apply_overrides_valid_values_still_apply():
+    from unturtle.cli.config import Config
+
+    cfg = Config()
+    cfg.apply_overrides(task="grpo", model_type="llada", learning_rate=1e-4)
+    assert cfg.training.task == "grpo"
+    assert cfg.model.model_type == "llada"
+    assert cfg.training.learning_rate == 1e-4
+
+
+def test_train_invalid_override_exits_with_clear_error(capsys):
+    config_path = CONFIG_DIR / "llada_sft.yaml"
+    # The add_options_from_config wrapper rebuilds config_overrides from field
+    # kwargs, so the override is passed as `task=` (as the CLI would).
+    with pytest.raises(Exit) as exc_info:
+        train(config=config_path, dry_run=True, task="bogus")
+    assert exc_info.value.exit_code == 2
+    captured = capsys.readouterr()
+    assert "Invalid value for --task" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# export --load-in-4bit default is format-aware
+# ---------------------------------------------------------------------------
+
+
+def _run_export_capture_load_kwargs(monkeypatch, tmp_path, *, format, load_in_4bit):
+    from unturtle import fast_diffusion_model as fdm
+    from unturtle.cli.commands.export import export
+
+    recorded = {}
+
+    def _fake_from_pretrained(**kwargs):
+        recorded.update(kwargs)
+        raise RuntimeError("stop after recording")
+
+    monkeypatch.setattr(
+        fdm.FastDiffusionModel, "from_pretrained", staticmethod(_fake_from_pretrained)
+    )
+    with pytest.raises(Exit) as exc_info:
+        export(
+            checkpoint=tmp_path,
+            output_dir=tmp_path / "out",
+            format=format,
+            quantization="q4_k_m",
+            push_to_hub=False,
+            repo_id=None,
+            hf_token=None,
+            private=False,
+            max_seq_length=2048,
+            load_in_4bit=load_in_4bit,
+        )
+    assert exc_info.value.exit_code == 1  # load intentionally aborted
+    return recorded
+
+
+def test_export_merged_16bit_defaults_to_16bit_load(monkeypatch, tmp_path):
+    recorded = _run_export_capture_load_kwargs(
+        monkeypatch, tmp_path, format="merged-16bit", load_in_4bit=None
+    )
+    assert recorded["load_in_4bit"] is False
+
+
+def test_export_lora_defaults_to_4bit_load(monkeypatch, tmp_path):
+    recorded = _run_export_capture_load_kwargs(
+        monkeypatch, tmp_path, format="lora", load_in_4bit=None
+    )
+    assert recorded["load_in_4bit"] is True
+
+
+def test_export_merged_16bit_explicit_4bit_warns(monkeypatch, tmp_path, capsys):
+    recorded = _run_export_capture_load_kwargs(
+        monkeypatch, tmp_path, format="merged-16bit", load_in_4bit=True
+    )
+    assert recorded["load_in_4bit"] is True  # explicit choice honored
+    captured = capsys.readouterr()
+    assert "dequantized" in captured.err

--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -715,6 +715,45 @@ class TestLoRAQKVBias:
         assert QB.grad is not None
         assert QBias.grad is not None
 
+    def test_2d_input_forward_and_backward(self):
+        """2-D X [total_tokens, D] (padding-free) must round-trip fwd+bwd.
+
+        The backward reshape bookkeeping previously assumed 3-D X
+        (``batch, seq_len, hd = X.shape``) even though forward accepts 2-D.
+        Gradients for the flattened input must match the 3-D equivalent.
+        """
+        from unturtle.kernels.fast_lora import LoRA_QKV_Bias
+
+        torch.manual_seed(3)
+        B, L, D, R = 2, 4, 16, 2
+        base = torch.randn(B, L, D)
+        QW = torch.randn(D, D)
+        QA = torch.randn(R, D)
+        QB = torch.randn(D, R)
+        QBias = torch.randn(D)
+        scale = 1.0
+
+        def _run(X):
+            args = []
+            for _ in range(3):
+                args += [QW, None, QA, QB, scale, QBias]
+            Q, K, V = LoRA_QKV_Bias.apply(X, *args, False)
+            return Q, K, V
+
+        X3 = base.clone().requires_grad_(True)
+        Q3, K3, V3 = _run(X3)
+        (Q3.square().sum() + K3.sum() + V3.sum()).backward()
+
+        X2 = base.clone().reshape(B * L, D).requires_grad_(True)
+        Q2, K2, V2 = _run(X2)
+        assert Q2.shape == (B * L, D)
+        (Q2.square().sum() + K2.sum() + V2.sum()).backward()
+
+        assert X2.grad is not None
+        assert X2.grad.shape == (B * L, D)
+        assert torch.allclose(X2.grad, X3.grad.reshape(B * L, D), atol=1e-5)
+        assert torch.allclose(Q2, Q3.reshape(B * L, D), atol=1e-5)
+
 
 class TestDreamPatching:
     @pytest.mark.skipif(
@@ -1659,3 +1698,262 @@ class TestPostLoadClassSwap:
         fdm._apply_post_load_class_swap(m)
         # Unregistered — instance attribute must be preserved
         assert m.__dict__.get("generate") is sentinel
+
+
+# ---------------------------------------------------------------------------
+# FastModel kwarg forwarding — _load_via_fastmodel
+# ---------------------------------------------------------------------------
+
+
+class TestFastModelKwargForwarding:
+    def test_forwards_revision_cache_dir_and_extras(self, monkeypatch):
+        """User kwargs (revision, cache_dir, subfolder, attn_implementation, …)
+        must reach FastModel.from_pretrained instead of being silently dropped."""
+        calls = {}
+
+        class _FakeFastModel:
+            @staticmethod
+            def from_pretrained(model_name, **kwargs):
+                calls["kwargs"] = kwargs
+                return "M", "T"
+
+        from unturtle import fast_diffusion_model as fdm
+
+        monkeypatch.setattr(fdm, "_import_fastmodel", lambda: _FakeFastModel)
+        out = fdm._load_via_fastmodel(
+            "some/hub-model",
+            {
+                "torch_dtype": "bf16",
+                "revision": "abc123",
+                "cache_dir": "/tmp/hf",
+                "subfolder": "sub",
+                "attn_implementation": "sdpa",
+                "token": "tok",
+            },
+            load_in_4bit=False,
+        )
+        assert out == ("M", "T")
+        kw = calls["kwargs"]
+        assert kw["dtype"] == "bf16"  # torch_dtype → dtype rename
+        assert "torch_dtype" not in kw
+        assert kw["revision"] == "abc123"
+        assert kw["cache_dir"] == "/tmp/hf"
+        assert kw["subfolder"] == "sub"
+        assert kw["attn_implementation"] == "sdpa"
+        assert kw["token"] == "tok"
+        assert kw["load_in_4bit"] is False
+
+    def test_quantization_config_not_forwarded(self, monkeypatch):
+        """FastModel owns quantization on this path — quantization_config is an
+        intentional skip, threaded through as load_in_4bit instead."""
+        calls = {}
+
+        class _FakeFastModel:
+            @staticmethod
+            def from_pretrained(model_name, **kwargs):
+                calls["kwargs"] = kwargs
+                return "M", "T"
+
+        from unturtle import fast_diffusion_model as fdm
+
+        monkeypatch.setattr(fdm, "_import_fastmodel", lambda: _FakeFastModel)
+        fdm._load_via_fastmodel(
+            "x", {"quantization_config": object(), "revision": "r"}, load_in_4bit=True
+        )
+        assert "quantization_config" not in calls["kwargs"]
+        assert calls["kwargs"]["load_in_4bit"] is True
+        assert calls["kwargs"]["revision"] == "r"
+
+    def test_unaccepted_kwargs_dropped_with_warning(self, monkeypatch):
+        """Keys a non-**kwargs FastModel signature cannot take are dropped loudly."""
+        calls = {}
+        warnings_seen: list[str] = []
+
+        class _FakeStrictFastModel:
+            @staticmethod
+            def from_pretrained(
+                model_name, dtype=None, revision=None, load_in_4bit=True
+            ):
+                calls["kwargs"] = {
+                    "dtype": dtype,
+                    "revision": revision,
+                    "load_in_4bit": load_in_4bit,
+                }
+                return "M", "T"
+
+        from unturtle import fast_diffusion_model as fdm
+
+        monkeypatch.setattr(fdm, "_import_fastmodel", lambda: _FakeStrictFastModel)
+        monkeypatch.setattr(fdm, "_warn_once", warnings_seen.append)
+        out = fdm._load_via_fastmodel(
+            "x",
+            {"torch_dtype": "bf16", "revision": "r", "not_a_real_kwarg": 1},
+            load_in_4bit=False,
+        )
+        assert out == ("M", "T")
+        assert calls["kwargs"]["revision"] == "r"
+        assert any("not_a_real_kwarg" in w for w in warnings_seen)
+
+
+# ---------------------------------------------------------------------------
+# 4-bit load fallback — _load_model_with_optional_4bit_fallback
+# ---------------------------------------------------------------------------
+
+
+class TestFourBitFallback:
+    def test_oom_is_reraised_not_retried(self, monkeypatch):
+        """OOM must NOT trigger the full-precision retry (which needs MORE memory)."""
+        from unturtle import fast_diffusion_model as fdm
+
+        attempts = []
+
+        class _OOMLoader:
+            @staticmethod
+            def from_pretrained(model_name, **kwargs):
+                attempts.append(kwargs)
+                raise torch.cuda.OutOfMemoryError("CUDA out of memory")
+
+        with pytest.raises(torch.cuda.OutOfMemoryError):
+            fdm._load_model_with_optional_4bit_fallback(
+                _OOMLoader, "x", {"quantization_config": object()}
+            )
+        assert len(attempts) == 1  # no retry
+
+    def test_genuine_4bit_failure_falls_back_with_exception_in_warning(
+        self, monkeypatch
+    ):
+        from unturtle import fast_diffusion_model as fdm
+
+        warnings_seen: list[str] = []
+        monkeypatch.setattr(fdm, "_warn_once", warnings_seen.append)
+        attempts = []
+
+        class _FlakyLoader:
+            @staticmethod
+            def from_pretrained(model_name, **kwargs):
+                attempts.append(dict(kwargs))
+                if "quantization_config" in kwargs:
+                    raise ValueError("bnb kaboom")
+                return "FULL_PRECISION_MODEL"
+
+        out = fdm._load_model_with_optional_4bit_fallback(
+            _FlakyLoader, "x", {"quantization_config": object(), "device_map": "auto"}
+        )
+        assert out == "FULL_PRECISION_MODEL"
+        assert len(attempts) == 2
+        assert "quantization_config" not in attempts[1]
+        # The warning must carry the original exception type + message
+        assert any("ValueError" in w and "bnb kaboom" in w for w in warnings_seen)
+
+
+# ---------------------------------------------------------------------------
+# Merged-16bit honesty — _dequantize_merged_model_ / save_pretrained_merged
+# ---------------------------------------------------------------------------
+
+
+class _FakeQuantState:
+    dtype = torch.float16
+
+
+def _make_fake_quantized_linear(in_features: int, out_features: int) -> torch.nn.Linear:
+    """nn.Linear whose weight mimics a bnb Params4bit (has .quant_state)."""
+    lin = torch.nn.Linear(in_features, out_features, bias=True)
+    packed = torch.zeros((out_features * in_features) // 2, 1, dtype=torch.uint8)
+    w = torch.nn.Parameter(packed, requires_grad=False)
+    w.quant_state = _FakeQuantState()
+    lin.weight = w
+    lin.in_features = in_features
+    lin.out_features = out_features
+    return lin
+
+
+class _FakeModelConfig:
+    def __init__(self):
+        # Instance attribute, like transformers' PretrainedConfig — `del` must work.
+        self.quantization_config = {"quant_method": "bitsandbytes"}
+
+
+class _FakeQuantizedModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = _make_fake_quantized_linear(4, 8)
+        self.config = _FakeModelConfig()
+
+
+class TestMergedSaveDequantizes:
+    def test_dequantize_replaces_quantized_linear(self, monkeypatch):
+        from unturtle import fast_diffusion_model as fdm
+
+        class _FakeBnb:
+            class functional:
+                @staticmethod
+                def dequantize_4bit(data, quant_state):
+                    return torch.zeros(8, 4, dtype=torch.float16)
+
+        monkeypatch.setattr(fdm, "_import_bitsandbytes", lambda: _FakeBnb)
+        model = _FakeQuantizedModel()
+        out = fdm._dequantize_merged_model_(model)
+
+        assert isinstance(out.proj, torch.nn.Linear)
+        assert out.proj.weight.dtype == torch.float16
+        assert out.proj.weight.shape == (8, 4)
+        assert getattr(out.proj.weight, "quant_state", None) is None
+        # Stale 4-bit metadata must not survive into the saved config
+        assert not hasattr(out.config, "quantization_config")
+
+    def test_bitsandbytes_unavailable_raises_clear_error(self, monkeypatch):
+        from unturtle import fast_diffusion_model as fdm
+
+        def _boom():
+            raise ImportError("no bitsandbytes")
+
+        monkeypatch.setattr(fdm, "_import_bitsandbytes", _boom)
+        with pytest.raises(RuntimeError, match="load_in_4bit=False"):
+            fdm._dequantize_merged_model_(_FakeQuantizedModel())
+
+    def test_dequantize_failure_raises_clear_error(self, monkeypatch):
+        from unturtle import fast_diffusion_model as fdm
+
+        class _FakeBnb:
+            class functional:
+                @staticmethod
+                def dequantize_4bit(data, quant_state):
+                    raise ValueError("bad quant_state")
+
+        monkeypatch.setattr(fdm, "_import_bitsandbytes", lambda: _FakeBnb)
+        with pytest.raises(RuntimeError, match="load_in_4bit=False"):
+            fdm._dequantize_merged_model_(_FakeQuantizedModel())
+
+    def test_non_quantized_model_untouched(self):
+        from unturtle import fast_diffusion_model as fdm
+
+        model = torch.nn.Linear(4, 8)
+        assert fdm._dequantize_merged_model_(model) is model
+
+    def test_save_pretrained_merged_refuses_mislabeled_4bit(self, monkeypatch):
+        """End-to-end: merged save on a 4-bit model must error, never save nf4."""
+        from unturtle import fast_diffusion_model as fdm
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        def _boom():
+            raise ImportError("no bitsandbytes")
+
+        monkeypatch.setattr(fdm, "_import_bitsandbytes", _boom)
+
+        saved: list[bool] = []
+
+        class _FakePeft(torch.nn.Module):
+            # merge_and_unload builds the quantized model at call time (after
+            # save_pretrained_merged's deepcopy — torch's Parameter deepcopy
+            # would strip the fake quant_state marker).
+            def merge_and_unload(self):
+                merged = _FakeQuantizedModel()
+                merged.save_pretrained = lambda *a, **k: saved.append(True)
+                return merged
+
+        model = _FakePeft()
+        with pytest.raises(RuntimeError, match="16-bit"):
+            FastDiffusionModel.save_pretrained_merged(
+                model, "/nonexistent/should-not-write"
+            )
+        assert saved == []

--- a/unturtle/cli/commands/export.py
+++ b/unturtle/cli/commands/export.py
@@ -114,7 +114,15 @@ def export(
         False, "--private", help="Make the HuggingFace repo private."
     ),
     max_seq_length: int = typer.Option(2048, "--max-seq-length"),
-    load_in_4bit: bool = typer.Option(True, "--load-in-4bit/--no-load-in-4bit"),
+    load_in_4bit: Optional[bool] = typer.Option(
+        None,
+        "--load-in-4bit/--no-load-in-4bit",
+        help=(
+            "Load the checkpoint in 4-bit before exporting. Default: false for "
+            "merged-16bit (a 16-bit artifact must come from 16-bit weights), "
+            "true for lora/gguf."
+        ),
+    ),
 ):
     """Export a checkpoint to various formats (merged-16bit, lora, gguf)."""
     if format not in EXPORT_FORMATS:
@@ -136,6 +144,19 @@ def export(
     if push_to_hub and not repo_id:
         typer.echo("Error: --repo-id is required when using --push-to-hub", err=True)
         raise typer.Exit(code=2)
+
+    # merged-16bit must be exported from a 16-bit load: merging into 4-bit bnb
+    # Linear4bit weights would either fail loudly at save time (dequant guard)
+    # or lose precision. Other formats keep the memory-friendly 4-bit default.
+    if load_in_4bit is None:
+        load_in_4bit = format != "merged-16bit"
+    elif load_in_4bit and format == "merged-16bit":
+        typer.echo(
+            "Warning: --load-in-4bit with --format merged-16bit — merged weights "
+            "will be dequantized from nf4 before saving (lossy vs a 16-bit load). "
+            "Prefer --no-load-in-4bit for this format.",
+            err=True,
+        )
 
     try:
         from unturtle import FastDiffusionModel

--- a/unturtle/cli/commands/train.py
+++ b/unturtle/cli/commands/train.py
@@ -107,7 +107,11 @@ def train(
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(code=2)
 
-    cfg.apply_overrides(**config_overrides)
+    try:
+        cfg.apply_overrides(**config_overrides)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(code=2)
 
     # CLI/env tokens override config file values
     from typer.models import OptionInfo
@@ -201,7 +205,20 @@ def train(
             from datasets import load_dataset
 
             dataset = load_dataset(cfg.data.dataset, token=hf_token)
-            train_dataset = dataset.get("train", dataset)
+            # load_dataset without split= returns a DatasetDict; select the
+            # train split explicitly — passing the whole dict to a trainer
+            # fails with confusing errors far from the cause.
+            if isinstance(dataset, dict):
+                if "train" not in dataset:
+                    typer.echo(
+                        f"Error: dataset {cfg.data.dataset!r} has no 'train' "
+                        f"split (available: {sorted(dataset.keys())})",
+                        err=True,
+                    )
+                    raise typer.Exit(code=2)
+                train_dataset = dataset["train"]
+            else:
+                train_dataset = dataset
         else:
             import json
 
@@ -215,6 +232,8 @@ def train(
                         if line:
                             rows.append(json.loads(line))
             train_dataset = Dataset.from_list(rows)
+    except typer.Exit:
+        raise
     except Exception as e:
         typer.echo(f"Error: dataset load failed — {e}", err=True)
         raise typer.Exit(code=1)
@@ -243,10 +262,17 @@ def train(
             train_dataset = _dataset_for_grpo(
                 train_dataset, cfg.data.dataset_text_field
             )
-            tok_mask = tokenizer.mask_token_id
+            tok_mask = getattr(tokenizer, "mask_token_id", None)
+            if tok_mask is None:
+                # Real checkpoints may only carry the mask id on the model
+                # config (same fallback as build_masked_diffusion_collator).
+                tok_mask = getattr(
+                    getattr(model, "config", None), "mask_token_id", None
+                )
             if tok_mask is None and cfg.grpo.mask_id is None:
                 typer.echo(
-                    "Error: tokenizer has no mask_token_id — set grpo.mask_id in config",
+                    "Error: neither tokenizer nor model.config has a "
+                    "mask_token_id — set grpo.mask_id in config",
                     err=True,
                 )
                 raise typer.Exit(code=2)

--- a/unturtle/cli/config.py
+++ b/unturtle/cli/config.py
@@ -48,7 +48,7 @@ from pathlib import Path
 from typing import List, Literal, Optional
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
 def _grpo_effective_world_size() -> int:
@@ -77,7 +77,18 @@ def _grpo_effective_world_size() -> int:
 # ---------------------------------------------------------------------------
 
 
-class ModelConfig(BaseModel):
+class _SectionConfig(BaseModel):
+    """Base for config sections: assignments are validated immediately.
+
+    Without ``validate_assignment``, CLI overrides applied via ``setattr`` in
+    :meth:`Config.apply_overrides` would bypass pydantic validation entirely —
+    an invalid ``--task`` / ``--model-type`` would only fail late (or never).
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+
+
+class ModelConfig(_SectionConfig):
     model: Optional[str] = Field(
         default=None,
         description="HuggingFace model ID or local path.",
@@ -95,7 +106,7 @@ class ModelConfig(BaseModel):
     )
 
 
-class DataConfig(BaseModel):
+class DataConfig(_SectionConfig):
     dataset: Optional[str] = Field(default=None, description="HuggingFace dataset ID.")
     local_dataset: Optional[List[str]] = Field(
         default=None, description="Paths to local JSONL/JSON dataset files."
@@ -105,7 +116,7 @@ class DataConfig(BaseModel):
     )
 
 
-class TrainingConfig(BaseModel):
+class TrainingConfig(_SectionConfig):
     task: Literal["sft", "grpo"] = Field(
         default="sft",
         description="Training task: masked diffusion SFT or Diffu-GRPO / wd1 RL.",
@@ -142,7 +153,7 @@ class TrainingConfig(BaseModel):
     )
 
 
-class DiffusionConfig(BaseModel):
+class DiffusionConfig(_SectionConfig):
     """dLLM-specific training options — maps to DiffusionTrainingArguments."""
 
     alpha_scheduler: Literal["linear", "cosine"] = Field(
@@ -168,7 +179,7 @@ class DiffusionConfig(BaseModel):
     )
 
 
-class LoraConfig(BaseModel):
+class LoraConfig(_SectionConfig):
     lora_r: int = Field(default=64, description="LoRA rank.")
     lora_alpha: int = Field(default=16, description="LoRA alpha scaling factor.")
     lora_dropout: float = Field(default=0.0, description="LoRA dropout probability.")
@@ -181,7 +192,7 @@ class LoraConfig(BaseModel):
     )
 
 
-class LoggingConfig(BaseModel):
+class LoggingConfig(_SectionConfig):
     enable_wandb: bool = Field(
         default=False, description="Enable Weights & Biases logging."
     )
@@ -204,7 +215,7 @@ class LoggingConfig(BaseModel):
     )
 
 
-class GRPOConfig(BaseModel):
+class GRPOConfig(_SectionConfig):
     """DiffuGRPO / wd1 settings — used when ``training.task == \"grpo\"``."""
 
     diffusion_steps: int = Field(
@@ -311,7 +322,15 @@ class Config(BaseModel):
                 continue
             for section in sections:
                 if hasattr(section, key):
-                    setattr(section, key, value)
+                    try:
+                        # _SectionConfig has validate_assignment=True, so bad
+                        # values raise here instead of failing late/silently.
+                        setattr(section, key, value)
+                    except ValidationError as e:
+                        flag = "--" + key.replace("_", "-")
+                        raise ValueError(
+                            f"Invalid value for {flag}: {value!r}\n{e}"
+                        ) from e
                     break
 
     def training_args_kwargs(self) -> dict:

--- a/unturtle/eval/_answer_parser.py
+++ b/unturtle/eval/_answer_parser.py
@@ -45,16 +45,28 @@ def _to_float(raw: str) -> float | None:
         return None
 
 
+#: Bare number: integer or decimal, optional leading minus, thousands commas.
+_NUMBER_RE = re.compile(r"-?\d[\d,]*(?:\.\d+)?")
+
+
 def extract_numeric_answer(text: str) -> float | None:
     """Extract a numeric answer from model output.
 
     Priority:
     1. Last \\boxed{...} occurrence (supports nested braces), if its content is numeric.
-    2. If \\boxed{...} is present but its content is not numeric: last bare number
-       in the text strictly before the \\boxed{ marker.
-    3. If no \\boxed{...} is present: last bare number anywhere in the text.
+    2. If \\boxed{...} is present but its content is not directly numeric
+       (e.g. ``\\boxed{$72}``, ``\\boxed{72 dollars}``, ``\\boxed{1,234}``):
+       the last bare number *inside* the boxed content.
+    3. If the boxed content contains no number at all: last bare number in the
+       text strictly before the \\boxed{ marker.
+    4. If no \\boxed{...} is present: last bare number anywhere in the text.
 
     Returns None if no number can be extracted.
+
+    CAVEAT: LaTeX expressions inside the box are not evaluated — e.g.
+    ``\\boxed{\\frac{1}{2}}`` yields 2.0 (the last bare number), not 0.5.
+    Acceptable for the integer-answer GSM8K smoke tier; do not reuse this
+    parser for math-style tasks without a proper LaTeX-aware extractor.
     """
     boxed_idx = text.rfind(r"\boxed{")
     if boxed_idx != -1:
@@ -63,13 +75,19 @@ def extract_numeric_answer(text: str) -> float | None:
             result = _to_float(boxed)
             if result is not None:
                 return result
-        # Non-numeric boxed content: search only the text before the \boxed{ marker
+            # Non-numeric boxed content ("$72", "72 dollars", "1,234"): the
+            # box still marks the intended answer — extract the last number
+            # inside it before falling back to the surrounding text.
+            inner = _NUMBER_RE.findall(boxed)
+            if inner:
+                return _to_float(inner[-1])
+        # No number inside the box: search only the text before the \boxed{ marker
         search_text = text[:boxed_idx]
     else:
         search_text = text
 
-    # Fallback: last number (integer or decimal, optional leading minus)
-    matches = re.findall(r"-?\d[\d,]*(?:\.\d+)?", search_text)
+    # Fallback: last bare number in the search region
+    matches = _NUMBER_RE.findall(search_text)
     if matches:
         return _to_float(matches[-1])
     return None

--- a/unturtle/eval/harness/model_adapter.py
+++ b/unturtle/eval/harness/model_adapter.py
@@ -21,7 +21,10 @@ requires ``lm_eval``.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 
 def _import_lm_base() -> type:
@@ -85,6 +88,7 @@ def build_harness_lm(
             self._temperature = temperature
             self._use_chat_template = use_chat_template
             self._algorithm = algorithm
+            self._warned_max_gen_toks: set[tuple[int, int]] = set()
 
         def _build_prompt(self, context: str) -> str:
             apply = getattr(self._tokenizer, "apply_chat_template", None)
@@ -104,7 +108,26 @@ def build_harness_lm(
             device = next(iter(self._model.parameters())).device
             input_ids = input_ids.to(device)
             prompt_len = input_ids.shape[1]
-            max_new = int(gen_kwargs.get("max_gen_toks", self._max_new_tokens))
+            # Reproducibility contract (see harness/configs.py): the pinned
+            # DecodingConfig is recorded with the score, so it must be what
+            # actually ran. Task-supplied max_gen_toks is therefore IGNORED in
+            # favor of the pinned max_new_tokens — with a warning when they
+            # differ, so the discrepancy is visible in logs.
+            task_max = gen_kwargs.get("max_gen_toks")
+            if task_max is not None and int(task_max) != self._max_new_tokens:
+                # Warn once per (task_max, pinned) pair — this runs per request,
+                # and a full task emits hundreds of identical calls.
+                warn_key = (int(task_max), self._max_new_tokens)
+                if warn_key not in self._warned_max_gen_toks:
+                    self._warned_max_gen_toks.add(warn_key)
+                    _logger.warning(
+                        "UnturtleHarnessLM: task-supplied max_gen_toks=%s ignored — "
+                        "using pinned DecodingConfig.max_new_tokens=%s (the recorded "
+                        "config must match the actual decode).",
+                        task_max,
+                        self._max_new_tokens,
+                    )
+            max_new = self._max_new_tokens
             max_length = prompt_len + max_new
 
             if self._algorithm == "block_ar":

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -239,6 +239,11 @@ def _patch_dream_peft(
 
     Layer layout: ``model.base_model.model.model.layers``
     (Dream wraps DreamBaseModel as ``self.model``, same depth as LLaMA).
+
+    The injected ``DreamAttention_fast_forward`` covers the non-cache path only;
+    cache-enabled block decode (tuple KV caches, ``dual_cache`` /
+    ``replace_position``) delegates internally to the standard class forward, so
+    ``model.generate(..., use_cache=True)`` keeps working on a patched model.
     """
     n_qkv = n_o = n_mlp = 0
 
@@ -578,6 +583,10 @@ def _load_model_with_optional_4bit_fallback(
 ) -> Any:
     try:
         return loader.from_pretrained(model_name, **load_kwargs)
+    except torch.cuda.OutOfMemoryError:
+        # OOM is not a 4-bit-specific failure — a full-precision retry needs
+        # MORE memory and is doomed. Surface the real error to the user.
+        raise
     except Exception as exc:  # noqa: BLE001
         if "quantization_config" not in load_kwargs:
             raise
@@ -586,13 +595,116 @@ def _load_model_with_optional_4bit_fallback(
         fallback_kwargs.pop("quantization_config", None)
         fallback_kwargs.pop("device_map", None)
         _warn_once(
-            "FastDiffusionModel: 4-bit loading failed — retrying with full-precision loading."
-        )
-        _logger.debug(
-            "FastDiffusionModel: retrying without 4-bit quantization after error: %s",
-            exc,
+            "FastDiffusionModel: 4-bit loading failed "
+            f"({type(exc).__name__}: {exc}) — retrying with full-precision loading."
         )
         return loader.from_pretrained(model_name, **fallback_kwargs)
+
+
+def _import_bitsandbytes() -> Any:
+    """Import hook for bitsandbytes (separate function for testability)."""
+    import bitsandbytes as bnb
+
+    return bnb
+
+
+def _find_quantized_linear_modules(model: Any) -> list[tuple[str, Any]]:
+    """Return ``(name, module)`` for modules holding bnb-quantized weights.
+
+    Detection is by the ``weight.quant_state`` attribute (present on
+    ``bitsandbytes`` ``Params4bit``), not by isinstance, so it works without
+    importing bitsandbytes and with test stubs.
+    """
+    return [
+        (name, module)
+        for name, module in model.named_modules()
+        if getattr(getattr(module, "weight", None), "quant_state", None) is not None
+    ]
+
+
+def _dequantize_merged_model_(model: Any) -> Any:
+    """Dequantize bnb 4-bit Linear modules in *model* to 16-bit, in place.
+
+    ``merge_and_unload()`` on a 4-bit-loaded PEFT model returns a base model
+    whose Linear layers are still ``bnb.nn.Linear4bit`` — saving that as a
+    "merged 16-bit" artifact would silently ship nf4 weights plus a
+    ``quantization_config``. This mirrors what unsloth's own merged save does
+    per layer (``fast_dequantize(W, quant_state)`` in ``unsloth/save.py``),
+    using bitsandbytes' public ``functional.dequantize_4bit``.
+
+    Raises:
+        RuntimeError: when the model holds quantized weights but they cannot
+            be dequantized (bitsandbytes missing or dequantization failed) —
+            the caller must NOT save mislabeled 4-bit weights. Re-export from
+            a 16-bit load (e.g. ``load_in_4bit=False``) instead.
+    """
+    quantized = _find_quantized_linear_modules(model)
+    if not quantized:
+        return model
+
+    error_hint = (
+        "cannot save a truthful merged 16-bit artifact from 4-bit weights. "
+        "Re-load the checkpoint with load_in_4bit=False (CLI: "
+        "`unturtle export --no-load-in-4bit`) and export again."
+    )
+    try:
+        bnb = _import_bitsandbytes()
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(
+            f"FastDiffusionModel: model has {len(quantized)} bnb-quantized "
+            f"module(s) but bitsandbytes is unavailable ({exc}); {error_hint}"
+        ) from exc
+
+    named_modules = dict(model.named_modules())
+    for name, module in quantized:
+        weight = module.weight
+        try:
+            dequant = bnb.functional.dequantize_4bit(weight.data, weight.quant_state)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                f"FastDiffusionModel: failed to dequantize module {name!r} "
+                f"({type(exc).__name__}: {exc}); {error_hint}"
+            ) from exc
+        target_dtype = getattr(weight.quant_state, "dtype", dequant.dtype)
+        new_linear = torch.nn.Linear(
+            module.in_features,
+            module.out_features,
+            bias=module.bias is not None,
+            device=dequant.device,
+            dtype=target_dtype,
+        )
+        new_linear.weight = torch.nn.Parameter(
+            dequant.to(target_dtype), requires_grad=False
+        )
+        if module.bias is not None:
+            new_linear.bias = torch.nn.Parameter(
+                module.bias.data.to(target_dtype), requires_grad=False
+            )
+        parent_name, _, child_name = name.rpartition(".")
+        parent = named_modules[parent_name] if parent_name else model
+        setattr(parent, child_name, new_linear)
+
+    # The artifact is now 16-bit — drop the stale quantization metadata so the
+    # saved config does not claim 4-bit loading.
+    config = getattr(model, "config", None)
+    if config is not None and hasattr(config, "quantization_config"):
+        try:
+            del config.quantization_config
+        except AttributeError:
+            config.quantization_config = None
+    for attr in ("is_loaded_in_4bit", "is_quantized"):
+        if getattr(model, attr, False):
+            setattr(model, attr, False)
+    hf_quantizer = getattr(model, "hf_quantizer", None)
+    if hf_quantizer is not None:
+        model.hf_quantizer = None
+
+    _logger.info(
+        "FastDiffusionModel: dequantized %d bnb 4-bit module(s) to 16-bit "
+        "for the merged save.",
+        len(quantized),
+    )
+    return model
 
 
 #: model_type → callable returning the wrapper class to swap in after a
@@ -806,13 +918,41 @@ def _load_via_fastmodel(
         _logger.debug("FastDiffusionModel: unsloth FastModel unavailable: %s", exc)
         return None
     try:
+        # Forward all user kwargs FastModel.from_pretrained can accept
+        # (revision, cache_dir, subfolder, attn_implementation, …) instead of a
+        # tiny allowlist. Keys FastModel's signature cannot take are dropped
+        # with a warning so nothing disappears silently.
+        import inspect
+
+        try:
+            sig = inspect.signature(fast_model_cls.from_pretrained)
+            accepted = set(sig.parameters)
+            accepts_var_kw = any(
+                p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+            )
+        except (TypeError, ValueError):
+            accepted = set()
+            accepts_var_kw = True
+
         fm_kwargs: dict[str, Any] = {}
-        # FastModel uses `dtype=` not `torch_dtype=`
-        if "torch_dtype" in load_kwargs:
-            fm_kwargs["dtype"] = load_kwargs["torch_dtype"]
-        for key in ("token", "device_map", "trust_remote_code"):
-            if key in load_kwargs:
-                fm_kwargs[key] = load_kwargs[key]
+        dropped: list[str] = []
+        for key, value in load_kwargs.items():
+            if key == "torch_dtype":
+                # FastModel uses `dtype=` not `torch_dtype=`
+                fm_kwargs["dtype"] = value
+            elif key == "quantization_config":
+                # FastModel owns quantization on this path (intentional skip;
+                # the caller's intent travels via load_in_4bit below).
+                continue
+            elif accepts_var_kw or key in accepted:
+                fm_kwargs[key] = value
+            else:
+                dropped.append(key)
+        if dropped:
+            _warn_once(
+                "FastDiffusionModel: dropping kwargs not accepted by "
+                f"unsloth FastModel.from_pretrained: {sorted(dropped)}"
+            )
         # FastModel owns quantization — pass load_in_4bit explicitly from the caller.
         fm_kwargs["load_in_4bit"] = load_in_4bit
         model, tokenizer = fast_model_cls.from_pretrained(model_name, **fm_kwargs)
@@ -1410,6 +1550,10 @@ class FastDiffusionModel:
         merged = copy.deepcopy(model)
         # merge_and_unload returns the unwrapped base model with adapters merged.
         merged = merged.merge_and_unload()
+        # On a 4-bit-loaded model the merged Linear layers are still bnb
+        # Linear4bit — dequantize (or fail loudly) so the saved artifact is
+        # genuinely 16-bit, never mislabeled nf4 weights.
+        merged = _dequantize_merged_model_(merged)
         merged.save_pretrained(
             save_directory,
             safe_serialization=safe_serialization,
@@ -1447,6 +1591,9 @@ class FastDiffusionModel:
         _logger.info("FastDiffusionModel: merging LoRA adapters for Hub push …")
         merged = copy.deepcopy(model)
         merged = merged.merge_and_unload()
+        # Same honesty guarantee as save_pretrained_merged: never push nf4
+        # weights under a merged-16bit label.
+        merged = _dequantize_merged_model_(merged)
 
         push_kwargs: dict[str, Any] = dict(
             safe_serialization=safe_serialization, **kwargs

--- a/unturtle/save.py
+++ b/unturtle/save.py
@@ -21,7 +21,10 @@ models with "unturtle" instead of "unsloth".
 from __future__ import annotations
 
 import inspect
+import logging
 import types
+
+_logger = logging.getLogger(__name__)
 
 
 def patch_saving_functions(model, vision: bool = False):
@@ -66,14 +69,21 @@ def patch_saving_functions(model, vision: bool = False):
         else:
             break
 
-    # Delegate heavier save methods to unsloth.save so they remain functional
+    # Delegate heavier save methods to unsloth.save so they remain functional.
+    # Only unavailability-shaped failures (unsloth missing / API drift) are
+    # tolerated — real bugs inside patch_saving_functions must propagate.
     try:
         from unsloth.save import patch_saving_functions as _unsloth_patch
 
         _unsloth_patch(model, vision=vision)
-    except (ImportError, Exception):
-        # If unsloth.save is not available, skip the extra methods silently.
-        pass
+    except (ImportError, AttributeError) as exc:
+        _logger.warning(
+            "unturtle.save: skipping unsloth.save.patch_saving_functions — "
+            "merged/GGUF/TorchAO save methods will be unavailable on this model "
+            "(%s: %s)",
+            type(exc).__name__,
+            exc,
+        )
 
     return model
 


### PR DESCRIPTION
Refs #48, #49.

## What
- **merged-16bit export honesty**: `save_pretrained_merged`/`push_to_hub_merged` now dequantize bnb Linear4bit modules to 16-bit (unsloth-style `dequantize_4bit`, `quant_state.dtype`) and scrub stale `quantization_config`/`is_loaded_in_4bit` — or raise with a clear re-export hint; never silently save nf4 as "16bit". `unturtle export` `--load-in-4bit` default is now format-aware (False for merged-16bit) with a lossy-dequant warning when forced.
- **Harness decode pinning**: task-supplied `max_gen_toks` no longer silently overrides the recorded `DecodingConfig.max_new_tokens` — the pinned value wins (repo reproducibility contract), with a warn-once when they differ.
- **Boxed answer parsing**: `\boxed{$72}` / `\boxed{72 dollars}` / `\boxed{1,234}` now parse (last number inside the box before falling back); LaTeX-fraction caveat documented.
- **`_load_via_fastmodel`**: forwards all user kwargs (revision, cache_dir, subfolder, attn_implementation, …) via signature introspection; warns on genuinely dropped keys. Previously silently discarded — wrong weights on `revision=`.
- **4-bit fallback**: `torch.cuda.OutOfMemoryError` re-raised (full-precision retry is doomed); fallback warning carries the original exception. `save.py` blanket `except (ImportError, Exception)` narrowed with a logged warning.
- **CLI validation**: pydantic `validate_assignment` on config sections (invalid `--task`/`--model-type` fail immediately with the flag name); explicit train-split selection (DatasetDict without "train" errors with available splits); GRPO mask resolution gains the `model.config.mask_token_id` fallback. install.sh notes when a user-level `UV_PYTHON` pin is ignored (#49).

Note: tests/test_fast_diffusion_model.py in this branch also contains a few kernel-side test additions from the sibling PR #54; merge #54 first (or together) for a fully green branch-local run.

## Test plan
- [x] tests/eval + tests/test_cli_smoke.py + tests/test_fast_diffusion_model.py: 165 passed (+20 new); ruff clean; bash -n install.sh OK