### PR TITLE
✨ feat(trainer/utils): packed guard + xformers bidirectional bias + MDLM-DiT mask heuristic (#57)

### DIFF
--- a/tests/diffusion/test_packed_guard.py
+++ b/tests/diffusion/test_packed_guard.py
@@ -1,0 +1,276 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the DiffusionTrainer unpatched-model packed-metadata guard (#57).
+
+An unpatched model silently ignores ``block_attention_mask`` /
+``packed_seq_lengths`` (they ride through ``**kwargs``), producing
+cross-sample attention while the loss still decreases.  The trainer must
+warn exactly once on the first packed batch when the model does not appear
+to consume the metadata — and stay silent when the FastDiffusionModel
+fast-forward patch (or a natively packed-aware forward) is detected.
+"""
+
+from __future__ import annotations
+
+import logging
+import types
+
+import pytest
+import torch
+from datasets import Dataset
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from transformers import BertConfig, BertForMaskedLM, PreTrainedTokenizerFast
+
+from unturtle.diffusion import (
+    DiffusionTrainer,
+    DiffusionTrainingArguments,
+    PackedMaskedDiffusionDataCollator,
+)
+from unturtle.diffusion.trainer import _model_consumes_packed_metadata
+
+TRAINER_LOGGER = "unturtle.diffusion.trainer"
+
+VOCAB = ["[PAD]", "[UNK]", "[MASK]", "[BOS]", "[EOS]"] + [f"w{i}" for i in range(95)]
+VOCAB_SIZE = len(VOCAB)
+MAX_SEQ_LEN = 16
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tokenizer() -> PreTrainedTokenizerFast:
+    tok = Tokenizer(
+        WordLevel(vocab={w: i for i, w in enumerate(VOCAB)}, unk_token="[UNK]")
+    )
+    tok.pre_tokenizer = Whitespace()
+    fast = PreTrainedTokenizerFast(tokenizer_object=tok)
+    fast.add_special_tokens(
+        {"pad_token": "[PAD]", "unk_token": "[UNK]", "mask_token": "[MASK]"}
+    )
+    return fast
+
+
+def _make_bert() -> BertForMaskedLM:
+    cfg = BertConfig(
+        vocab_size=VOCAB_SIZE,
+        hidden_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        intermediate_size=64,
+        max_position_embeddings=MAX_SEQ_LEN + 4,
+        pad_token_id=0,
+    )
+    return BertForMaskedLM(cfg)
+
+
+class _KwargsSinkLM(torch.nn.Module):
+    """Tiny LM whose forward silently swallows packed metadata via **kwargs.
+
+    This is exactly the failure mode of an unpatched TinyA2D: the packed
+    kwargs are accepted without error and never reach any attention module.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.inner = _make_bert()
+
+    def forward(self, input_ids=None, attention_mask=None, **kwargs):
+        return self.inner(input_ids=input_ids, attention_mask=attention_mask)
+
+
+def _mark_as_unturtle_patched(model: torch.nn.Module) -> None:
+    """Install an instance-level forward like FastDiffusionModel patching does.
+
+    FastDiffusionModel installs its fast forwards via ``types.MethodType``;
+    only the packed-aware TinyA2D fast forward carries the explicit
+    ``_consumes_packed_metadata`` marker the guard keys on. The dummy
+    submodule is never invoked during the actual forward pass.
+    """
+
+    def _fake_fast_forward(self, *args, **kwargs):  # pragma: no cover
+        raise AssertionError("marker forward must never be called")
+
+    _fake_fast_forward._consumes_packed_metadata = True
+    marker = torch.nn.Identity()
+    marker.forward = types.MethodType(_fake_fast_forward, marker)
+    model._unturtle_marker = marker
+
+
+def _mark_as_non_packed_unturtle_patched(model: torch.nn.Module) -> None:
+    """Instance-level unturtle fast forward WITHOUT the packed marker
+    (Dream / ModernBERT / LLaDA patching) — must NOT count as packed-aware."""
+
+    def _fake_fast_forward(self, *args, **kwargs):  # pragma: no cover
+        raise AssertionError("marker forward must never be called")
+
+    _fake_fast_forward.__module__ = "unturtle.models.backbones.dream.modeling_dream"
+    marker = torch.nn.Identity()
+    marker.forward = types.MethodType(_fake_fast_forward, marker)
+    model._non_packed_marker = marker
+
+
+def _make_trainer(tmp_path, model, tokenizer):
+    """Build a DiffusionTrainer.
+
+    ``model`` should be an HF PreTrainedModel (trainer init requirement); the
+    guard itself is exercised through ``compute_loss(sink_model, ...)`` which
+    checks the model passed to it.
+    """
+    collator = PackedMaskedDiffusionDataCollator(
+        tokenizer=tokenizer,
+        max_seq_length=MAX_SEQ_LEN,
+        completion_only=False,
+    )
+    args = DiffusionTrainingArguments(
+        output_dir=str(tmp_path / "out"),
+        per_device_train_batch_size=2,
+        remove_unused_columns=False,
+        report_to="none",
+        use_cpu=True,
+        bf16=False,
+        fp16=False,
+        max_steps=1,
+        completion_only=False,
+        loss_weight_type="uniform",
+    )
+    dataset = Dataset.from_list(
+        [{"input_ids": torch.randint(5, VOCAB_SIZE, (8,)).tolist()} for _ in range(4)]
+    )
+    return DiffusionTrainer(
+        model=model,
+        args=args,
+        train_dataset=dataset,
+        processing_class=tokenizer,
+        data_collator=collator,
+    )
+
+
+def _packed_batch(trainer) -> dict:
+    torch.manual_seed(0)
+    samples = [
+        {"input_ids": torch.randint(5, VOCAB_SIZE, (6,)).tolist()} for _ in range(4)
+    ]
+    return dict(trainer.data_collator(samples))
+
+
+def _guard_warnings(caplog) -> list[logging.LogRecord]:
+    return [
+        rec
+        for rec in caplog.records
+        if rec.name == TRAINER_LOGGER
+        and rec.levelno == logging.WARNING
+        and "packed-attention metadata" in rec.getMessage()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _model_consumes_packed_metadata unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelConsumesPackedMetadata:
+    def test_plain_model_does_not_consume(self):
+        assert not _model_consumes_packed_metadata(_make_bert())
+        assert not _model_consumes_packed_metadata(_KwargsSinkLM())
+
+    def test_unturtle_instance_forward_counts_as_patched(self):
+        model = _KwargsSinkLM()
+        _mark_as_unturtle_patched(model)
+        assert _model_consumes_packed_metadata(model)
+
+    def test_unturtle_non_packed_instance_forward_does_not_count(self):
+        """Dream/ModernBERT/LLaDA fast forwards never read packed metadata —
+        being patched from unturtle code alone is not a signal (review fix)."""
+        model = _make_bert()
+        _mark_as_non_packed_unturtle_patched(model)
+        assert not _model_consumes_packed_metadata(model)
+
+    def test_non_unturtle_instance_forward_does_not_count(self):
+        model = _KwargsSinkLM()
+
+        def _other_forward(self, *args, **kwargs):  # pragma: no cover
+            raise AssertionError
+
+        # __module__ is this test module, not an unturtle one.
+        marker = torch.nn.Identity()
+        marker.forward = types.MethodType(_other_forward, marker)
+        model._marker = marker
+        assert not _model_consumes_packed_metadata(model)
+
+    def test_explicit_signature_declaration_counts_as_native(self):
+        class _NativePacked(torch.nn.Module):
+            def forward(self, hidden_states, block_attention_mask=None):
+                return hidden_states
+
+        model = _KwargsSinkLM()
+        model._native = _NativePacked()
+        assert _model_consumes_packed_metadata(model)
+
+
+# ---------------------------------------------------------------------------
+# DiffusionTrainer.compute_loss guard behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestPackedMetadataGuard:
+    def test_unpatched_model_packed_batch_warns_once(self, tmp_path, caplog):
+        tokenizer = _make_tokenizer()
+        model = _KwargsSinkLM()
+        trainer = _make_trainer(tmp_path, model.inner, tokenizer)
+
+        with caplog.at_level(logging.WARNING, logger=TRAINER_LOGGER):
+            loss1 = trainer.compute_loss(model, _packed_batch(trainer))
+            loss2 = trainer.compute_loss(model, _packed_batch(trainer))
+
+        warnings = _guard_warnings(caplog)
+        assert len(warnings) == 1, "guard must warn exactly once per trainer"
+        message = warnings[0].getMessage()
+        assert "block_attention_mask" in message
+        assert "packed_seq_lengths" in message
+        # Warning only — the loss must still be computed.
+        assert torch.isfinite(loss1) and torch.isfinite(loss2)
+
+    def test_patched_marker_model_does_not_warn(self, tmp_path, caplog):
+        tokenizer = _make_tokenizer()
+        model = _KwargsSinkLM()
+        _mark_as_unturtle_patched(model)
+        trainer = _make_trainer(tmp_path, model.inner, tokenizer)
+
+        with caplog.at_level(logging.WARNING, logger=TRAINER_LOGGER):
+            loss = trainer.compute_loss(model, _packed_batch(trainer))
+
+        assert not _guard_warnings(caplog)
+        assert torch.isfinite(loss)
+
+    def test_unpacked_batches_never_trigger_the_check(self, tmp_path, caplog):
+        tokenizer = _make_tokenizer()
+        model = _KwargsSinkLM()
+        trainer = _make_trainer(tmp_path, model.inner, tokenizer)
+
+        batch = _packed_batch(trainer)
+        for key in ("block_attention_mask", "packed_seq_lengths"):
+            batch.pop(key, None)
+
+        with caplog.at_level(logging.WARNING, logger=TRAINER_LOGGER):
+            loss = trainer.compute_loss(model, batch)
+
+        assert not _guard_warnings(caplog)
+        # The one-shot flag must remain unarmed so a later packed batch warns.
+        assert trainer._packed_metadata_checked is False
+        assert torch.isfinite(loss)

--- a/tests/models/test_mdlm_dit.py
+++ b/tests/models/test_mdlm_dit.py
@@ -601,3 +601,34 @@ class TestMDLMDiTGradientCheckpointing:
             got = model(input_ids=input_ids).logits
 
         assert torch.allclose(ref, got, atol=1e-5)
+
+
+class TestNormalizeAttentionMaskFloatKeepHeuristic:
+    """Float masks with 0/1 keep semantics are detected via max() > 0 and not
+    misread as HF-additive all-keep."""
+
+    def test_float_binary_keep_mask(self):
+        from unturtle.models.backbones.mdlm_dit.modeling_mdlm_dit import (
+            _normalize_attention_mask,
+        )
+
+        B, L = 1, 4
+        keep_mask = torch.ones(B, 1, L, L)
+        keep_mask[:, :, :, -1] = 0.0  # last key masked (keep semantics)
+        bias = _normalize_attention_mask(keep_mask, torch.float32)
+        assert bias is not None
+        assert (bias[:, :, :, -1] < 0).all(), "0.0 keep-positions must be masked"
+        assert (bias[:, :, :, :-1] == 0).all()
+
+    def test_additive_mask_still_additive(self):
+        from unturtle.models.backbones.mdlm_dit.modeling_mdlm_dit import (
+            _normalize_attention_mask,
+        )
+
+        B, L = 1, 4
+        additive = torch.zeros(B, 1, L, L)
+        additive[:, :, :, -1] = torch.finfo(torch.float32).min
+        bias = _normalize_attention_mask(additive, torch.float32)
+        assert bias is not None
+        assert (bias[:, :, :, -1] < 0).all()
+        assert (bias[:, :, :, :-1] == 0).all()

--- a/tests/utils/test_attention_masks.py
+++ b/tests/utils/test_attention_masks.py
@@ -403,8 +403,110 @@ def test_run_attention_bidirectional_no_mask_disables_is_causal(monkeypatch):
     assert captured["is_causal"] is False
 
 
+def test_xformers_block_bidirectional_mask_is_noncausal_block_diagonal():
+    """The non-causal BlockDiagonalMask must match the dense bidirectional mask."""
+    if packing_utils._XFormersBidirectionalBlockMask is None:
+        pytest.skip("xformers BlockDiagonalMask not available")
+    packing_utils.clear_packed_caches()
+
+    seq_info = _make_seq_info([3, 5])
+    bias = packing_utils.build_xformers_block_bidirectional_mask(seq_info)
+    assert bias is not None
+    assert isinstance(bias, packing_utils._XFormersBidirectionalBlockMask)
+    # Must NOT be the causal subclass.
+    assert not isinstance(bias, packing_utils._XFormersBlockMask)
+
+    dense = bias.materialize((8, 8))
+    expected = packing_utils.build_sdpa_packed_bidirectional_attention_mask(
+        seq_info, dtype=dense.dtype, device=torch.device("cpu")
+    )[0, 0]
+    assert torch.equal(dense.isinf(), expected.isinf())
+    # Bidirectional inside each block (upper triangle allowed).
+    assert dense[0, 2].item() == 0.0
+    assert dense[3, 7].item() == 0.0
+    # Blocked across samples.
+    assert dense[0, 3].item() == float("-inf")
+    assert dense[7, 2].item() == float("-inf")
+
+
+def test_xformers_block_bidirectional_mask_sliding_window_unsupported():
+    """sliding_window has no non-causal xformers bias → must return None."""
+    if packing_utils._XFormersBidirectionalBlockMask is None:
+        pytest.skip("xformers BlockDiagonalMask not available")
+    packing_utils.clear_packed_caches()
+
+    seq_info = _make_seq_info([4, 4])
+    assert (
+        packing_utils.build_xformers_block_bidirectional_mask(
+            seq_info, sliding_window=2
+        )
+        is None
+    )
+    # window<=0 means "no window" and must still build the bias
+    assert (
+        packing_utils.build_xformers_block_bidirectional_mask(
+            seq_info, sliding_window=0
+        )
+        is not None
+    )
+
+
+def test_run_attention_bidirectional_xformers_packed_uses_noncausal_bias(monkeypatch):
+    """causal=False + seq_info must route through xformers with a NON-causal bias."""
+    if packing_utils._XFormersBidirectionalBlockMask is None:
+        pytest.skip("xformers BlockDiagonalMask not available")
+    packing_utils.clear_packed_caches()
+    captured = {}
+
+    def _fail_sdpa(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("SDPA fallback must not be used when the bias exists")
+
+    def _fake_xformers(Q, K, V, attn_bias=None, **kwargs):
+        captured["bias"] = attn_bias
+        return torch.zeros(Q.shape)
+
+    monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fail_sdpa)
+    monkeypatch.setattr(
+        attention_dispatch, "xformers_attention", _fake_xformers, raising=False
+    )
+
+    config = attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.XFORMERS,
+        n_kv_heads=1,
+        n_groups=1,
+        causal=False,
+    )
+    seq_info = _make_seq_info([2, 2])
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+    )
+
+    Q = torch.zeros(1, 1, 4, 1)
+    attention_dispatch.run_attention(
+        config=config, context=context, Q=Q, K=Q.clone(), V=Q.clone()
+    )
+
+    bias = captured["bias"]
+    assert isinstance(bias, packing_utils._XFormersBidirectionalBlockMask)
+    assert not isinstance(bias, packing_utils._XFormersBlockMask)
+    dense = bias.materialize((4, 4))
+    assert dense[0, 1].item() == 0.0  # bidirectional inside block
+    assert dense[1, 0].item() == 0.0
+    assert dense[0, 2].item() == float("-inf")  # blocked across samples
+
+
 def test_run_attention_bidirectional_xformers_packed_falls_back_to_sdpa(monkeypatch):
-    """causal=False must never route packed input through the causal xformers bias."""
+    """When the non-causal bias can't be built (no xformers class, or a sliding
+    window), causal=False + seq_info must fall back to the SDPA dense mask —
+    never the causal xformers bias."""
     packing_utils.clear_packed_caches()
     captured = {}
 
@@ -418,6 +520,10 @@ def test_run_attention_bidirectional_xformers_packed_falls_back_to_sdpa(monkeypa
     monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
     monkeypatch.setattr(
         attention_dispatch, "xformers_attention", _fail_xformers, raising=False
+    )
+    # Simulate xformers BlockDiagonalMask being unavailable.
+    monkeypatch.setattr(
+        packing_utils, "_XFormersBidirectionalBlockMask", None, raising=False
     )
 
     config = attention_dispatch.AttentionConfig(
@@ -448,6 +554,137 @@ def test_run_attention_bidirectional_xformers_packed_falls_back_to_sdpa(monkeypa
     assert mask is not None and mask.shape == (1, 1, 4, 4)
     assert mask[0, 0, 0, 1].item() == 0.0  # bidirectional inside block
     assert mask[0, 0, 0, 2].item() == float("-inf")  # blocked across samples
+
+
+def test_run_attention_bidirectional_xformers_packed_sliding_window_uses_sdpa(
+    monkeypatch,
+):
+    """Sliding window + bidirectional packed cannot be an xformers bias → SDPA band."""
+    packing_utils.clear_packed_caches()
+    captured = {}
+
+    def _fake_sdpa(Q, K, V, **kwargs):
+        captured["mask"] = kwargs.get("attn_mask")
+        return torch.zeros_like(Q)
+
+    def _fail_xformers(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("xformers has no bidirectional local block bias")
+
+    monkeypatch.setattr(attention_dispatch, "scaled_dot_product_attention", _fake_sdpa)
+    monkeypatch.setattr(
+        attention_dispatch, "xformers_attention", _fail_xformers, raising=False
+    )
+
+    config = attention_dispatch.AttentionConfig(
+        backend=attention_dispatch.XFORMERS,
+        n_kv_heads=1,
+        n_groups=1,
+        causal=False,
+    )
+    seq_info = _make_seq_info([4])
+    context = attention_dispatch.AttentionContext(
+        bsz=1,
+        q_len=4,
+        kv_seq_len=4,
+        n_heads=1,
+        head_dim=1,
+        requires_grad=False,
+        seq_info=seq_info,
+        attention_mask=None,
+        causal_mask=None,
+        sliding_window=2,
+    )
+
+    Q = torch.zeros(1, 1, 4, 1)
+    attention_dispatch.run_attention(
+        config=config, context=context, Q=Q, K=Q.clone(), V=Q.clone()
+    )
+
+    mask = captured["mask"]
+    assert mask is not None and mask.shape == (1, 1, 4, 4)
+    assert mask[0, 0, 0, 1].item() == 0.0  # within symmetric band
+    assert mask[0, 0, 1, 0].item() == 0.0
+    assert mask[0, 0, 0, 2].item() == float("-inf")  # outside band
+    assert mask[0, 0, 3, 0].item() == float("-inf")
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("n_kv_heads,n_groups", [(4, 1), (2, 2)])
+def test_xformers_bidirectional_packed_matches_sdpa_gpu(n_kv_heads, n_groups):
+    """Numerics: xformers non-causal packed bias must match the SDPA dense path."""
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    if not attention_dispatch.HAS_XFORMERS:
+        pytest.skip("xformers unavailable/unsupported on this GPU")
+    if packing_utils._XFormersBidirectionalBlockMask is None:
+        pytest.skip("xformers BlockDiagonalMask not available")
+
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    lengths = [5, 3, 8]
+    total = sum(lengths)
+    n_heads = n_kv_heads * n_groups
+    head_dim = 32
+
+    seq_lengths = torch.tensor(lengths, dtype=torch.int32, device=device)
+    cu = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=device),
+            torch.cumsum(seq_lengths, dim=0, dtype=torch.int32),
+        ]
+    )
+    seq_info = (seq_lengths, cu, max(lengths))
+
+    Q = torch.randn(1, n_heads, total, head_dim, device=device, dtype=torch.float16)
+    K = torch.randn(1, n_kv_heads, total, head_dim, device=device, dtype=torch.float16)
+    V = torch.randn(1, n_kv_heads, total, head_dim, device=device, dtype=torch.float16)
+
+    def _context():
+        return attention_dispatch.AttentionContext(
+            bsz=1,
+            q_len=total,
+            kv_seq_len=total,
+            n_heads=n_heads,
+            head_dim=head_dim,
+            requires_grad=False,
+            seq_info=seq_info,
+            attention_mask=None,
+            causal_mask=None,
+        )
+
+    packing_utils.clear_packed_caches()
+    out_xf = attention_dispatch.run_attention(
+        config=attention_dispatch.AttentionConfig(
+            backend=attention_dispatch.XFORMERS,
+            n_kv_heads=n_kv_heads,
+            n_groups=n_groups,
+            causal=False,
+        ),
+        context=_context(),
+        Q=Q,
+        K=K,
+        V=V,
+    )
+
+    packing_utils.clear_packed_caches()
+    out_sdpa = attention_dispatch.run_attention(
+        config=attention_dispatch.AttentionConfig(
+            backend=attention_dispatch.SDPA,
+            n_kv_heads=n_kv_heads,
+            n_groups=n_groups,
+            sdpa_kwargs={"is_causal": False},
+            causal=False,
+        ),
+        context=_context(),
+        Q=Q,
+        K=K,
+        V=V,
+    )
+
+    assert out_xf.shape == out_sdpa.shape
+    assert torch.allclose(out_xf.float(), out_sdpa.float(), atol=2e-3, rtol=2e-3), (
+        f"max diff {(out_xf.float() - out_sdpa.float()).abs().max().item()}"
+    )
 
 
 def test_run_attention_packed_lengths_exceeding_seq_len_raises(monkeypatch):

--- a/unturtle/diffusion/trainer.py
+++ b/unturtle/diffusion/trainer.py
@@ -41,6 +41,8 @@ Reference implementations:
 
 from __future__ import annotations
 
+import inspect
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -54,6 +56,56 @@ from .collator import MaskedDiffusionDataCollator
 from .packed_collator import PackedMaskedDiffusionDataCollator
 from .reweighting import context_adaptive_reweight
 from .schedulers import BaseAlphaScheduler, LinearAlphaScheduler, make_alpha_scheduler
+
+logger = logging.getLogger(__name__)
+
+# Batch keys emitted by PackedMaskedDiffusionDataCollator that only a
+# packed-aware attention forward consumes.
+_PACKED_METADATA_KEYS = ("block_attention_mask", "packed_seq_lengths")
+
+
+def _model_consumes_packed_metadata(model: torch.nn.Module) -> bool:
+    """Best-effort check that ``model``'s forward path consumes packed metadata.
+
+    ``block_attention_mask`` / ``packed_seq_lengths`` ride through
+    ``**kwargs``-tolerant transformers forwards without error, so an unpatched
+    model silently ignores them — attention is then NOT blocked at packed
+    sample boundaries and the loss still decreases (cross-sample
+    contamination).  Two signals, in order of reliability:
+
+    1. An *instance-level* ``forward`` override carrying the explicit
+       ``_consumes_packed_metadata`` marker.  ``FastDiffusionModel`` patching
+       installs fast forwards via ``types.MethodType``; only the packed-aware
+       ones (``TinyA2DAttention_fast_forward``) set the marker — other
+       unturtle fast forwards (Dream / ModernBERT / LLaDA) never read the
+       packed keys, so merely being patched from unturtle code is NOT a
+       signal.
+    2. A module class whose ``forward`` signature *explicitly* declares one of
+       the packed metadata arguments (a backbone with native packed support).
+       No current unturtle backbone does; a plain ``**kwargs`` sink is
+       deliberately NOT accepted — silently swallowing these kwargs is exactly
+       the failure mode this guard exists to catch.
+
+    This is a documented heuristic: a model consuming packed metadata through
+    an opaque ``**kwargs`` sink would be reported as non-consuming (the guard
+    only warns, it never raises).
+    """
+    for module in model.modules():
+        # Signal 1: MethodType-patched instance forward carrying the explicit
+        # packed-aware marker (class-level forwards do not appear in the
+        # instance __dict__).
+        fwd = module.__dict__.get("forward")
+        func = getattr(fwd, "__func__", fwd)
+        if func is not None and getattr(func, "_consumes_packed_metadata", False):
+            return True
+        # Signal 2: explicit packed-metadata parameter in the class forward.
+        try:
+            signature = inspect.signature(type(module).forward)
+        except (TypeError, ValueError):
+            continue
+        if any(key in signature.parameters for key in _PACKED_METADATA_KEYS):
+            return True
+    return False
 
 
 @dataclass
@@ -276,6 +328,10 @@ class DiffusionTrainer(UnturtleTrainer):
         # reference trainer behavior.  See transformers Trainer.training_step L1925.
         self.model_accepts_loss_kwargs = False
 
+        # One-shot guard flag: on the first batch carrying packed metadata,
+        # verify the model actually consumes it (see compute_loss).
+        self._packed_metadata_checked = False
+
         if isinstance(
             self.data_collator, PackedMaskedDiffusionDataCollator
         ) and self._loss_weight_type not in ("uniform", "cart"):
@@ -305,6 +361,32 @@ class DiffusionTrainer(UnturtleTrainer):
           ``diffusion_mask`` – bool tensor, True at masked positions
           ``timesteps``      – sampled ``t``, shape ``(B,)``
         """
+        # Packed-batch guard (#57): warn once when packed metadata rides
+        # through **kwargs into a model that never consumes it (cross-sample
+        # attention; the loss still decreases, hiding the bug).  Warning only —
+        # backbones that consume packed metadata through an opaque **kwargs
+        # sink must not be broken by a false positive.
+        if not getattr(self, "_packed_metadata_checked", False) and any(
+            key in inputs for key in _PACKED_METADATA_KEYS
+        ):
+            self._packed_metadata_checked = True
+            if not _model_consumes_packed_metadata(model):
+                logger.warning(
+                    "DiffusionTrainer: the batch carries packed-attention metadata "
+                    "(%s) but the model does not appear to consume it — no "
+                    "unturtle fast-attention forward is installed on any module "
+                    "and no module forward declares these arguments.  The "
+                    "metadata will ride through **kwargs unused, so attention is "
+                    "NOT blocked at packed-sample boundaries (cross-sample "
+                    "contamination; the loss still decreases, hiding the bug).  "
+                    "Load the model via FastDiffusionModel.from_pretrained / "
+                    "get_peft_model on CUDA so the packed fast forward is "
+                    "installed, or use the unpacked MaskedDiffusionDataCollator.  "
+                    "If your backbone consumes packed metadata natively through a "
+                    "**kwargs sink, this warning is a false positive.",
+                    " / ".join(key for key in _PACKED_METADATA_KEYS if key in inputs),
+                )
+
         labels: torch.Tensor = inputs.pop("labels")  # [B, L]
         diffusion_mask: torch.Tensor = inputs.pop("diffusion_mask")
         timesteps: torch.Tensor = inputs.pop("timesteps")

--- a/unturtle/models/backbones/mdlm_dit/modeling_mdlm_dit.py
+++ b/unturtle/models/backbones/mdlm_dit/modeling_mdlm_dit.py
@@ -330,9 +330,7 @@ def _normalize_attention_mask(
         # never contain positive values, so max() > 0 identifies a keep-mask
         # (an all-zero 0/1 keep-mask remains ambiguous and is read as additive
         # all-keep — pass bool masks to be explicit).
-        keep = (
-            attention_mask > 0 if attention_mask.max() > 0 else attention_mask >= 0
-        )
+        keep = attention_mask > 0 if attention_mask.max() > 0 else attention_mask >= 0
     else:
         # bool / integer masks use keep-mask semantics (nonzero = keep).
         keep = attention_mask.bool()

--- a/unturtle/models/backbones/mdlm_dit/modeling_mdlm_dit.py
+++ b/unturtle/models/backbones/mdlm_dit/modeling_mdlm_dit.py
@@ -326,10 +326,13 @@ def _normalize_attention_mask(
         # _prepare_4d_attention_mask): 0.0 = keep, a large negative value
         # (finfo.min or -inf) = masked. `.bool()` would invert this — 0.0 keep
         # positions become False and negative masked positions become True.
-        # CAVEAT: a float mask with 0/1 *keep* semantics is ambiguous at 0.0 and
-        # is treated as additive here (0.0 -> keep). Pass bool masks for
-        # keep-mask semantics.
-        keep = attention_mask >= 0
+        # Heuristic for float masks with 0/1 *keep* semantics: additive masks
+        # never contain positive values, so max() > 0 identifies a keep-mask
+        # (an all-zero 0/1 keep-mask remains ambiguous and is read as additive
+        # all-keep — pass bool masks to be explicit).
+        keep = (
+            attention_mask > 0 if attention_mask.max() > 0 else attention_mask >= 0
+        )
     else:
         # bool / integer masks use keep-mask semantics (nonzero = keep).
         keep = attention_mask.bool()

--- a/unturtle/models/conversion/a2d/tiny_a2d/_fast_forward.py
+++ b/unturtle/models/conversion/a2d/tiny_a2d/_fast_forward.py
@@ -353,3 +353,9 @@ def TinyA2DAttention_fast_forward(
     # Dispatch through apply_o — uses Triton fused kernel when patched
     attn_output = self.apply_o(self, attn_output)
     return attn_output, None
+
+
+# Explicit marker consumed by DiffusionTrainer's packed-metadata guard: this is
+# the only fast forward that actually reads block_attention_mask /
+# packed_seq_lengths (via kwargs), so signature inspection cannot detect it.
+TinyA2DAttention_fast_forward._consumes_packed_metadata = True  # type: ignore[attr-defined]

--- a/unturtle/utils/attention_dispatch.py
+++ b/unturtle/utils/attention_dispatch.py
@@ -30,6 +30,7 @@ from unsloth.models._utils import HAS_FLASH_ATTENTION, xformers, xformers_attent
 from .packing import (
     build_sdpa_packed_attention_mask,
     build_sdpa_packed_bidirectional_attention_mask,
+    build_xformers_block_bidirectional_mask,
     build_xformers_block_causal_mask,
 )
 
@@ -52,8 +53,17 @@ XFORMERS = "xformers"
 SDPA = "sdpa"
 
 
+# Base class covering both the causal (BlockDiagonalCausalMask) and the
+# non-causal (BlockDiagonalMask) packed biases — the causal mask subclasses
+# the non-causal one in xformers.
 XFORMERS_BLOCK_DIAG_CLS = (
-    xformers.attn_bias.BlockDiagonalCausalMask if HAS_XFORMERS else None
+    getattr(
+        xformers.attn_bias,
+        "BlockDiagonalMask",
+        xformers.attn_bias.BlockDiagonalCausalMask,
+    )
+    if HAS_XFORMERS
+    else None
 )
 
 
@@ -123,11 +133,20 @@ def run_attention(
     ):
         backend = SDPA
 
-    if backend == XFORMERS and context.seq_info is not None and not config.causal:
-        # The xformers packed path builds a *causal* block-diagonal bias
-        # (build_xformers_block_causal_mask).  Bidirectional configs must not
-        # receive causal masking, so fall back to the SDPA packed path which
-        # builds a bidirectional block mask below.
+    # Bidirectional packed attention uses the non-causal BlockDiagonalMask
+    # bias.  When it cannot be built (xformers class unavailable, or a
+    # sliding window is set — xformers has no *bidirectional* local block
+    # bias), fall back to the SDPA packed path which builds a dense
+    # bidirectional block mask below.
+    if (
+        backend == XFORMERS
+        and context.seq_info is not None
+        and not config.causal
+        and build_xformers_block_bidirectional_mask(
+            context.seq_info, sliding_window=context.sliding_window
+        )
+        is None
+    ):
         backend = SDPA
 
     flash_dense_kwargs = config.flash_dense_kwargs or {}
@@ -166,11 +185,18 @@ def run_attention(
             bsz, q_len, n_heads, head_dim
         )
     if backend == XFORMERS:
-        attn_bias = build_xformers_block_causal_mask(
-            context.seq_info,
-            sliding_window=sliding_window,
-            base_mask=context.causal_mask,
-        )
+        if not config.causal and context.seq_info is not None:
+            # Non-causal packed: block-diagonal bias WITHOUT the causal
+            # triangle (guaranteed non-None by the routing check above).
+            attn_bias = build_xformers_block_bidirectional_mask(
+                context.seq_info, sliding_window=sliding_window
+            )
+        else:
+            attn_bias = build_xformers_block_causal_mask(
+                context.seq_info,
+                sliding_window=sliding_window,
+                base_mask=context.causal_mask,
+            )
 
         Q_t = Q.transpose(1, 2)
         K_t = K.transpose(1, 2)
@@ -359,6 +385,7 @@ __all__ = [
     "XFORMERS",
     "build_sdpa_packed_attention_mask",
     "build_sdpa_packed_bidirectional_attention_mask",
+    "build_xformers_block_bidirectional_mask",
     "build_xformers_block_causal_mask",
     "run_attention",
     "select_attention_backend",

--- a/unturtle/utils/packing.py
+++ b/unturtle/utils/packing.py
@@ -29,14 +29,24 @@ try:
     from xformers.ops.fmha.attn_bias import (
         BlockDiagonalCausalMask as _XFormersBlockMask,
     )
+    from xformers.ops.fmha.attn_bias import (
+        BlockDiagonalMask as _XFormersBidirectionalBlockMask,
+    )
 except Exception:
     try:
-        from xformers.attn_bias import BlockDiagonalCausalMask as _XFormersBlockMask
+        from xformers.attn_bias import (
+            BlockDiagonalCausalMask as _XFormersBlockMask,
+        )
+        from xformers.attn_bias import (
+            BlockDiagonalMask as _XFormersBidirectionalBlockMask,
+        )
     except Exception:
         _XFormersBlockMask = None
+        _XFormersBidirectionalBlockMask = None
 
 _XFORMERS_MASK_CACHE_MAXSIZE = 32
 _XFORMERS_MASK_CACHE: OrderedDict[Tuple[Tuple[int, ...], int], Any] = OrderedDict()
+_XFORMERS_BIDIRECTIONAL_MASK_CACHE: OrderedDict[Tuple[int, ...], Any] = OrderedDict()
 
 # Cache per device for get_packed_info_from_kwargs to avoid repeated D2H sync across layers
 _PACKED_INFO_CACHE: dict = {}
@@ -51,6 +61,9 @@ logger = logging.getLogger(__name__)
 
 # Cache per device for build_xformers_block_causal_mask to avoid repeated D2H sync across layers
 _XFORMERS_BLOCK_MASK_CACHE: dict = {}
+
+# Cache per device for build_xformers_block_bidirectional_mask
+_XFORMERS_BIDIRECTIONAL_BLOCK_MASK_CACHE: dict = {}
 
 
 def _window_cache_key(sliding_window: Optional[int]) -> int:
@@ -80,6 +93,23 @@ def _get_cached_block_mask(
     _XFORMERS_MASK_CACHE[cache_key] = mask
     if len(_XFORMERS_MASK_CACHE) > _XFORMERS_MASK_CACHE_MAXSIZE:
         _XFORMERS_MASK_CACHE.popitem(last=False)
+    return mask
+
+
+def _get_cached_bidirectional_block_mask(lengths: Tuple[int, ...]):
+    if _XFormersBidirectionalBlockMask is None:
+        return None
+
+    cached = _XFORMERS_BIDIRECTIONAL_MASK_CACHE.get(lengths)
+    if cached is not None:
+        _XFORMERS_BIDIRECTIONAL_MASK_CACHE.move_to_end(lengths)
+        return cached
+
+    mask = _XFormersBidirectionalBlockMask.from_seqlens(list(lengths))
+
+    _XFORMERS_BIDIRECTIONAL_MASK_CACHE[lengths] = mask
+    if len(_XFORMERS_BIDIRECTIONAL_MASK_CACHE) > _XFORMERS_MASK_CACHE_MAXSIZE:
+        _XFORMERS_BIDIRECTIONAL_MASK_CACHE.popitem(last=False)
     return mask
 
 
@@ -297,6 +327,53 @@ def build_xformers_block_causal_mask(
     return mask
 
 
+def build_xformers_block_bidirectional_mask(
+    seq_info: Optional[Tuple[torch.Tensor, torch.Tensor, int]],
+    *,
+    sliding_window: Optional[int] = None,
+):
+    """Non-causal ``BlockDiagonalMask`` for packed *bidirectional* attention.
+
+    Mirrors :func:`build_xformers_block_causal_mask` but every token in a
+    packed sample attends to every other token of the same sample — the
+    xformers-native equivalent of
+    :func:`build_sdpa_packed_bidirectional_attention_mask` (O(T) bias instead
+    of a dense O(T^2) additive mask).
+
+    Returns ``None`` — callers must fall back to the SDPA dense mask — when:
+
+      * xformers (or ``BlockDiagonalMask``) is unavailable,
+      * ``seq_info`` is ``None`` or empty, or
+      * ``sliding_window`` is set: ``BlockDiagonalMask.make_local_attention``
+        returns a *causal* local bias (``BlockDiagonalCausalLocalAttentionMask``
+        as of xformers 0.0.35), so the symmetric bidirectional band
+        (``|q - k| < sliding_window``) cannot be represented as an xformers
+        attn_bias.
+    """
+    if _XFormersBidirectionalBlockMask is None or seq_info is None:
+        return None
+    if sliding_window is not None and sliding_window > 0:
+        return None
+
+    seq_lengths, _, _ = seq_info
+    device = seq_lengths.device
+    entry = _XFORMERS_BIDIRECTIONAL_BLOCK_MASK_CACHE.get(device)
+    if entry is not None and entry["seq_lengths"] is seq_lengths:
+        return entry["mask"]
+
+    lengths_tensor = seq_lengths.to("cpu", torch.int32)
+    if lengths_tensor.numel() == 0:
+        return None
+    lengths = tuple(int(x) for x in lengths_tensor.tolist())
+    mask = _get_cached_bidirectional_block_mask(lengths)
+
+    _XFORMERS_BIDIRECTIONAL_BLOCK_MASK_CACHE[device] = {
+        "seq_lengths": seq_lengths,
+        "mask": mask,
+    }
+    return mask
+
+
 def build_sdpa_packed_attention_mask(
     seq_info: Tuple[torch.Tensor, torch.Tensor, int],
     *,
@@ -467,6 +544,9 @@ def clear_packed_caches():
     _SDPA_MASK_CACHE.clear()
     _SDPA_BIDIRECTIONAL_MASK_CACHE.clear()
     _XFORMERS_BLOCK_MASK_CACHE.clear()
+    _XFORMERS_BIDIRECTIONAL_BLOCK_MASK_CACHE.clear()
+    _XFORMERS_MASK_CACHE.clear()
+    _XFORMERS_BIDIRECTIONAL_MASK_CACHE.clear()
 
 
 __all__ = [
@@ -477,6 +557,7 @@ __all__ = [
     "mark_allow_overlength",
     "get_packed_info_from_kwargs",
     "build_xformers_block_causal_mask",
+    "build_xformers_block_bidirectional_mask",
     "build_sdpa_packed_attention_mask",
     "build_sdpa_packed_bidirectional_attention_mask",
     "mask_packed_sequence_boundaries",


### PR DESCRIPTION
Closes #57 (together with #58, #59).

## What
- **Unpatched-model packed guard**: `DiffusionTrainer` warns once when a batch carries `block_attention_mask`/`packed_seq_lengths` but the model has no packed-aware attention path (silent cross-sample attention previously). Detection keys on an explicit `_consumes_packed_metadata` marker now set on `TinyA2DAttention_fast_forward` — review caught that a module-prefix heuristic would false-negative for patched Dream/ModernBERT/LLaDA (their fast forwards never read the packed keys); fixed and regression-tested, with the real fast forward verified end-to-end.
- **xformers bidirectional packed bias**: bidirectional packed batches on the xformers backend now use a non-causal `BlockDiagonalMask` (O(T) bias; xformers 0.0.35 `from_seqlens`) instead of the dense O(T²) SDPA fallback introduced by #54. Sliding-window keeps the SDPA fallback (`make_local_attention` on the non-causal mask returns a *causal* local bias — verified empirically). Cache-keyed like the causal helper; `clear_packed_caches` extended. GPU0 numerics: xformers vs SDPA dense match (fp16, MHA + GQA).
- **MDLM-DiT float keep-mask heuristic**: float masks with 0/1 keep semantics (`max() > 0`) are no longer misread as HF-additive all-keep; additive conventions (0/-min, 0/-inf, legacy -1e4) unchanged; all-zero ambiguity documented.

## Test plan
- [x] 8 packed-guard tests (incl. the unturtle-non-packed false-negative regression), xformers bias unit + gpu equivalence tests (ran on GPU0), 2 heuristic tests
- [x] full fast suite: 758 passed / 0 failed; ruff clean