### PR TITLE
✨ feat(generation): BD3LM honors attention_mask instead of pad_id inference (#57)

### DIFF
--- a/tests/diffusion/test_block_diffusion_generator.py
+++ b/tests/diffusion/test_block_diffusion_generator.py
@@ -89,6 +89,40 @@ class TestPrepareForSampling:
         assert not mask[0, 0, :, 3:].any(), "Padding columns must not be attended to"
         assert not mask[0, 0, 3:, :].any(), "Padding rows must not attend"
 
+    def test_explicit_valid_mask_overrides_pad_id_inference(self):
+        # Token value == PAD_ID at position 1, but the explicit valid_mask marks
+        # it as real: it must be attended and counted in logical positions.
+        x = torch.tensor([[5, PAD_ID, 7, 0, 0]])
+        valid = torch.tensor([[True, True, True, False, False]])
+        mask, pos = prepare_for_sampling(
+            x, block_size=2, pad_token_id=PAD_ID, valid_mask=valid
+        )
+        # Position 1 (pad_id token, valid) serves as key and queries
+        assert mask[0, 0, 0, 1], "Valid pad_id token must serve as a key"
+        assert mask[0, 0, 1, 0], "Valid pad_id token must query"
+        # Logical positions count the pad_id token as real
+        assert pos[0].tolist()[:3] == [0, 1, 2]
+        # Invalid positions still excluded regardless of token value
+        assert not mask[0, 0, :, 3:].any()
+        assert not mask[0, 0, 3:, :].any()
+
+    def test_explicit_valid_mask_excludes_non_pad_tokens(self):
+        # Non-pad token values marked invalid by the mask must be excluded.
+        x = torch.tensor([[9, 8, 7, 6]])
+        valid = torch.tensor([[False, False, True, True]])
+        mask, pos = prepare_for_sampling(
+            x, block_size=2, pad_token_id=PAD_ID, valid_mask=valid
+        )
+        assert not mask[0, 0, :, :2].any(), "Masked-out columns must be excluded"
+        assert not mask[0, 0, :2, :].any(), "Masked-out rows must be excluded"
+        assert pos[0].tolist() == [0, 0, 0, 1]
+
+    def test_valid_mask_shape_mismatch_raises(self):
+        x = torch.tensor([[5, 6, 7, 0]])
+        bad = torch.ones(1, 3, dtype=torch.bool)
+        with pytest.raises(ValueError, match="valid_mask"):
+            prepare_for_sampling(x, block_size=2, pad_token_id=PAD_ID, valid_mask=bad)
+
 
 # ---------------------------------------------------------------------------
 # BD3LM generation via model.generate(use_block_diffusion=True)
@@ -214,6 +248,181 @@ class TestBD3LMViaModelAPI:
             assert not (out[:, first_eos + 1 :] == MASK_ID).any(), (
                 "No mask tokens should remain after EOS"
             )
+
+
+# ---------------------------------------------------------------------------
+# BD3LM attention_mask plumbing (#57): explicit padding mask vs pad_id inference
+# ---------------------------------------------------------------------------
+
+
+class TestBD3LMAttentionMask:
+    def _spy_prepare_for_sampling(self, monkeypatch):
+        """Capture (x, valid_mask) for every prepare_for_sampling call."""
+        import unturtle.models.generation.diffusion_generation_utils as dgu
+
+        calls = []
+        original = dgu.prepare_for_sampling
+
+        def spy(x, block_size, pad_token_id, valid_mask=None):
+            calls.append((x.detach().clone(), valid_mask))
+            return original(x, block_size, pad_token_id, valid_mask=valid_mask)
+
+        monkeypatch.setattr(dgu, "prepare_for_sampling", spy)
+        return calls
+
+    def test_prompt_containing_pad_id_with_mask_treated_as_real(
+        self, tiny_model, monkeypatch
+    ):
+        """(a) pad_id tokens in the prompt + explicit all-ones attention_mask:
+
+        the mask is authoritative, so those positions are valid — unlike the
+        pad_id-inference fallback, which would treat them as padding.
+        """
+        calls = self._spy_prepare_for_sampling(monkeypatch)
+        prompt = torch.tensor([[1, PAD_ID, 3, 4]])  # genuine pad_id at pos 1
+        block_size = 4
+        with torch.no_grad():
+            out = tiny_model.generate(
+                inputs=prompt,
+                attention_mask=torch.ones_like(prompt),
+                use_block_diffusion=True,
+                bd3lm_block_size=block_size,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=MASK_ID,
+                pad_token_id=PAD_ID,
+                temperature=0.0,
+            )
+        assert out.shape == (1, 4 + 4)
+        assert len(calls) > 0
+        # Every call received an explicit valid_mask (mask-driven path)
+        assert all(vm is not None for _, vm in calls)
+        # First (prefix) call: the pad_id token at position 1 is marked valid
+        first_x, first_vm = calls[0]
+        assert first_x[0, 1].item() == PAD_ID
+        assert bool(first_vm[0, 1]), "pad_id token under mask=1 must be valid"
+        assert first_vm[0].all(), "All prompt positions must be valid per the mask"
+
+    def test_prompt_containing_pad_id_without_mask_uses_inference_fallback(
+        self, tiny_model, monkeypatch
+    ):
+        """(c) No attention_mask: fallback passes valid_mask=None so padding is
+
+        inferred from pad_id equality inside prepare_for_sampling (pre-#57
+        behavior, unchanged).
+        """
+        calls = self._spy_prepare_for_sampling(monkeypatch)
+        prompt = torch.tensor([[1, PAD_ID, 3, 4]])
+        with torch.no_grad():
+            out = tiny_model.generate(
+                inputs=prompt,
+                use_block_diffusion=True,
+                bd3lm_block_size=4,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=MASK_ID,
+                pad_token_id=PAD_ID,
+                temperature=0.0,
+            )
+        assert out.shape == (1, 4 + 4)
+        assert len(calls) > 0
+        assert all(vm is None for _, vm in calls), (
+            "Without attention_mask, prepare_for_sampling must run the "
+            "pad_id-inference fallback (valid_mask=None)"
+        )
+
+    def test_padded_batch_mask_derived_validity(self, tiny_model, monkeypatch):
+        """(b) 2-row batch: row 1 is left-padded with NON-pad token values under
+
+        mask=0.  Only the attention_mask can mark them invalid — assert the
+        canvas validity handed to prepare_for_sampling reflects the mask, not
+        the token values.
+        """
+        calls = self._spy_prepare_for_sampling(monkeypatch)
+        prompt = torch.tensor(
+            [
+                [1, 2, 3, 4],
+                [9, 9, 3, 4],  # first two positions are padding per the mask
+            ]
+        )
+        attn = torch.tensor([[1, 1, 1, 1], [0, 0, 1, 1]])
+        with torch.no_grad():
+            out = tiny_model.generate(
+                inputs=prompt,
+                attention_mask=attn,
+                use_block_diffusion=True,
+                bd3lm_block_size=4,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=MASK_ID,
+                pad_token_id=PAD_ID,
+                temperature=0.0,
+            )
+        assert out.shape == (2, 4 + 4)
+        first_x, first_vm = calls[0]
+        assert first_vm is not None
+        # Row 0 fully valid; row 1: mask=0 positions invalid despite tokens != pad_id
+        assert first_vm[0].all()
+        assert not first_vm[1, 0] and not first_vm[1, 1]
+        assert first_vm[1, 2] and first_vm[1, 3]
+        assert first_x[1, 0].item() == 9  # token value untouched — mask decided
+        # No mask tokens left in the generated region
+        assert not (out[:, 4:] == MASK_ID).any()
+
+    def test_padded_batch_unpadded_row_matches_single_run(self, tiny_model):
+        """(b) The unpadded row of a masked, padded batch matches a single-row run."""
+        row0 = torch.tensor([[1, 2, 3, 4]])
+        batch = torch.tensor([[1, 2, 3, 4], [9, 9, 3, 4]])
+        attn = torch.tensor([[1, 1, 1, 1], [0, 0, 1, 1]])
+        gen_kwargs = dict(
+            use_block_diffusion=True,
+            bd3lm_block_size=4,
+            max_new_tokens=4,
+            steps=2,
+            mask_token_id=MASK_ID,
+            pad_token_id=PAD_ID,
+            temperature=0.0,
+        )
+        with torch.no_grad():
+            out_single = tiny_model.generate(
+                inputs=row0, attention_mask=torch.ones_like(row0), **gen_kwargs
+            )
+            out_batch = tiny_model.generate(
+                inputs=batch, attention_mask=attn, **gen_kwargs
+            )
+        assert torch.equal(out_batch[0], out_single[0])
+
+    def test_attention_mask_shape_mismatch_raises(self, tiny_model):
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        bad_mask = torch.ones(1, 3, dtype=torch.long)
+        with pytest.raises(ValueError, match="attention_mask"):
+            tiny_model.generate(
+                inputs=prompt,
+                attention_mask=bad_mask,
+                use_block_diffusion=True,
+                bd3lm_block_size=4,
+                max_new_tokens=4,
+                steps=2,
+                mask_token_id=MASK_ID,
+                pad_token_id=PAD_ID,
+            )
+
+    def test_no_mask_runs_match_before_and_after(self, tiny_model):
+        """(c) Fallback determinism: two identical no-mask runs agree (temperature=0)."""
+        prompt = torch.tensor([[1, 2, 3, 4]])
+        gen_kwargs = dict(
+            use_block_diffusion=True,
+            bd3lm_block_size=4,
+            max_new_tokens=4,
+            steps=2,
+            mask_token_id=MASK_ID,
+            pad_token_id=PAD_ID,
+            temperature=0.0,
+        )
+        with torch.no_grad():
+            out1 = tiny_model.generate(inputs=prompt, **gen_kwargs)
+            out2 = tiny_model.generate(inputs=prompt, **gen_kwargs)
+        assert torch.equal(out1, out2)
 
 
 # ---------------------------------------------------------------------------

--- a/unturtle/models/generation/diffusion_generation_utils.py
+++ b/unturtle/models/generation/diffusion_generation_utils.py
@@ -346,6 +346,7 @@ def prepare_for_sampling(
     x: torch.Tensor,
     block_size: int,
     pad_token_id: int,
+    valid_mask: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Build block-causal attention mask and logical position IDs.
 
@@ -357,6 +358,13 @@ def prepare_for_sampling(
         x: Token ID tensor of shape ``[B, T]``.
         block_size: Number of tokens per block.
         pad_token_id: Token ID used for padding (will be masked out).
+        valid_mask: Optional ``[B, T]`` bool tensor marking valid (non-padding)
+            positions explicitly.  When provided it is authoritative — padding
+            is NOT inferred from ``pad_token_id`` equality, so prompts that
+            legitimately contain ``pad_token_id`` tokens (e.g. pad==eos chat
+            templates) are handled correctly.  When ``None`` (default),
+            validity falls back to ``x != pad_token_id`` (documented
+            limitation since #53).
 
     Returns:
         attn_mask: ``[B, 1, T, T]`` bool tensor — ``True`` means the query can
@@ -367,8 +375,16 @@ def prepare_for_sampling(
     B, T = x.shape
     device = x.device
 
-    # Per-sample valid mask
-    valid = x != pad_token_id  # [B, T]
+    # Per-sample valid mask: explicit mask wins; else infer from pad_token_id.
+    if valid_mask is not None:
+        if valid_mask.shape != x.shape:
+            raise ValueError(
+                f"`valid_mask` shape {tuple(valid_mask.shape)} must match "
+                f"`x` shape {tuple(x.shape)}."
+            )
+        valid = valid_mask.to(device=device, dtype=torch.bool)  # [B, T]
+    else:
+        valid = x != pad_token_id  # [B, T]
 
     # Logical positions for RoPE (cumsum over valid tokens, 0-based)
     pos_raw = torch.cumsum(valid.to(torch.long), dim=-1)  # [B, T] 1-based
@@ -928,7 +944,9 @@ class MaskedDiffusionGenerationMixin:
             return self._sample_with_cache(input_ids, attention_mask, generation_config)
 
         if generation_config.use_block_diffusion:
-            return self._sample_block_diffusion(input_ids, generation_config)
+            return self._sample_block_diffusion(
+                input_ids, generation_config, attention_mask=attention_mask
+            )
 
         output_history = generation_config.output_history
         return_dict_out = generation_config.return_dict

--- a/unturtle/models/generation/masked_diffusion_block_mixin.py
+++ b/unturtle/models/generation/masked_diffusion_block_mixin.py
@@ -198,6 +198,7 @@ class MaskedDiffusionBlockGenerationMixin(
         self,
         input_ids: torch.Tensor,
         generation_config: "MaskedDiffusionGenerationConfig",
+        attention_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """BD3LM block-diffusion generation loop.
 
@@ -208,6 +209,18 @@ class MaskedDiffusionBlockGenerationMixin(
 
         Called by :meth:`MaskedDiffusionGenerationMixin._sample` when
         ``generation_config.use_block_diffusion=True``.
+
+        Args:
+            input_ids: ``[B, prompt_len]`` prompt token IDs.
+            generation_config: Resolved generation configuration.
+            attention_mask: Optional ``[B, prompt_len]`` padding mask (1 = real
+                token, 0 = padding), matching the convention of ``_sample`` /
+                ``_sample_with_cache``.  When provided it is authoritative:
+                prompt validity is derived from the mask, so prompts that
+                legitimately contain ``pad_token_id`` tokens (e.g. pad==eos
+                chat templates) are treated as real tokens.  When ``None``,
+                padding is inferred from ``pad_token_id`` equality (the
+                documented pre-#57 fallback, kept for backward compatibility).
         """
         from unturtle.models.generation.diffusion_generation_utils import (
             _add_gumbel_noise,
@@ -235,12 +248,13 @@ class MaskedDiffusionBlockGenerationMixin(
                 "before calling `generate(algorithm='bd3lm')`."
             )
 
-        # Known limitation: padding is inferred purely from pad_id token values
-        # (both here for the internal left-pad and in prepare_for_sampling),
-        # not from an attention_mask.  Genuine pad_id tokens inside the prompt
-        # would be treated as padding.  prepare_for_sampling keeps pad rows
-        # numerically safe (no all-False attention rows), but the inference
-        # itself is intentionally not redesigned here.
+        # Padding semantics (#57): when `attention_mask` is provided, prompt
+        # validity comes from the mask (authoritative) and is threaded through
+        # `prepare_for_sampling` via `valid_mask`, so genuine pad_id tokens in
+        # the prompt are treated as real.  Without a mask, padding falls back
+        # to pad_id-equality inference (documented limitation since #53).
+        # In both paths, prepare_for_sampling output is made numerically safe
+        # via _pad_safe_attention_mask (no all-False attention rows).
         pad_id = generation_config.pad_token_id
         if pad_id is None:
             pad_id = getattr(self.config, "pad_token_id", None)
@@ -256,6 +270,17 @@ class MaskedDiffusionBlockGenerationMixin(
 
         device = input_ids.device
         B, prompt_len = input_ids.shape
+
+        if attention_mask is not None:
+            if attention_mask.shape != input_ids.shape:
+                raise ValueError(
+                    f"`attention_mask` shape {tuple(attention_mask.shape)} must "
+                    f"match `input_ids` shape {tuple(input_ids.shape)} for BD3LM "
+                    "generation."
+                )
+            prompt_valid = attention_mask.to(device=device, dtype=torch.bool)
+        else:
+            prompt_valid = None
 
         if max_new_tokens is None:
             if generation_config.max_length is None:
@@ -277,8 +302,23 @@ class MaskedDiffusionBlockGenerationMixin(
             offset = padded_prompt_len - prompt_len
             x[b, offset : offset + prompt_len] = input_ids[b]
 
+        # Canvas-wide validity mask (mask-driven path only).  The internal
+        # left-pad region is invalid; prompt validity comes from the caller's
+        # attention_mask.  Extended per appended block below and passed to
+        # prepare_for_sampling as `valid_mask`.  None => pad_id-inference
+        # fallback inside prepare_for_sampling.
+        canvas_valid = None
+        if prompt_valid is not None:
+            canvas_valid = torch.zeros(
+                B, padded_prompt_len, dtype=torch.bool, device=device
+            )
+            canvas_valid[:, prompt_left_pad:] = prompt_valid
+
         # Track "given" tokens for CFG unconditional branch
-        unmasked_index = (x != mask_id) & (x != pad_id)
+        if canvas_valid is not None:
+            unmasked_index = (x != mask_id) & canvas_valid
+        else:
+            unmasked_index = (x != mask_id) & (x != pad_id)
 
         done = torch.zeros(B, dtype=torch.bool, device=device)
 
@@ -300,7 +340,9 @@ class MaskedDiffusionBlockGenerationMixin(
             T_prefix = x.shape[1]
 
             # Build block-causal attention mask + logical position IDs for prefix
-            prefix_attn, prefix_pos = prepare_for_sampling(x, block_size, pad_id)
+            prefix_attn, prefix_pos = prepare_for_sampling(
+                x, block_size, pad_id, valid_mask=canvas_valid
+            )
             prefix_attn = _pad_safe_attention_mask(prefix_attn)
 
             # Obtain KV cache for the prefix when the model's forward supports
@@ -351,6 +393,9 @@ class MaskedDiffusionBlockGenerationMixin(
             )
             new_block[done] = pad_id
             x = torch.cat([x, new_block], dim=1)
+            if canvas_valid is not None:
+                block_valid = (~done).unsqueeze(1).expand(B, cur_block_len)
+                canvas_valid = torch.cat([canvas_valid, block_valid], dim=1)
             unmasked_index = torch.cat(
                 [
                     unmasked_index,
@@ -367,7 +412,9 @@ class MaskedDiffusionBlockGenerationMixin(
             )
             effective_steps = num_transfer_tokens.shape[1]
 
-            full_attn, full_pos = prepare_for_sampling(x, block_size, pad_id)
+            full_attn, full_pos = prepare_for_sampling(
+                x, block_size, pad_id, valid_mask=canvas_valid
+            )
             full_attn = _pad_safe_attention_mask(full_attn)
             attn_block = full_attn[:, :, T_prefix:T_total, :]
             pos_block = full_pos[:, T_prefix:T_total]
@@ -415,7 +462,7 @@ class MaskedDiffusionBlockGenerationMixin(
                         self, ("position_ids",)
                     )
                     full_attn_step, full_pos_step = prepare_for_sampling(
-                        x, block_size, pad_id
+                        x, block_size, pad_id, valid_mask=canvas_valid
                     )
                     full_attn_step = _pad_safe_attention_mask(full_attn_step)
                     if supports_position_ids:


### PR DESCRIPTION
Refs #57.

## What
`_sample_block_diffusion` accepted no `attention_mask`; padding was inferred purely from `pad_id` token values — mis-handling prompts that legitimately contain pad_id (pad==eos chat templates). Now:
- `generate(algorithm="bd3lm", attention_mask=...)` reaches the BD3LM loop (`_sample` previously dropped it).
- `prepare_for_sampling` gains an authoritative optional `valid_mask`; a maintained `canvas_valid` tensor (left-pad region, prompt validity from the mask, appended blocks per-row via `~done`) feeds all four call sites and the CFG `unmasked_index`.
- No mask → the documented pad_id-inference fallback, byte-identical (spy-verified end-to-end).
- The #53 pad-safe all-False-row flip remains applied after every mask build.

## Review
canvas offsets verified against the canvas fill logic (no off-by-one); fallback None-branches byte-identical; other algorithm paths receive unchanged kwargs; verdict MERGE-READY.

## Test plan
- [x] prompts containing pad_id treated as real under an explicit mask (differs from inference fallback); padded-batch row exactly equals single-row run (`torch.equal`); shape-mismatch raise; no-mask regression — tests/diffusion/test_block_diffusion_generator.py 20 passed; tests/models+diffusion 522+ passed; ruff clean