### PR TITLE
🐛 fix(mdlm-dit): additive 4-D mask inversion, flash/SDPA dtype guards (#48 follow-ups)

### DIFF
--- a/tests/models/test_mdlm_dit.py
+++ b/tests/models/test_mdlm_dit.py
@@ -173,6 +173,82 @@ class TestMDLMDiTAttention:
             out = model(input_ids=input_ids, attention_mask=m4d).logits
         assert out.shape == (1, 8, tiny_config.vocab_size)
 
+    def test_attention_mask_4d_hf_additive(self, tiny_config):
+        """An HF-additive 4-D float mask (0.0 keep / finfo.min masked) must match
+        the 2-D padding path — not be inverted (regression for #48)."""
+        from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask
+
+        from unturtle.models.backbones.mdlm_dit import MDLMDiTForMaskedDiffusionLM
+
+        model = MDLMDiTForMaskedDiffusionLM(tiny_config).cpu().eval()
+        _activate_adaln(model)
+        input_ids = torch.randint(0, tiny_config.vocab_size, (1, 8))
+        padding = torch.ones(1, 8, dtype=torch.long)
+        padding[0, -2:] = 0  # last two positions are padding
+        additive = _prepare_4d_attention_mask(padding, torch.float32)  # [1,1,8,8]
+        with torch.no_grad():
+            out_2d = model(input_ids=input_ids, attention_mask=padding).logits
+            out_4d = model(input_ids=input_ids, attention_mask=additive).logits
+        # Real-token positions must agree with the 2-D padding path.
+        assert torch.allclose(out_2d[0, :6], out_4d[0, :6], atol=1e-5)
+        # And the mask must actually restrict attention (differ from no-mask).
+        with torch.no_grad():
+            out_nomask = model(input_ids=input_ids).logits
+        assert not torch.allclose(out_nomask[0, 0], out_4d[0, 0], atol=1e-5)
+
+    def test_attention_mask_4d_additive_neg_inf(self, tiny_config):
+        """-inf-style additive masks are also treated as masked (not kept) and
+        must not produce NaNs (bias is rebuilt with finfo.min)."""
+        from unturtle.models.backbones.mdlm_dit import MDLMDiTForMaskedDiffusionLM
+
+        model = MDLMDiTForMaskedDiffusionLM(tiny_config).cpu().eval()
+        _activate_adaln(model)
+        input_ids = torch.randint(0, tiny_config.vocab_size, (1, 8))
+        padding = torch.ones(1, 8, dtype=torch.long)
+        padding[0, -2:] = 0
+        additive = torch.zeros(1, 1, 8, 8)
+        additive[:, :, :, -2:] = float("-inf")
+        with torch.no_grad():
+            out_2d = model(input_ids=input_ids, attention_mask=padding).logits
+            out_4d = model(input_ids=input_ids, attention_mask=additive).logits
+        assert torch.isfinite(out_4d).all()
+        # Key-masking of the last two columns matches the 2-D path on real rows.
+        assert torch.allclose(out_2d[0, :6], out_4d[0, :6], atol=1e-5)
+
+    def test_sdpa_bias_cast_to_query_dtype(self, tiny_config):
+        """A float bias built in a wider dtype than q (autocast scenario) is cast
+        to the query dtype at use time, with finfo.min clamped (no -inf NaNs)."""
+        from unturtle.models.backbones.mdlm_dit import MDLMDiTForMaskedDiffusionLM
+
+        model = MDLMDiTForMaskedDiffusionLM(tiny_config).cpu().eval()
+        block = model.model.blocks[0]
+        B, L, H = 1, 8, tiny_config.num_attention_heads
+        D = tiny_config.hidden_size // H
+        torch.manual_seed(0)
+        q = torch.randn(B, L, H, D, dtype=torch.bfloat16)
+        k = torch.randn(B, L, H, D, dtype=torch.bfloat16)
+        v = torch.randn(B, L, H, D, dtype=torch.bfloat16)
+        # fp32 bias with finfo.min entries and one fully-masked query row.
+        bias = torch.zeros(B, 1, L, L, dtype=torch.float32)
+        bias[:, :, :, -2:] = torch.finfo(torch.float32).min
+        bias[:, :, -1, :] = torch.finfo(torch.float32).min
+        out = block._attention(q, k, v, bias)
+        assert out.dtype == torch.bfloat16
+        assert torch.isfinite(out.float()).all()
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+    def test_fp32_cuda_forward_no_flash_crash(self, tiny_config):
+        """fp32 on CUDA must not hit flash_attn (fp16/bf16-only) — SDPA fallback."""
+        from unturtle.models.backbones.mdlm_dit import MDLMDiTForMaskedDiffusionLM
+
+        model = MDLMDiTForMaskedDiffusionLM(tiny_config).cuda().float().eval()
+        input_ids = torch.randint(0, tiny_config.vocab_size, (2, 8), device="cuda")
+        with torch.no_grad():
+            out = model(input_ids=input_ids).logits
+        assert out.dtype == torch.float32
+        assert torch.isfinite(out).all()
+
     def test_fully_masked_query_row_is_finite(self, tiny_config):
         """A fully-masked query row must not produce NaNs (finfo.min, not -inf)."""
         from unturtle.models.backbones.mdlm_dit import MDLMDiTForMaskedDiffusionLM

--- a/unturtle/models/backbones/mdlm_dit/modeling_mdlm_dit.py
+++ b/unturtle/models/backbones/mdlm_dit/modeling_mdlm_dit.py
@@ -163,6 +163,7 @@ class DDiTBlock(nn.Module):
         if (
             self.flash_attn_func is not None
             and q.device.type == "cuda"
+            and q.dtype in (torch.float16, torch.bfloat16)
             and attn_bias is None
         ):
             out = self.flash_attn_func(
@@ -171,6 +172,16 @@ class DDiTBlock(nn.Module):
             return out.reshape(b, length, -1)
         # SDPA expects [B, H, L, D]
         qs, ks, vs = (t.transpose(1, 2) for t in (q, k, v))
+        if (
+            attn_bias is not None
+            and attn_bias.is_floating_point()
+            and attn_bias.dtype != qs.dtype
+        ):
+            # Under autocast the query dtype can differ from the dtype the bias
+            # was built in; SDPA rejects mismatched float masks. Cast at use
+            # time, clamping so finfo.min of a wider dtype does not overflow to
+            # -inf in the narrower one (-inf can NaN fully-masked query rows).
+            attn_bias = attn_bias.to(qs.dtype).clamp_min(torch.finfo(qs.dtype).min)
         out = F.scaled_dot_product_attention(
             qs, ks, vs, attn_mask=attn_bias, dropout_p=0.0, is_causal=False
         )
@@ -297,7 +308,8 @@ class MDLMDiTPreTrainedModel(PreTrainedModel):
 def _normalize_attention_mask(
     attention_mask: Optional[torch.Tensor], dtype: torch.dtype
 ) -> Optional[torch.Tensor]:
-    """Convert a [B,L] padding mask or [B,1,L,L] bool mask to an additive SDPA bias.
+    """Convert a [B,L] padding mask or a [B,1,L,L] bool / HF-additive-float mask
+    to an additive SDPA bias.
 
     Returns None when no positions are masked (lets the flash fast path run).
     """
@@ -309,7 +321,17 @@ def _normalize_attention_mask(
             attention_mask.bool().unsqueeze(1).unsqueeze(-2),
             attention_mask.bool().unsqueeze(1).unsqueeze(-1),
         )
+    elif attention_mask.is_floating_point():
+        # HF-standard additive convention (transformers'
+        # _prepare_4d_attention_mask): 0.0 = keep, a large negative value
+        # (finfo.min or -inf) = masked. `.bool()` would invert this — 0.0 keep
+        # positions become False and negative masked positions become True.
+        # CAVEAT: a float mask with 0/1 *keep* semantics is ambiguous at 0.0 and
+        # is treated as additive here (0.0 -> keep). Pass bool masks for
+        # keep-mask semantics.
+        keep = attention_mask >= 0
     else:
+        # bool / integer masks use keep-mask semantics (nonzero = keep).
         keep = attention_mask.bool()
     if keep.all():
         return None


### PR DESCRIPTION
Refs #48.

## What
- **Additive 4-D mask inversion**: `_normalize_attention_mask` treated HF-additive float masks (0.0 = keep, finfo.min/-inf = masked) as bool keep-masks — exactly inverted, restricting attention to the padding. Float masks are now converted via `keep = mask >= 0` (handles finfo.min, -inf, and legacy -1e4); bool/int masks keep their semantics (0/1-float ambiguity documented).
- **Flash dtype gate**: `flash_attn_func` only for fp16/bf16; fp32 CUDA falls back to SDPA instead of crashing.
- **SDPA bias dtype cast**: under autocast the fp32 bias is cast to the query dtype with `clamp_min(finfo(query.dtype).min)` so fp32-min doesn't overflow to -inf in fp16 (fully-masked-row NaN guard preserved).

Architecture semantics (rotary/adaLN-Zero/gating vs kuleshov-group/mdlm) untouched — mask/dtype plumbing only.

## Test plan
- [x] 4 new tests (HF-additive mask vs 2-D path equality, -inf variant, bias-cast, gpu fp32 smoke — ran on GPU0, not skipped): tests/models/ -k mdlm 42 passed; ruff clean