### PR TITLE
✨ feat(grpo): reward-model support + docstring reference fixes (#57)

### DIFF
--- a/tests/diffusion/test_grpo_trainer.py
+++ b/tests/diffusion/test_grpo_trainer.py
@@ -1024,3 +1024,139 @@ class TestComputeGroupAdvantages:
         tr = _make_advantage_trainer("bogus")
         with pytest.raises(ValueError, match="scale_rewards"):
             DiffuGRPOTrainer._compute_group_advantages(tr, self.rewards)
+
+
+# ---------------------------------------------------------------------------
+# Reward scoring (_score_rewards_per_func) — callables vs. reward models
+# ---------------------------------------------------------------------------
+
+
+def _make_tiny_reward_model():
+    """A real ``PreTrainedModel`` sequence-classification-style stub.
+
+    ``forward`` returns ``logits`` of shape ``[B, 1]`` equal to the number of
+    non-pad tokens per row, so expected scores are trivially checkable.
+    """
+    from transformers import PretrainedConfig, PreTrainedModel
+
+    class _Cfg(PretrainedConfig):
+        model_type = "tiny-reward-stub"
+
+    class _TinyRewardModel(PreTrainedModel):
+        config_class = _Cfg
+
+        def __init__(self, config):
+            super().__init__(config)
+            self.bias = nn.Parameter(torch.zeros(1))
+
+        def forward(self, input_ids=None, attention_mask=None, **kwargs):
+            score = attention_mask.sum(dim=1, keepdim=True).float() + self.bias
+            return SimpleNamespace(logits=score)
+
+    return _TinyRewardModel(_Cfg(_name_or_path="stub/tiny-reward"))
+
+
+class _CharTokenizer:
+    """Whitespace-free char-level tokenizer stub (pad_token_id=0)."""
+
+    pad_token_id = 0
+
+    def __call__(self, text, return_tensors, padding, padding_side, add_special_tokens):
+        assert return_tensors == "pt" and padding and padding_side == "right"
+        assert add_special_tokens is False
+        ids = [[(ord(ch) % 100) + 1 for ch in t] for t in text]
+        max_len = max(len(seq) for seq in ids)
+        input_ids = torch.zeros(len(ids), max_len, dtype=torch.long)
+        attention_mask = torch.zeros(len(ids), max_len, dtype=torch.long)
+        for row, seq in enumerate(ids):
+            input_ids[row, : len(seq)] = torch.tensor(seq, dtype=torch.long)
+            attention_mask[row, : len(seq)] = 1
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+def _make_reward_scoring_trainer(reward_funcs, reward_processing_classes):
+    from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+    tr = DiffuGRPOTrainer.__new__(DiffuGRPOTrainer)
+    tr.accelerator = SimpleNamespace(device=torch.device("cpu"))
+    tr.reward_funcs = reward_funcs
+    tr.reward_processing_classes = reward_processing_classes
+    # Attributes read by transformers.Trainer._prepare_inputs on the reward-model path.
+    tr.args = SimpleNamespace(device=torch.device("cpu"), past_index=-1)
+    tr.is_deepspeed_enabled = False
+    return tr
+
+
+class TestScoreRewardsPerFunc:
+    prompts = ["ab", "c"]
+    completions = ["xyz", "q"]
+    inputs = [
+        {"prompt": "ab", "answer": "42"},
+        {"prompt": "c", "answer": "7"},
+    ]
+
+    def test_reward_model_scored_trl_style(self):
+        """A PreTrainedModel reward is tokenized as prompt+completion and scored
+        via ``logits[:, 0]`` (TRL 0.24 ``_calculate_rewards`` semantics)."""
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        model = _make_tiny_reward_model()
+        tr = _make_reward_scoring_trainer([model], [_CharTokenizer()])
+        out = DiffuGRPOTrainer._score_rewards_per_func(
+            tr, self.inputs, self.prompts, self.completions
+        )
+        assert out.shape == (2, 1)
+        # score == len(prompt + completion) per row: "abxyz" -> 5, "cq" -> 2
+        assert torch.equal(out[:, 0], torch.tensor([5.0, 2.0]))
+
+    def test_callable_rewards_unchanged(self):
+        """Callable rewards keep the exact legacy contract: kwargs forwarded,
+        ``None`` mapped to NaN."""
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        seen = {}
+
+        def reward(prompts, completions, **kwargs):
+            seen["prompts"] = prompts
+            seen["completions"] = completions
+            seen["kwargs"] = kwargs
+            return [0.5, None]
+
+        tr = _make_reward_scoring_trainer([reward], [None])
+        out = DiffuGRPOTrainer._score_rewards_per_func(
+            tr, self.inputs, self.prompts, self.completions
+        )
+        assert seen["prompts"] == self.prompts
+        assert seen["completions"] == self.completions
+        assert seen["kwargs"] == {"answer": ["42", "7"]}
+        assert out[0, 0].item() == pytest.approx(0.5)
+        assert torch.isnan(out[1, 0])
+
+    def test_mixed_callable_and_model_rewards(self):
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        def reward(prompts, completions, **kwargs):
+            return [1.0, 2.0]
+
+        model = _make_tiny_reward_model()
+        tr = _make_reward_scoring_trainer([reward, model], [None, _CharTokenizer()])
+        out = DiffuGRPOTrainer._score_rewards_per_func(
+            tr, self.inputs, self.prompts, self.completions
+        )
+        assert torch.equal(out[:, 0], torch.tensor([1.0, 2.0]))
+        assert torch.equal(out[:, 1], torch.tensor([5.0, 2.0]))
+
+    def test_conversational_inputs_with_model_reward_raise(self):
+        """Conversational prompts require chat-template re-rendering through the
+        reward tokenizer (TRL's conversational branch), which is unsupported here."""
+        from unturtle.diffusion.grpo_trainer import DiffuGRPOTrainer
+
+        model = _make_tiny_reward_model()
+        tr = _make_reward_scoring_trainer([model], [_CharTokenizer()])
+        conv_inputs = [{"prompt": [{"role": "user", "content": "hi"}]}]
+        conv_prompts = [[{"role": "user", "content": "hi"}]]
+        conv_completions = [[{"role": "assistant", "content": "yo"}]]
+        with pytest.raises(NotImplementedError, match="conversational"):
+            DiffuGRPOTrainer._score_rewards_per_func(
+                tr, conv_inputs, conv_prompts, conv_completions
+            )

--- a/unturtle/diffusion/grpo_trainer.py
+++ b/unturtle/diffusion/grpo_trainer.py
@@ -123,7 +123,8 @@ class DiffuGRPOConfig(_GRPOConfigBase):
     **d1-style advantages:** TRL sets ``scale_rewards`` to ``\"group\"`` by default
     (per-group std scaling). The d1 / dllm references use mean-centered rewards only.
     Pass ``scale_rewards=False`` or ``scale_rewards=\"none\"`` for that behavior.
-    See ``docs/diffu-grpo-d1-notes.md``.
+    See the d1 reference implementation
+    (``dev/repos/d1/diffu-grpo/diffu_grpo_trainer.py``).
 
     Args:
         block_length:      Block size for block-wise iterative denoising.
@@ -221,7 +222,7 @@ class DiffuGRPOTrainer(GRPOTrainer):
     All other GRPO bookkeeping (reward scoring, advantage normalisation,
     buffered rollout reuse) is inherited unchanged from TRL. Use
     ``scale_rewards=False`` or ``\"none\"`` for d1-style mean-only advantages
-    (see ``docs/diffu-grpo-d1-notes.md``).
+    (see ``dev/repos/d1/diffu-grpo/diffu_grpo_trainer.py``).
 
     Args:
         model:                    Policy model or model-id string.
@@ -295,7 +296,7 @@ class DiffuGRPOTrainer(GRPOTrainer):
         if getattr(self.args, "diffu_policy_objective", "grpo") == "wd1++":
             warnings.warn(
                 "diffu_policy_objective='wd1++' stores full denoise trajectories per rollout "
-                "and runs extra forward passes; see docs/wd1plusplus-design.md.",
+                "and runs extra forward passes (wd1 paper Eq. 10).",
                 UserWarning,
                 stacklevel=2,
             )
@@ -385,7 +386,7 @@ class DiffuGRPOTrainer(GRPOTrainer):
 
         The d1 reference ``add_gumbel_noise`` uses a different reparameterization of
         stochastic argmax; paths agree when ``temperature == 0`` (deterministic argmax).
-        See ``docs/diffu-grpo-d1-notes.md``.
+        See the d1 reference (``dev/repos/d1/diffu-grpo/diffu_grpo_trainer.py``).
 
         Per arXiv:2409.02908, float64 noise improves perplexity but reduces
         generation quality for MDMs. We keep it in the model's native dtype.
@@ -663,7 +664,7 @@ class DiffuGRPOTrainer(GRPOTrainer):
     ) -> torch.Tensor:
         """Sum of log π(target) over completion tokens that are still ``mask_id`` in ``x_l``.
 
-        Matches the DCE-style conditioning on ``x_l`` (wd1++ / ``docs/wd1plusplus-design.md``):
+        Matches the DCE-style conditioning on ``x_l`` (wd1++, wd1 paper Eq. 10):
         one forward on prompt-jittered noisy input, cross-entropy targets from ``x0_pred``
         at positions where ``x_l`` is masked in the completion region.
         """
@@ -1107,6 +1108,77 @@ class DiffuGRPOTrainer(GRPOTrainer):
             advantages = advantages / (std_rewards + 1e-4)
         return advantages, std_rewards
 
+    def _score_rewards_per_func(
+        self,
+        inputs: list[dict[str, Any]],
+        prompts: list,
+        completions: list,
+    ) -> torch.Tensor:
+        """Score ``completions`` with every reward function.
+
+        Mirrors TRL 0.24 ``GRPOTrainer._calculate_rewards``: reward *models*
+        (``torch.nn.Module`` — the check TRL uses instead of
+        :class:`~transformers.PreTrainedModel` for compatibility with compiled
+        models) are scored by tokenizing ``prompt + completion`` with the paired
+        entry of ``self.reward_processing_classes`` (built by TRL's ``__init__``,
+        padding side right, no special tokens) and reading the
+        sequence-classification head's ``logits[:, 0]``. Reward *callables* are
+        invoked with ``(prompts=..., completions=..., **reward_kwargs)`` exactly
+        as before.
+
+        Conversational inputs are not supported with model rewards: TRL's
+        conversational branch re-renders ``prompt + completion`` message lists
+        through the *reward* tokenizer's chat template
+        (``apply_chat_template``), and this trainer's diffusion decode path has
+        not been validated against that re-rendering — raise a clear error
+        rather than silently mis-tokenize.
+
+        Returns:
+            Float tensor ``[len(prompts), len(self.reward_funcs)]`` on the
+            accelerator device (not gathered across processes).
+        """
+        device = self.accelerator.device
+        rewards_per_func = torch.zeros(
+            len(prompts), len(self.reward_funcs), device=device
+        )
+        for i, (reward_func, reward_processing_class) in enumerate(
+            zip(self.reward_funcs, self.reward_processing_classes, strict=True)
+        ):
+            if isinstance(reward_func, torch.nn.Module):
+                # Reward model (TRL-style sequence classification scoring).
+                if is_conversational(inputs[0]):
+                    raise NotImplementedError(
+                        "DiffuGRPOTrainer does not support reward models with "
+                        "conversational (message-list) prompts. Use a plain-text "
+                        "dataset or a callable reward function instead."
+                    )
+                texts = [p + c for p, c in zip(prompts, completions, strict=True)]
+                reward_inputs = reward_processing_class(
+                    text=texts,
+                    return_tensors="pt",
+                    padding=True,
+                    padding_side="right",
+                    add_special_tokens=False,
+                )
+                from transformers import Trainer as _Trainer
+
+                reward_inputs = _Trainer._prepare_inputs(self, reward_inputs)
+                with torch.inference_mode():
+                    rewards_per_func[:, i] = reward_func(**reward_inputs).logits[
+                        :, 0
+                    ]  # Shape (B*G,)
+            else:
+                keys = [k for k in inputs[0] if k not in ("prompt", "completion")]
+                reward_kwargs = {k: [ex[k] for ex in inputs] for k in keys}
+                output = reward_func(
+                    prompts=prompts, completions=completions, **reward_kwargs
+                )
+                output = [r if r is not None else float("nan") for r in output]
+                rewards_per_func[:, i] = torch.tensor(
+                    output, dtype=torch.float32, device=device
+                )
+        return rewards_per_func
+
     def _generate_and_score_completions(
         self,
         inputs: dict[str, Any],
@@ -1282,19 +1354,7 @@ class DiffuGRPOTrainer(GRPOTrainer):
         else:
             completions = completions_text
 
-        rewards_per_func = torch.zeros(
-            len(prompts), len(self.reward_funcs), device=device
-        )
-        for i, reward_func in enumerate(self.reward_funcs):
-            keys = [k for k in inputs[0] if k not in ("prompt", "completion")]
-            reward_kwargs = {k: [ex[k] for ex in inputs] for k in keys}
-            output = reward_func(
-                prompts=prompts, completions=completions, **reward_kwargs
-            )
-            output = [r if r is not None else float("nan") for r in output]
-            rewards_per_func[:, i] = torch.tensor(
-                output, dtype=torch.float32, device=device
-            )
+        rewards_per_func = self._score_rewards_per_func(inputs, prompts, completions)
 
         if torch.isnan(rewards_per_func).all(dim=1).any():
             warnings.warn(


### PR DESCRIPTION
Refs #57.

## What
- **Reward-model scoring**: `PreTrainedModel` reward functions (admitted by the `RewardFunc` type and anticipated by the metrics-naming branch) previously crashed with TypeError. New `_score_rewards_per_func` mirrors TRL 0.24's `_calculate_rewards` exactly: `isinstance(reward_func, torch.nn.Module)` branch, paired `reward_processing_classes` tokenization (`padding=True, padding_side="right", add_special_tokens=False`), device move via `Trainer._prepare_inputs`, `logits[:, 0]` under `inference_mode`. Callable rewards are byte-identical to the previous loop. Conversational inputs + model rewards raise `NotImplementedError` (TRL's chat-template re-rendering is unvalidated for this trainer — documented).
- **Docstring references**: five references to nonexistent `docs/diffu-grpo-d1-notes.md` / `docs/wd1plusplus-design.md` replaced with real pointers (d1 reference repo path; wd1 paper equation citations).

## Review
Read against `.venv` TRL 0.24 sources line-by-line: faithful mirror; callable path unchanged; verdict MERGE-READY.

## Test plan
- [x] 4 new tests (TRL-style model scoring with exact expected scores, callable unchanged, mixed, conversational raise); tests/diffusion/test_grpo_trainer.py 39 passed; tests/diffusion/ 230+ passed; ruff clean